### PR TITLE
Use binaryen-rs as dep instead of requiring manual wasm-opt installation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,8 @@ variables:
   CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   RUST_LIB_BACKTRACE:              "0"
+
+  # Necessary for building binaryen-sys, which is part of the binaryen dependency
   CXX:                             "/usr/bin/clang++-8"
 
 workflow:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ variables:
   CARGO_HOME:                      "/ci-cache/${CI_PROJECT_NAME}/cargo/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   RUST_LIB_BACKTRACE:              "0"
+  CXX:                             "/usr/bin/clang++-8"
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,9 +17,6 @@ variables:
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
   RUST_LIB_BACKTRACE:              "0"
 
-  # Necessary for building binaryen-sys, which is part of the binaryen dependency
-  CXX:                             "/usr/bin/clang++-8"
-
 workflow:
   rules:
     - if: $CI_COMMIT_TAG

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "binaryen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a51ad23b3c7ab468d9daa948201921879ef0052e561c250fd0b326e6f000f2dd"
+dependencies = [
+ "binaryen-sys",
+]
+
+[[package]]
+name = "binaryen-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df5829a7c89f7827e58866704e4dfdf48a635d73c6e5449c1a8a0ba5a319d28a"
+dependencies = [
+ "cc",
+ "cmake",
+ "heck",
+ "regex",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +498,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-std",
+ "binaryen",
  "blake2",
  "cargo-xbuild",
  "cargo_metadata 0.11.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde = { version = "1.0.115", default-features = false, features = ["derive"] }
 serde_json = "1.0.57"
 tempfile = "3.1.0"
 url = { version = "2.1.1", features = ["serde"] }
+binaryen = "0.10.0"
 
 # dependencies for optional extrinsics feature
 async-std = { version = "1.6.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A CLI tool for helping setting up and managing WebAssembly smart contracts writt
 - **Prerequisites**
 
   - **rust-src**: `rustup component add rust-src`
-  - **wasm-opt**: https://github.com/WebAssembly/binaryen#tools
+  - A C++14 compiler is required for building the [binaryen](https://github.com/WebAssembly/binaryen)
+    dependency. `binaryen` is build automatically during the `cargo-contract` build process.
 
 - **Install latest version from [crates.io](https://crates.io/crates/cargo-contract)**
   - `cargo install cargo-contract`


### PR DESCRIPTION
Closes #91.