### PR TITLE
Bump xbuild to 0.6.0 to fix "build" command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ codec = { package = "parity-scale-codec", version = "1.2" }
 which = "3.1.0"
 colored = "1.9"
 toml = "0.5.4"
-cargo-xbuild = "0.5.32"
+cargo-xbuild = "0.6.0"
 rustc_version = "0.2.3"
 blake2 = "0.9.0"
 semver = { version = "0.10.0", features = ["serde"] }


### PR DESCRIPTION
Bump `cargo-xbuild` to 0.6.0 version to fix the `build` command which fails on the recent cargo version with error:

```
[1/3] Building cargo project
ERROR: Building with xbuild

Caused by:
    `rust-src` component not found. Run `rustup component add rust-src`.

```

As described on [`cargo-xbuild`](https://github.com/rust-osdev/cargo-xbuild#installation-of-cargo-xbuild) repo, version `0.6.0` fixes issue with `rust-src component not found` in :
```
Note: The latest version of cargo-xbuild supports all nightlies after 2020-07-30. If you are on an older nightly, you need to install version 0.5.35: cargo install cargo-xbuild --version 0.5.35.
```

