### PR TITLE
Fix ManifestPath compiler errors

### DIFF
--- a/src/crate_metadata.rs
+++ b/src/crate_metadata.rs
@@ -95,7 +95,7 @@ impl CrateMetadata {
 fn get_cargo_metadata(manifest_path: &ManifestPath) -> Result<(CargoMetadata, Package)> {
     let mut cmd = MetadataCommand::new();
     let metadata = cmd
-        .manifest_path(manifest_path)
+        .manifest_path(manifest_path.as_ref())
         .exec()
         .context("Error invoking `cargo metadata`")?;
     let root_package_id = metadata

--- a/src/workspace/manifest.rs
+++ b/src/workspace/manifest.rs
@@ -88,6 +88,12 @@ impl AsRef<Path> for ManifestPath {
     }
 }
 
+impl From<ManifestPath> for PathBuf {
+    fn from(path: ManifestPath) -> Self {
+        path.path
+    }
+}
+
 /// Create, amend and save a copy of the specified `Cargo.toml`.
 pub struct Manifest {
     path: ManifestPath,


### PR DESCRIPTION
Broken by upgrading `cargo-metadata` in #71