### PR TITLE
Specify optional --manifest-path for build and generate-metadata

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -291,7 +291,7 @@ pub(crate) fn execute_with_metadata(
 #[cfg(feature = "test-ci-only")]
 #[cfg(test)]
 mod tests {
-    use crate::{cmd, util::tests::with_tmp_dir, workspace::ManifestPath, UnstableFlags};
+    use crate::{cmd, util::tests::with_tmp_dir, ManifestPath, UnstableFlags};
 
     #[test]
     fn build_template() {

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -192,8 +192,7 @@ pub(crate) fn execute(
 #[cfg(test)]
 mod tests {
     use crate::{
-        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, workspace::ManifestPath,
-        UnstableFlags,
+        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, ManifestPath, UnstableFlags,
     };
     use blake2::digest::{Update as _, VariableOutput as _};
     use contract_metadata::*;

--- a/src/crate_metadata.rs
+++ b/src/crate_metadata.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::workspace::ManifestPath;
+use crate::ManifestPath;
 use anyhow::{Context, Result};
 use cargo_metadata::{Metadata as CargoMetadata, MetadataCommand, Package};
 use semver::Version;

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ enum Command {
     #[structopt(name = "build")]
     Build {
         /// Path to the Cargo.toml of the contract to build.
-        #[structopt(parse(from_os_str))]
+        #[structopt(long, parse(from_os_str))]
         manifest_path: Option<PathBuf>,
         #[structopt(flatten)]
         verbosity: VerbosityFlags,
@@ -176,7 +176,7 @@ enum Command {
     #[structopt(name = "generate-metadata")]
     GenerateMetadata {
         /// Path to the Cargo.toml of the contract for which to generate metadata
-        #[structopt(parse(from_os_str))]
+        #[structopt(long, parse(from_os_str))]
         manifest_path: Option<PathBuf>,
         #[structopt(flatten)]
         verbosity: VerbosityFlags,

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ enum Command {
     /// Compiles the smart contract
     #[structopt(name = "build")]
     Build {
-        /// Path to the Cargo.toml of the contract to build.
+        /// Path to the Cargo.toml of the contract to build
         #[structopt(long, parse(from_os_str))]
         manifest_path: Option<PathBuf>,
         #[structopt(flatten)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,8 @@ mod crate_metadata;
 mod util;
 mod workspace;
 
+use self::workspace::ManifestPath;
+
 #[cfg(feature = "extrinsics")]
 use sp_core::{crypto::Pair, sr25519, H256};
 use std::{
@@ -31,7 +33,6 @@ use subxt::PairSigner;
 use anyhow::{Error, Result};
 use colored::Colorize;
 use structopt::{clap, StructOpt};
-use crate::workspace::ManifestPath;
 
 #[derive(Debug, StructOpt)]
 #[structopt(bin_name = "cargo")]

--- a/src/workspace/manifest.rs
+++ b/src/workspace/manifest.rs
@@ -78,7 +78,7 @@ impl TryFrom<&PathBuf> for ManifestPath {
 
 impl<P> TryFrom<Option<P>> for ManifestPath
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     type Error = anyhow::Error;
 

--- a/src/workspace/manifest.rs
+++ b/src/workspace/manifest.rs
@@ -76,6 +76,17 @@ impl TryFrom<&PathBuf> for ManifestPath {
     }
 }
 
+impl<P> TryFrom<Option<P>> for ManifestPath
+where
+    P: AsRef<Path>
+{
+    type Error = anyhow::Error;
+
+    fn try_from(value: Option<P>) -> Result<Self, Self::Error> {
+        value.map_or(Ok(Default::default()), ManifestPath::new)
+    }
+}
+
 impl Default for ManifestPath {
     fn default() -> ManifestPath {
         ManifestPath::new(MANIFEST_FILE).expect("it's a valid manifest file")


### PR DESCRIPTION
Allows building contracts/generating metadata from a location outside the working directory.

Usage:

```
cargo run -- contract build --manifest-path ../ink/examples/erc2/Cargo.toml
cargo run -- contract generate-metadata --manifest-path ../ink/examples/erc20/Cargo.toml    
```

The `--manifest-path` flag is so named from the equivalent option in `cargo` which has the same effect.