### PR TITLE
Fix LTO regressions in nightly toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version 0.6.1 (2020-05-12)
 
-- Upgrade xbuild to include LTO fix [#52](https://github.com/paritytech/cargo-contract/pull/52)
+- Fix LTO regressions in nightly toolchain [#52](https://github.com/paritytech/cargo-contract/pull/52)
 
 # Version 0.6.0 (2020-03-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.6.1 (2020-05-12)
+
+- Upgrade xbuild to include LTO fix [#52](https://github.com/paritytech/cargo-contract/pull/52)
+
 # Version 0.6.0 (2020-03-25)
 
 - First release to crates.io

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-xbuild"
-version = "0.5.28"
+version = "0.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cf1fcfab5ef1b3aeacb5bc16c248ecc4ef9e3e81ed96087e3801b81b305ca0"
+checksum = "c6c11ec6bf11f95578c3698b9dab2d605df796e32886d65431b87a434691b8c5"
 dependencies = [
  "cargo_metadata",
  "error-chain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "cargo-contract"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ codec = { package = "parity-scale-codec", version = "1.2" }
 which = "3.1.0"
 colored = "1.9"
 toml = "0.5.4"
-cargo-xbuild = "0.5.26"
+cargo-xbuild = "0.5.31"
 rustc_version = "0.2.3"
 serde_json = "1.0"
 tempfile = "3.1.0"

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -138,7 +138,9 @@ fn build_cargo_project(crate_metadata: &CrateMetadata, verbosity: Option<Verbosi
 
     Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
         .with_root_package_manifest(|manifest| {
-            manifest.with_removed_crate_type("rlib")?;
+            manifest
+                .with_removed_crate_type("rlib")?
+                .with_profile_release_lto(true)?;
             Ok(())
         })?
         .using_temp(xbuild)?;

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -59,7 +59,9 @@ pub(crate) fn execute_generate_metadata(
 
     Workspace::new(&metadata, &root_package_id)?
         .with_root_package_manifest(|manifest| {
-            manifest.with_added_crate_type("rlib")?;
+            manifest
+                .with_added_crate_type("rlib")?
+                .with_profile_release_lto(false)?;
             Ok(())
         })?
         .using_temp(generate_metadata)?;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -135,6 +135,24 @@ impl Manifest {
         Ok(self)
     }
 
+    /// Set `[profile.release]` lto flag
+    pub fn with_profile_release_lto(&mut self, enabled: bool) -> Result<&mut Self> {
+        let profile = self.toml.entry("profile")
+            .or_insert(value::Value::Table(Default::default()));
+        let release = profile
+            .as_table_mut()
+            .ok_or(anyhow::anyhow!("profile should be a table"))?
+            .entry("release")
+            .or_insert(value::Value::Table(Default::default()));
+        let lto = release
+            .as_table_mut()
+            .ok_or(anyhow::anyhow!("release should be a table"))?
+            .entry("lto")
+            .or_insert(enabled.into());
+        *lto = enabled.into();
+        Ok(self)
+    }
+
     /// Remove a value from the `[lib] crate-types = []` section
     ///
     /// If the value does not exist, does nothing.

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -137,7 +137,9 @@ impl Manifest {
 
     /// Set `[profile.release]` lto flag
     pub fn with_profile_release_lto(&mut self, enabled: bool) -> Result<&mut Self> {
-        let profile = self.toml.entry("profile")
+        let profile = self
+            .toml
+            .entry("profile")
             .or_insert(value::Value::Table(Default::default()));
         let release = profile
             .as_table_mut()


### PR DESCRIPTION
Fix for https://github.com/paritytech/ink/issues/391.

Recent nightly has broken since https://github.com/rust-lang/rust/pull/71925 (see https://github.com/rust-osdev/cargo-xbuild/issues/69#issuecomment-627231724)

- Upgrades version of `cargo-xbuild` which adds LTO flag to sysroot build: https://github.com/rust-osdev/cargo-xbuild/pull/71.
- Disables lto flag when generating metadata which fixes `file not recognized: File format not recognized`. rel: #40