### PR TITLE
Fail the build if xbuild fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version 0.4.0 (2020-02-26)
 
 - Minimize contract wasm binary size:
+  - Run `wasm-opt` on the contract Wasm binary.
   - Uses [`cargo-xbuild`](https://github.com/rust-osdev/cargo-xbuild) to build custom sysroot crates without panic string
 bloat.
   - Automatically removes the `rlib` crate type from `Cargo.toml`, removing redundant metadata.

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -130,7 +130,10 @@ fn build_cargo_project(crate_metadata: &CrateMetadata, verbosity: Option<Verbosi
         let exit_status = xargo_lib::build(args, "build", Some(config))
             .map_err(|e| anyhow::anyhow!("{}", e))
             .context("Building with xbuild")?;
-        log::debug!("xargo exit status: {:?}", exit_status);
+        log::debug!("xbuild exit status: {}", exit_status);
+        if !exit_status.success() {
+            anyhow::bail!("xbuild failed with status {}", exit_status)
+        }
         Ok(())
     };
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -130,7 +130,6 @@ fn build_cargo_project(crate_metadata: &CrateMetadata, verbosity: Option<Verbosi
         let exit_status = xargo_lib::build(args, "build", Some(config))
             .map_err(|e| anyhow::anyhow!("{}", e))
             .context("Building with xbuild")?;
-        log::debug!("xbuild exit status: {}", exit_status);
         if !exit_status.success() {
             anyhow::bail!("xbuild failed with status {}", exit_status)
         }


### PR DESCRIPTION
Previously if the xbuild failed it would continue to the optimization step, which would of course fail too because of the missing artifact.

This PR fails the whole build with an error if the `xbuild` step fails.