### PR TITLE
Add preferred default release profile settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parity-wasm",
+ "pretty_assertions",
  "pwasm-utils",
  "rustc_version",
  "serde_json",
@@ -514,6 +515,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +547,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
@@ -1546,6 +1563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "pallet-indices"
 version = "2.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1781,18 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "pretty_assertions"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "difference",
+ "output_vt100",
+]
 
 [[package]]
 name = "primitive-types"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ walkdir = "2.3.1"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
+pretty_assertions = "0.6.1"
 wabt = "0.9.2"
 
 [features]

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -23,7 +23,7 @@ use std::{
 
 use crate::{
     util,
-    workspace::{ManifestPath, Workspace, Profile},
+    workspace::{ManifestPath, Profile, Workspace},
     UnstableFlags, Verbosity,
 };
 use anyhow::{Context, Result};
@@ -100,7 +100,10 @@ pub fn collect_crate_metadata(manifest_path: &ManifestPath) -> Result<CrateMetad
 /// The original Cargo.toml will be amended to remove the `rlib` crate type in order to minimize
 /// the final Wasm binary size.
 ///
-/// To disable this and use the `Cargo.toml` as is then pass the `-Z original_manifest` flag.
+/// Preferred default `[profile.release]` settings will be added if they are missing, existing
+/// user-defined settings will be preserved.
+///
+/// To disable this and use the original `Cargo.toml` as is then pass the `-Z original_manifest` flag.
 fn build_cargo_project(
     crate_metadata: &CrateMetadata,
     verbosity: Option<Verbosity>,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -23,7 +23,7 @@ use std::{
 
 use crate::{
     util,
-    workspace::{ManifestPath, Workspace},
+    workspace::{ManifestPath, Workspace, Profile},
     UnstableFlags, Verbosity,
 };
 use anyhow::{Context, Result};
@@ -160,7 +160,7 @@ fn build_cargo_project(
             .with_root_package_manifest(|manifest| {
                 manifest
                     .with_removed_crate_type("rlib")?
-                    .with_profile_release_lto(true)?;
+                    .with_profile_release_defaults(Profile::default_contract_release())?;
                 Ok(())
             })?
             .using_temp(xbuild)?;

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -432,7 +432,7 @@ impl Workspace {
 
 /// Subset of cargo profile settings to configure defaults for building contracts
 pub struct Profile {
-    opt_level: OptLevel,
+    opt_level: Option<OptLevel>,
     lto: Lto,
     // `None` means use rustc default.
     codegen_units: Option<u32>,
@@ -444,7 +444,7 @@ impl Profile {
     /// The preferred set of defaults for compiling a release build of a contract
     pub fn default_contract_release() -> Profile {
         Profile {
-            opt_level: OptLevel::Z,
+            opt_level: Some(OptLevel::Z),
             lto: Lto::Bool(true),
             codegen_units: Some(1),
             overflow_checks: true,
@@ -463,7 +463,9 @@ impl Profile {
                 profile.insert(key.into(), value);
             }
         };
-        set_value_if_vacant("opt-level", self.opt_level.to_toml_value());
+        if let Some(opt_level) = self.opt_level {
+            set_value_if_vacant("opt-level", opt_level.to_toml_value());
+        }
         set_value_if_vacant("lto", self.lto.to_toml_value());
         if let Some(codegen_units) = self.codegen_units {
             set_value_if_vacant("codegen-units", codegen_units.into());
@@ -474,13 +476,12 @@ impl Profile {
 }
 
 /// The [`opt-level`](https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level) setting
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
 #[allow(unused)]
+#[derive(Clone, Copy)]
 pub enum OptLevel {
-    Zero,
-    One,
-    Two,
-    Three,
+    O1,
+    O2,
+    O3,
     S,
     Z,
 }
@@ -488,10 +489,9 @@ pub enum OptLevel {
 impl OptLevel {
     fn to_toml_value(&self) -> value::Value {
         match self {
-            OptLevel::Zero => 0.into(),
-            OptLevel::One => 1.into(),
-            OptLevel::Two => 2.into(),
-            OptLevel::Three => 3.into(),
+            OptLevel::O1 => 1.into(),
+            OptLevel::O2 => 2.into(),
+            OptLevel::O3 => 3.into(),
             OptLevel::S => "s".into(),
             OptLevel::Z => "z".into(),
         }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -432,7 +432,7 @@ impl Workspace {
 
 /// Subset of cargo profile settings to configure defaults for building contracts
 pub struct Profile {
-    opt_level: Option<OptLevel>,
+    opt_level: OptLevel,
     lto: Lto,
     // `None` means use rustc default.
     codegen_units: Option<u32>,
@@ -444,7 +444,7 @@ impl Profile {
     /// The preferred set of defaults for compiling a release build of a contract
     pub fn default_contract_release() -> Profile {
         Profile {
-            opt_level: Some(OptLevel::Z),
+            opt_level: OptLevel::Z,
             lto: Lto::Fat,
             codegen_units: Some(1),
             overflow_checks: true,
@@ -463,9 +463,7 @@ impl Profile {
                 profile.insert(key.into(), value);
             }
         };
-        if let Some(opt_level) = self.opt_level {
-            set_value_if_vacant("opt-level", opt_level.to_toml_value());
-        }
+        set_value_if_vacant("opt-level", self.opt_level.to_toml_value());
         set_value_if_vacant("lto", self.lto.to_toml_value());
         if let Some(codegen_units) = self.codegen_units {
             set_value_if_vacant("codegen-units", codegen_units.into());
@@ -479,6 +477,7 @@ impl Profile {
 #[allow(unused)]
 #[derive(Clone, Copy)]
 pub enum OptLevel {
+    NoOptimizations,
     O1,
     O2,
     O3,
@@ -489,6 +488,7 @@ pub enum OptLevel {
 impl OptLevel {
     fn to_toml_value(&self) -> value::Value {
         match self {
+            OptLevel::NoOptimizations => 0.into(),
             OptLevel::O1 => 1.into(),
             OptLevel::O2 => 2.into(),
             OptLevel::O3 => 3.into(),

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -453,7 +453,7 @@ impl Default for Profile {
 
 impl Profile {
     /// The preferred set of defaults for compiling a release build of a contract
-    fn default_contract_build_release() -> Profile {
+    pub fn default_contract_release() -> Profile {
         Profile {
             opt_level: OptLevel::Z,
             lto: Lto::Bool(true),
@@ -552,7 +552,7 @@ mod tests {
 
     #[test]
     fn merge_profile_inserts_preferred_defaults() {
-        let profile = Profile::default_contract_build_release();
+        let profile = Profile::default_contract_release();
 
         // no `[profile.release]` section specified
         let manifest_toml = "";
@@ -572,7 +572,7 @@ mod tests {
 
     #[test]
     fn merge_profile_preserves_user_defined_settings() {
-        let profile = Profile::default_contract_build_release();
+        let profile = Profile::default_contract_release();
 
         let manifest_toml = r#"
 panic = "unwind"

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -440,18 +440,6 @@ pub struct Profile {
     panic: PanicStrategy,
 }
 
-impl Default for Profile {
-    fn default() -> Profile {
-        Profile {
-            opt_level: OptLevel::One,
-            lto: Lto::Bool(false),
-            codegen_units: None,
-            overflow_checks: false,
-            panic: PanicStrategy::Unwind,
-        }
-    }
-}
-
 impl Profile {
     /// The preferred set of defaults for compiling a release build of a contract
     pub fn default_contract_release() -> Profile {
@@ -532,6 +520,7 @@ impl Lto {
 
 /// The `panic` setting.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
+#[allow(unused)]
 pub enum PanicStrategy {
     Unwind,
     Abort,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -445,7 +445,7 @@ impl Profile {
     pub fn default_contract_release() -> Profile {
         Profile {
             opt_level: Some(OptLevel::Z),
-            lto: Lto::Bool(true),
+            lto: Lto::Fat,
             codegen_units: Some(1),
             overflow_checks: true,
             panic: PanicStrategy::Abort,
@@ -499,21 +499,26 @@ impl OptLevel {
 }
 
 /// The [`link-time-optimization`](https://doc.rust-lang.org/cargo/reference/profiles.html#lto) setting.
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy)]
+#[allow(unused)]
 pub enum Lto {
-    /// False = no LTO
-    /// True = "Fat" LTO
-    Bool(bool),
-    /// Named LTO settings like "thin".
-    #[allow(unused)]
-    Named(&'static str),
+    /// Sets `lto = false`
+    ThinLocal,
+    /// Sets `lto = "fat"`, the equivalent of `lto = true`
+    Fat,
+    /// Sets `lto = "thin"`
+    Thin,
+    /// Sets `lto = "off"`
+    Off,
 }
 
 impl Lto {
     fn to_toml_value(&self) -> value::Value {
         match self {
-            Lto::Bool(b) => value::Value::Boolean(*b),
-            Lto::Named(n) => value::Value::String(n.to_string()),
+            Lto::ThinLocal => value::Value::Boolean(false),
+            Lto::Fat => value::Value::String("fat".into()),
+            Lto::Thin => value::Value::String("thin".into()),
+            Lto::Off => value::Value::String("off".into()),
         }
     }
 }
@@ -548,7 +553,7 @@ mod tests {
         let manifest_toml = "";
         let mut expected = toml::value::Table::new();
         expected.insert("opt-level".into(), value::Value::String("z".into()));
-        expected.insert("lto".into(), value::Value::Boolean(true));
+        expected.insert("lto".into(), value::Value::String("fat".into()));
         expected.insert("codegen-units".into(), value::Value::Integer(1));
         expected.insert("overflow-checks".into(), value::Value::Boolean(true));
         expected.insert("panic".into(), value::Value::String("abort".into()));

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -565,11 +565,11 @@ mod tests {
         let profile = Profile::default_contract_release();
 
         let manifest_toml = r#"
-panic = "unwind"
-lto = false
-opt-level = 3
-overflow-checks = false
-codegen-units = 256
+            panic = "unwind"
+            lto = false
+            opt-level = 3
+            overflow-checks = false
+            codegen-units = 256
         "#;
         let mut expected = toml::value::Table::new();
         expected.insert("opt-level".into(), value::Value::Integer(3));

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -137,7 +137,8 @@ impl Manifest {
 
     /// Set `[profile.release]` lto flag
     pub fn with_profile_release_lto(&mut self, enabled: bool) -> Result<&mut Self> {
-        let lto = self.get_profile_release_table_mut()?
+        let lto = self
+            .get_profile_release_table_mut()?
             .entry("lto")
             .or_insert(enabled.into());
         *lto = enabled.into();

--- a/template/_Cargo.toml
+++ b/template/_Cargo.toml
@@ -11,7 +11,13 @@ ink_core = { version = "2", git = "https://github.com/paritytech/ink", tag = "la
 ink_lang = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.2", default-features = false, features = ["derive"] }
-scale-info = { version = "0.1", default-features = false, features = ["derive"], optional = true }
+
+[dependencies.type-metadata]
+git = "https://github.com/type-metadata/type-metadata.git"
+rev = "02eae9f35c40c943b56af5b60616219f2b72b47d"
+default-features = false
+features = ["derive"]
+optional = true
 
 [lib]
 name = "{{name}}"
@@ -31,7 +37,7 @@ std = [
     "ink_core/std",
     "ink_primitives/std",
     "scale/std",
-    "scale-info/std",
+    "type-metadata/std",
 ]
 test-env = [
     "std",
@@ -40,7 +46,7 @@ test-env = [
 ink-generate-abi = [
     "std",
     "ink_abi",
-    "scale-info",
+    "type-metadata",
     "ink_core/ink-generate-abi",
     "ink_lang/ink-generate-abi",
 ]

--- a/template/_Cargo.toml
+++ b/template/_Cargo.toml
@@ -31,7 +31,7 @@ std = [
     "ink_core/std",
     "ink_primitives/std",
     "scale/std",
-    "type-metadata/std",
+    "scale-info/std",
 ]
 test-env = [
     "std",
@@ -40,7 +40,7 @@ test-env = [
 ink-generate-abi = [
     "std",
     "ink_abi",
-    "type-metadata",
+    "scale-info",
     "ink_core/ink-generate-abi",
     "ink_lang/ink-generate-abi",
 ]

--- a/template/_Cargo.toml
+++ b/template/_Cargo.toml
@@ -11,13 +11,7 @@ ink_core = { version = "2", git = "https://github.com/paritytech/ink", tag = "la
 ink_lang = { version = "2", git = "https://github.com/paritytech/ink", tag = "latest-v2", package = "ink_lang", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.2", default-features = false, features = ["derive"] }
-
-[dependencies.type-metadata]
-git = "https://github.com/type-metadata/type-metadata.git"
-rev = "02eae9f35c40c943b56af5b60616219f2b72b47d"
-default-features = false
-features = ["derive"]
-optional = true
+scale-info = { version = "0.1", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "{{name}}"
@@ -51,12 +45,6 @@ ink-generate-abi = [
     "ink_lang/ink-generate-abi",
 ]
 ink-as-dependency = []
-
-[profile.release]
-panic = "abort"
-lto = true
-opt-level = "z"
-overflow-checks = true
 
 [workspace]
 members = [


### PR DESCRIPTION
Rel #40, https://github.com/paritytech/ink/pull/448

If any of the following `[profile.release]` settings are missing, then they are added with the following preferred defaults:

```
[profile.release]
panic = "abort"
lto = true
opt-level = "z"
overflow-checks = true
codegen-units = 1
```
Any of the above that are manually specified are **not** overwritten. This allows manual control over e.g. `opt-level` where in some cases `opt-level = 3` might result in a smaller binary size.  

**Template changes:**
  - Remove `[profile.release]` section
  - ~~Use `scale-info` from crates.io instead of `type-metadata`~~ (reverted: requires ink! 3 release)




