### PR TITLE
Add file header check, update file headers

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+license_template_path = "FILE_HEADER" # changed

--- a/FILE_HEADER
+++ b/FILE_HEADER
@@ -1,0 +1,15 @@
+// Copyright {20\d{2}}-{20\d{2}} Parity Technologies (UK) Ltd.
+// This file is part of cargo-contract.
+//
+// cargo-contract is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// cargo-contract is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
     env,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
     fs::metadata,

--- a/src/cmd/deploy.rs
+++ b/src/cmd/deploy.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{fs, io::Read, path::PathBuf};
 

--- a/src/cmd/instantiate.rs
+++ b/src/cmd/instantiate.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use anyhow::Result;
 use subxt::{balances::Balances, contracts::*, system::System, ClientBuilder, DefaultNodeRuntime};

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
     util,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 mod build;
 #[cfg(feature = "extrinsics")]

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
     env, fs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 mod cmd;
 mod util;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{workspace::ManifestPath, Verbosity};
 use anyhow::{Context, Result};

--- a/src/workspace/manifest.rs
+++ b/src/workspace/manifest.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use anyhow::{Context, Result};
 

--- a/src/workspace/metadata.rs
+++ b/src/workspace/metadata.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use anyhow::Result;
 use std::{fs, path::Path};

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 mod manifest;
 mod metadata;

--- a/src/workspace/profile.rs
+++ b/src/workspace/profile.rs
@@ -1,18 +1,18 @@
 // Copyright 2018-2020 Parity Technologies (UK) Ltd.
 // This file is part of cargo-contract.
 //
-// ink! is free software: you can redistribute it and/or modify
+// cargo-contract is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 //
-// ink! is distributed in the hope that it will be useful,
+// cargo-contract is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License
-// along with ink!.  If not, see <http://www.gnu.org/licenses/>.
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use toml::value;
 


### PR DESCRIPTION
- Removes some legacy references from when the files were copied from `ink!`.
- Adds a `cargo fmt` check which ensures the file header format is adhered to.