### PR TITLE
Upgrade cargo-xbuild and other dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
 name = "arrayref"
@@ -364,7 +364,7 @@ dependencies = [
  "async-std",
  "blake2",
  "cargo-xbuild",
- "cargo_metadata",
+ "cargo_metadata 0.11.1",
  "colored",
  "env_logger",
  "futures 0.3.5",
@@ -387,17 +387,17 @@ dependencies = [
  "url 2.1.1",
  "wabt",
  "walkdir",
- "which",
+ "which 4.0.2",
  "zip",
 ]
 
 [[package]]
 name = "cargo-xbuild"
-version = "0.5.32"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251916356141490b16283653fc2c0d04503f070d2942d456248cff5632b02e28"
+checksum = "681545a8d9888d72325ffc1603065ec4732986c8ce88cfffae0464ce22daad3a"
 dependencies = [
- "cargo_metadata",
+ "cargo_metadata 0.9.1",
  "error-chain",
  "fs2",
  "libc",
@@ -405,7 +405,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tempdir",
+ "tempfile",
  "toml",
  "walkdir",
 ]
@@ -419,6 +419,17 @@ dependencies = [
  "semver 0.9.0",
  "serde",
  "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89fec17b16f1ac67908af82e47d0a90a7afd0e1827b181cd77504323d3263d35"
+dependencies = [
+ "semver 0.10.0",
+ "serde",
  "serde_json",
 ]
 
@@ -469,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "1.9.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
@@ -577,7 +588,7 @@ checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
 dependencies = [
  "byteorder",
  "digest 0.8.1",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle 2.2.2",
  "zeroize",
 ]
@@ -640,7 +651,7 @@ checksum = "21a8a37f4e8b35af971e6db5e3897e7a6344caa3f92f6544f88125a1f5f0035a"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
+ "rand",
  "serde",
  "sha2",
  "zeroize",
@@ -721,7 +732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
- "rand 0.7.3",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -838,12 +849,6 @@ dependencies = [
  "libc",
  "winapi 0.3.8",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -1387,7 +1392,7 @@ dependencies = [
  "jsonrpc-core",
  "log",
  "parking_lot 0.10.2",
- "rand 0.7.3",
+ "rand",
  "serde",
 ]
 
@@ -1412,7 +1417,7 @@ dependencies = [
  "log",
  "parking_lot 0.10.2",
  "pin-project",
- "rand 0.7.3",
+ "rand",
  "serde",
  "serde_json",
  "smallvec 1.4.1",
@@ -1526,7 +1531,7 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand",
  "ring",
  "rw-stream-sink",
  "sha2",
@@ -1556,7 +1561,7 @@ dependencies = [
  "futures 0.3.5",
  "libp2p-core",
  "log",
- "rand 0.7.3",
+ "rand",
  "smallvec 1.4.1",
  "void",
  "wasm-timer",
@@ -1572,7 +1577,7 @@ dependencies = [
  "crunchy",
  "digest 0.8.1",
  "hmac-drbg",
- "rand 0.7.3",
+ "rand",
  "sha2",
  "subtle 2.2.2",
  "typenum",
@@ -1648,7 +1653,7 @@ checksum = "c6feca46f4fa3443a01769d768727f10c10a20fdb65e52dc16a81f0c8269bb78"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.5.1",
+ "rand_core",
  "zeroize",
 ]
 
@@ -2182,7 +2187,7 @@ dependencies = [
  "prost",
  "prost-types",
  "tempfile",
- "which",
+ "which 3.1.1",
 ]
 
 [[package]]
@@ -2216,9 +2221,9 @@ checksum = "8e86d370532557ae7573551a1ec8235a0f8d6cb276c7c9e6aa490b511c447485"
 
 [[package]]
 name = "pwasm-utils"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
+checksum = "0f53bc2558e8376358ebdc28301546471d67336584f6438ed4b7c7457a055fd7"
 dependencies = [
  "byteorder",
  "log",
@@ -2248,19 +2253,6 @@ checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2268,7 +2260,7 @@ dependencies = [
  "getrandom",
  "libc",
  "rand_chacha",
- "rand_core 0.5.1",
+ "rand_core",
  "rand_hc",
  "rand_pcg",
 ]
@@ -2280,23 +2272,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2313,7 +2290,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -2322,16 +2299,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -2525,8 +2493,8 @@ dependencies = [
  "curve25519-dalek",
  "getrandom",
  "merlin",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand",
+ "rand_core",
  "sha2",
  "subtle 2.2.2",
  "zeroize",
@@ -2603,18 +2571,18 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+checksum = "609feed1d0a73cc36a0182a840a9b37b4a82f0b1150369f0536a9e3f2a31dc48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2747,7 +2715,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.7.3",
+ "rand",
  "sha1",
  "smallvec 1.4.1",
  "static_assertions",
@@ -2902,7 +2870,7 @@ dependencies = [
  "parity-util-mem",
  "parking_lot 0.10.2",
  "primitive-types",
- "rand 0.7.3",
+ "rand",
  "regex",
  "schnorrkel",
  "secrecy",
@@ -3034,7 +3002,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "paste",
- "rand 0.7.3",
+ "rand",
  "serde",
  "sp-application-crypto",
  "sp-arithmetic",
@@ -3085,7 +3053,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.10.2",
- "rand 0.7.3",
+ "rand",
  "smallvec 1.4.1",
  "sp-core",
  "sp-externalities",
@@ -3220,9 +3188,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
+checksum = "de5472fb24d7e80ae84a7801b7978f95a19ec32cb1876faea59ab711eb901976"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3231,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
+checksum = "1e0eb37335aeeebe51be42e2dc07f031163fbabfa6ac67d7ea68b5c2f68d5f99"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -3380,16 +3348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3397,7 +3355,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
  "libc",
- "rand 0.7.3",
+ "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
@@ -3470,7 +3428,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2",
- "rand 0.7.3",
+ "rand",
  "rustc-hash",
  "sha2",
  "unicode-normalization",
@@ -3595,7 +3553,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bfd5b7557925ce778ff9b9ef90e3ade34c524b5ff10e239c69a42d546d2af56"
 dependencies = [
- "rand 0.7.3",
+ "rand",
 ]
 
 [[package]]
@@ -3722,9 +3680,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wabt"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5c5c1286c6e578416982609f47594265f9d489f9b836157d403ad605a46693"
+checksum = "00bef93d5e6c81a293bccf107cf43aa47239382f455ba14869d36695d8963b9c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -3734,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "wabt-sys"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7043ebb3e5d96fad7a8d3ca22ee9880748ff8c3e18092cfb2a49d3b8f9084"
+checksum = "1a4e043159f63e16986e713e9b5e1c06043df4848565bf672e27c523864c7791"
 dependencies = [
  "cc",
  "cmake",
@@ -3925,8 +3883,17 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
- "failure",
  "libc",
+]
+
+[[package]]
+name = "which"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
 ]
 
 [[package]]
@@ -4005,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df134e83b8f0f8153a094c7b0fd79dfebe437f1d76e7715afa18ed95ebe2fd7"
+checksum = "58287c28d78507f5f91f2a4cf1e8310e2c76fd4c6932f93ac60fd1ceb402db7d"
 dependencies = [
  "crc32fast",
  "podio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,24 +17,24 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE", "build.rs", "tem
 
 [dependencies]
 env_logger = "0.7.1"
-anyhow = "1.0.26"
-structopt = "0.3.9"
-log = "0.4.8"
+anyhow = "1.0.32"
+structopt = "0.3.16"
+log = "0.4.11"
 heck = "0.3.1"
-zip = { version = "0.5.4", default-features = false }
-pwasm-utils = "0.12.0"
+zip = { version = "0.5.6", default-features = false }
+pwasm-utils = "0.14.0"
 parity-wasm = "0.41.0"
-cargo_metadata = "0.9.1"
-codec = { package = "parity-scale-codec", version = "1.2" }
-which = "3.1.0"
-colored = "1.9"
-toml = "0.5.4"
-cargo-xbuild = "0.5.32"
+cargo_metadata = "0.11.1"
+codec = { package = "parity-scale-codec", version = "1.3.4" }
+which = "4.0.2"
+colored = "2.0.0"
+toml = "0.5.6"
+cargo-xbuild = "0.6.0"
 rustc_version = "0.2.3"
 blake2 = "0.9.0"
 semver = { version = "0.10.0", features = ["serde"] }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0.115", default-features = false, features = ["derive"] }
+serde_json = "1.0.57"
 tempfile = "3.1.0"
 url = { version = "2.1.1", features = ["serde"] }
 
@@ -42,18 +42,18 @@ url = { version = "2.1.1", features = ["serde"] }
 async-std = { version = "1.6.2", optional = true }
 sp-core = { version = "2.0.0-rc5", optional = true }
 subxt = { version = "0.11.0", package = "substrate-subxt", optional = true }
-futures = { version = "0.3.2", optional = true }
-hex = { version = "0.4.0", optional = true }
+futures = { version = "0.3.5", optional = true }
+hex = { version = "0.4.2", optional = true }
 
 [build-dependencies]
-anyhow = "1.0"
-zip = { version = "0.5.4", default-features = false }
+anyhow = "1.0.32"
+zip = { version = "0.5.6", default-features = false }
 walkdir = "2.3.1"
 
 [dev-dependencies]
 assert_matches = "1.3.0"
 pretty_assertions = "0.6.1"
-wabt = "0.9.2"
+wabt = "0.10.0"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ SUBCOMMANDS:
 To avoid having to add `+nightly` you can also create a `rust-toolchain` file in your local directory containing 
 `nightly`. Read more about how to [specify the rustup toolchain](https://github.com/rust-lang/rustup#override-precedence).
 
+### Note 
+
+The latest version of `cargo-contract` supports all nightlies after `2020-07-30`, because of a change in the directory
+structure of the `rust-src` component. 
+
 ## Features
 
 The `deploy` and `instantiate` subcommands are **disabled by default**, since they are not fully stable yet and increase the build time.


### PR DESCRIPTION
Fixes #70.

Upgrades to `cargo-xbuild 0.6.0` which includes https://github.com/rust-osdev/cargo-xbuild/pull/87. This makes it compatible with the new `rust-src` layout here https://github.com/rust-lang/rust/pull/73265.

I will merge this once there is a new `nightly` > 2020-07-30 which includes `rustfmt`: https://rust-lang.github.io/rustup-components-history/