### PR TITLE
Add feature deploy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,12 @@ zip = { version = "0.5", default-features = false }
 pwasm-utils = "0.12"
 parity-wasm = "0.41"
 cargo_metadata = "0.9"
-substrate-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-primitives" }
-subxt = { git = "https://github.com/paritytech/substrate-subxt/", branch = "v0.3", package = "substrate-subxt" }
-tokio = "0.1"
-futures = "0.1"
-url = "1.7"
+
+substrate-primitives = { git = "https://github.com/paritytech/substrate/", package = "substrate-primitives", optional = true }
+subxt = { git = "https://github.com/paritytech/substrate-subxt/", branch = "v0.3", package = "substrate-subxt", optional = true }
+tokio = { version = "0.1", optional = true }
+futures = { version = "0.1", optional = true }
+url = { version = "1.7", optional = true }
 
 [build-dependencies]
 anyhow = "1.0"
@@ -42,4 +43,5 @@ wabt = "0.9"
 
 [features]
 default = []
+deploy = ["substrate-primitives", "subxt", "tokio", "futures", "url"]
 test-ci-only = []

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ SUBCOMMANDS:
     help                 Prints this message or the help of the given subcommand(s)
 ```
 
+## Feature
+
+The `deploy` subcommand is **disabled by default**, since it's not working properly at the moment and increases the build time.
+
+If you want to try it, you need to enable the `deploy` feature.
+
+Once it is working properly and the compilation time is acceptable, we will consider removing the `deploy` feature.
+
 ## License
 
 The entire code within this repository is licensed under the [GPLv3](LICENSE). Please [contact us](https://www.parity.io/contact/) if you have questions about the licensing of our products.

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -26,14 +26,7 @@ const MAX_MEMORY_PAGES: u32 = 16;
 /// Relevant metadata obtained from Cargo.toml.
 pub struct CrateMetadata {
     original_wasm: PathBuf,
-    dest_wasm: PathBuf,
-}
-
-impl CrateMetadata {
-    /// Get the path of the wasm destination file
-    pub fn dest_wasm(self) -> PathBuf {
-        self.dest_wasm
-    }
+    pub dest_wasm: PathBuf,
 }
 
 /// Parses the contract manifest and returns relevant metadata.

--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -27,7 +27,7 @@ use crate::cmd::build::{self, CrateMetadata};
 ///
 /// Defaults to the target contract wasm in the current project, inferred via the crate metadata.
 fn load_contract_code(path: Option<&PathBuf>) -> Result<Vec<u8>> {
-    let default_wasm_path = build::collect_crate_metadata(path).map(CrateMetadata::dest_wasm)?;
+    let default_wasm_path = build::collect_crate_metadata(path)?.dest_wasm;
     let contract_wasm_path = path.unwrap_or(&default_wasm_path);
 
     let mut data = Vec::new();

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -23,13 +23,15 @@ use std::{
 use anyhow::Result;
 
 mod build;
+#[cfg(feature = "deploy")]
 mod deploy;
 mod metadata;
 mod new;
 
+#[cfg(feature = "deploy")]
+pub(crate) use self::deploy::execute_deploy;
 pub(crate) use self::{
-    build::execute_build, deploy::execute_deploy, metadata::execute_generate_metadata,
-    new::execute_new,
+    build::execute_build, metadata::execute_generate_metadata, new::execute_new,
 };
 
 fn exec_cargo(command: &str, args: &[&'static str], working_dir: Option<&PathBuf>) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ enum Command {
     #[structopt(name = "test")]
     Test {},
     /// Deploy the smart contract on-chain. (Also for testing purposes.)
+    #[cfg(feature = "deploy")]
     #[structopt(name = "deploy")]
     Deploy {
         /// Websockets url of a substrate node
@@ -136,6 +137,7 @@ fn exec(cmd: Command) -> Result<String> {
         Command::Build {} => cmd::execute_build(None),
         Command::GenerateMetadata {} => cmd::execute_generate_metadata(None),
         Command::Test {} => Err(anyhow::anyhow!("Command unimplemented")),
+        #[cfg(feature = "deploy")]
         Command::Deploy {
             url,
             suri,


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

I think the `deploy` subcommand can be optional, because developers can send a RPC request to deploy the contract by using other tools. 