### PR TITLE
Implement new commands `build` and `check` + introduce bundles (.contract files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ OPTIONS:
 
 SUBCOMMANDS:
     new                  Setup and create a new smart contract project
-    build                Compiles the smart contract
-    generate-metadata    Generate contract metadata artifacts
+    build                Compiles the contract, generates metadata, bundles both together in a '.contract' file
+    check                Check that the Wasm builds; does not optimize, generate metadata, or bundle
     test                 Test the smart contract off-chain
     deploy               Upload the smart contract code to the chain
     instantiate          Instantiate a deployed smart contract

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ OPTIONS:
 SUBCOMMANDS:
     new                  Setup and create a new smart contract project
     build                Compiles the contract, generates metadata, bundles both together in a '.contract' file
-    check                Check that the Wasm builds; does not optimize, generate metadata, or bundle
+    check                Check that the code builds as Wasm; does not output any build artifact to the top level `target/` directory
     test                 Test the smart contract off-chain
     deploy               Upload the smart contract code to the chain
     instantiate          Instantiate a deployed smart contract

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -28,7 +28,7 @@
 //! let language = SourceLanguage::new(Language::Ink, Version::new(2, 1, 0));
 //! let compiler = SourceCompiler::new(Compiler::RustC, Version::parse("1.46.0-nightly").unwrap());
 //! let wasm = SourceWasm::new(vec![0u8]);
-//! let source = Source::new(Some(wasm), Some([0u8; 32]), language, compiler);
+//! let source = Source::new(Some(wasm), Some(CodeHash([0u8; 32])), language, compiler);
 //! let contract = Contract::builder()
 //!     .name("incrementer".to_string())
 //!     .version(Version::new(2, 1, 0))
@@ -522,7 +522,7 @@ mod tests {
         let compiler =
             SourceCompiler::new(Compiler::RustC, Version::parse("1.46.0-nightly").unwrap());
         let wasm = SourceWasm::new(vec![0u8, 1u8, 2u8]);
-        let source = Source::new(Some(wasm), Some([0u8; 32]), language, compiler);
+        let source = Source::new(Some(wasm), Some(CodeHash([0u8; 32])), language, compiler);
         let contract = Contract::builder()
             .name("incrementer".to_string())
             .version(Version::new(2, 1, 0))
@@ -604,7 +604,7 @@ mod tests {
         let language = SourceLanguage::new(Language::Ink, Version::new(2, 1, 0));
         let compiler =
             SourceCompiler::new(Compiler::RustC, Version::parse("1.46.0-nightly").unwrap());
-        let source = Source::new(None, Some([0u8; 32]), language, compiler);
+        let source = Source::new(None, Some(CodeHash([0u8; 32])), language, compiler);
         let contract = Contract::builder()
             .name("incrementer".to_string())
             .version(Version::new(2, 1, 0))

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -33,9 +33,9 @@
 //!     .version(Version::new(2, 1, 0))
 //!     .authors(vec!["Parity Technologies <admin@parity.io>".to_string()])
 //!     .description("increment a value".to_string())
-//!     .documentation(Url::parse("http:docs.rs/").unwrap())
-//!     .repository(Url::parse("http:github.com/paritytech/ink/").unwrap())
-//!     .homepage(Url::parse("http:example.com/").unwrap())
+//!     .documentation(Url::parse("http://docs.rs/").unwrap())
+//!     .repository(Url::parse("http://github.com/paritytech/ink/").unwrap())
+//!     .homepage(Url::parse("http://example.com/").unwrap())
 //!     .license("Apache-2.0".to_string())
 //!     .build()
 //!     .unwrap();

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -99,13 +99,23 @@ impl ContractMetadata {
     }
 }
 
+/// Representation of the Wasm code hash.
+#[derive(Debug, Eq, PartialEq)]
+pub struct CodeHash(pub [u8; 32]);
+
+impl Serialize for CodeHash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_as_byte_str(&self.0[..], serializer)
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct Source {
-    #[serde(
-        serialize_with = "serialize_as_byte_str_foo",
-        skip_serializing_if = "Option::is_none"
-    )]
-    hash: Option<[u8; 32]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hash: Option<CodeHash>,
     language: SourceLanguage,
     compiler: SourceCompiler,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -116,7 +126,7 @@ impl Source {
     /// Constructs a new InkProjectSource.
     pub fn new(
         wasm: Option<SourceWasm>,
-        hash: Option<[u8; 32]>,
+        hash: Option<CodeHash>,
         language: SourceLanguage,
         compiler: SourceCompiler,
     ) -> Self {
@@ -434,14 +444,6 @@ impl ContractBuilder {
             ))
         }
     }
-}
-
-fn serialize_as_byte_str_foo<S>(bytes: &Option<[u8; 32]>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    let bytes = bytes.expect("must_exist");
-    serialize_as_byte_str(&bytes[..], serializer)
 }
 
 /// Serializes the given bytes as byte string.

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -28,7 +28,7 @@
 //! let language = SourceLanguage::new(Language::Ink, Version::new(2, 1, 0));
 //! let compiler = SourceCompiler::new(Compiler::RustC, Version::parse("1.46.0-nightly").unwrap());
 //! let wasm = SourceWasm::new(vec![0u8]);
-//! let source = Source::new(Some(wasm), [0u8; 32], language, compiler);
+//! let source = Source::new(Some(wasm), Some([0u8; 32]), language, compiler);
 //! let contract = Contract::builder()
 //!     .name("incrementer".to_string())
 //!     .version(Version::new(2, 1, 0))

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -520,7 +520,7 @@ mod tests {
         let compiler =
             SourceCompiler::new(Compiler::RustC, Version::parse("1.46.0-nightly").unwrap());
         let wasm = SourceWasm::new(vec![0u8, 1u8, 2u8]);
-        let source = Source::new(Some(wasm), [0u8; 32], language, compiler);
+        let source = Source::new(Some(wasm), Some([0u8; 32]), language, compiler);
         let contract = Contract::builder()
             .name("incrementer".to_string())
             .version(Version::new(2, 1, 0))
@@ -602,7 +602,7 @@ mod tests {
         let language = SourceLanguage::new(Language::Ink, Version::new(2, 1, 0));
         let compiler =
             SourceCompiler::new(Compiler::RustC, Version::parse("1.46.0-nightly").unwrap());
-        let source = Source::new(None, [0u8; 32], language, compiler);
+        let source = Source::new(None, Some([0u8; 32]), language, compiler);
         let contract = Contract::builder()
             .name("incrementer".to_string())
             .version(Version::new(2, 1, 0))

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -101,8 +101,11 @@ impl ContractMetadata {
 
 #[derive(Debug, Serialize)]
 pub struct Source {
-    #[serde(serialize_with = "serialize_as_byte_str")]
-    hash: [u8; 32],
+    #[serde(
+        serialize_with = "serialize_as_byte_str_foo",
+        skip_serializing_if = "Option::is_none"
+    )]
+    hash: Option<[u8; 32]>,
     language: SourceLanguage,
     compiler: SourceCompiler,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -113,7 +116,7 @@ impl Source {
     /// Constructs a new InkProjectSource.
     pub fn new(
         wasm: Option<SourceWasm>,
-        hash: [u8; 32],
+        hash: Option<[u8; 32]>,
         language: SourceLanguage,
         compiler: SourceCompiler,
     ) -> Self {
@@ -431,6 +434,14 @@ impl ContractBuilder {
             ))
         }
     }
+}
+
+fn serialize_as_byte_str_foo<S>(bytes: &Option<[u8; 32]>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let bytes = bytes.expect("must_exist");
+    serialize_as_byte_str(&bytes[..], serializer)
 }
 
 /// Serializes the given bytes as byte string.

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -61,7 +61,7 @@ use url::Url;
 const METADATA_VERSION: &str = "0.1.0";
 
 /// Smart contract metadata.
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ContractMetadata {
     #[serde(rename = "metadataVersion")]
     metadata_version: semver::Version,
@@ -100,7 +100,7 @@ impl ContractMetadata {
 }
 
 /// Representation of the Wasm code hash.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CodeHash(pub [u8; 32]);
 
 impl Serialize for CodeHash {
@@ -112,7 +112,7 @@ impl Serialize for CodeHash {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct Source {
     #[serde(skip_serializing_if = "Option::is_none")]
     hash: Option<CodeHash>,
@@ -140,7 +140,7 @@ impl Source {
 }
 
 /// The bytes of the compiled Wasm smart contract.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SourceWasm {
     wasm: Vec<u8>,
 }
@@ -172,7 +172,7 @@ impl Display for SourceWasm {
 }
 
 /// The language and version in which a smart contract is written.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SourceLanguage {
     language: Language,
     version: Version,
@@ -201,7 +201,7 @@ impl Display for SourceLanguage {
 }
 
 /// The language in which the smart contract is written.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Language {
     Ink,
     Solidity,
@@ -219,7 +219,7 @@ impl Display for Language {
 }
 
 /// A compiler used to compile a smart contract.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SourceCompiler {
     compiler: Compiler,
     version: Version,
@@ -247,7 +247,7 @@ impl SourceCompiler {
 }
 
 /// Compilers used to compile a smart contract.
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub enum Compiler {
     RustC,
     Solang,
@@ -263,7 +263,7 @@ impl Display for Compiler {
 }
 
 /// Metadata about a smart contract.
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct Contract {
     name: String,
     version: Version,
@@ -287,7 +287,7 @@ impl Contract {
 }
 
 /// Additional user defined metadata, can be any valid json.
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct User {
     #[serde(flatten)]
     json: Map<String, Value>,

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -94,7 +94,7 @@ impl ContractMetadata {
         }
     }
 
-    pub fn remove_wasm(&mut self) {
+    pub fn remove_source_wasm_attribute(&mut self) {
         self.source.wasm = None;
     }
 }

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -93,6 +93,10 @@ impl ContractMetadata {
             abi,
         }
     }
+
+    pub fn remove_wasm(&mut self) {
+        self.source.wasm = None;
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -339,8 +339,15 @@ mod tests {
             cmd::new::execute("new_project", Some(path)).expect("new project creation failed");
             let manifest_path =
                 ManifestPath::new(&path.join("new_project").join("Cargo.toml")).unwrap();
-            super::execute(&manifest_path, None, true, false, false, UnstableFlags::default())
-                .expect("build failed");
+            super::execute(
+                &manifest_path,
+                None,
+                true,
+                false,
+                false,
+                UnstableFlags::default(),
+            )
+            .expect("build failed");
             Ok(())
         })
     }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -296,7 +296,7 @@ pub(crate) fn execute(
 ) -> Result<BuildResult> {
     let crate_metadata = CrateMetadata::collect(manifest_path)?;
     if build_artifact == BuildArtifacts::CodeOnly {
-        let dest_wasm = execute_with_metadata(
+        let dest_wasm = execute_with_crate_metadata(
             &crate_metadata,
             verbosity,
             optimize_contract,
@@ -321,14 +321,14 @@ pub(crate) fn execute(
     Ok(res)
 }
 
-/// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.
+/// Executes build of the smart-contract which produces a Wasm binary that is ready for deploying.
 ///
 /// It does so by invoking `cargo build` and then post processing the final binary.
 ///
 /// # Note
 ///
 /// Uses the supplied `CrateMetadata`. If an instance is not available use [`execute_build`]
-pub(crate) fn execute_with_metadata(
+pub(crate) fn execute_with_crate_metadata(
     crate_metadata: &CrateMetadata,
     verbosity: Option<Verbosity>,
     optimize_contract: bool,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -302,7 +302,8 @@ mod tests {
             cmd::new::execute("new_project", Some(path)).expect("new project creation failed");
             let manifest_path =
                 ManifestPath::new(&path.join("new_project").join("Cargo.toml")).unwrap();
-            super::execute(&manifest_path, None, UnstableFlags::default()).expect("build failed");
+            super::execute(&manifest_path, None, UnstableFlags::default(), true)
+                .expect("build failed");
             Ok(())
         })
     }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -243,7 +243,10 @@ pub(crate) fn execute(
     unstable_options: UnstableFlags,
     optimize_contract: bool,
 ) -> Result<PathBuf> {
-    let crate_metadata = CrateMetadata::collect(manifest_path)?;
+    let mut crate_metadata = CrateMetadata::collect(manifest_path)?;
+    if !optimize_contract {
+        crate_metadata.dest_wasm.set_extension("wasm.unoptimized");
+    }
     execute_with_metadata(
         &crate_metadata,
         verbosity,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -266,7 +266,7 @@ pub(crate) fn execute(
             total_steps,
         )?;
         let res = BuildResult {
-            dest_wasm: dest_wasm,
+            dest_wasm,
             dest_metadata: None,
             dest_bundle: None,
         };

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -278,7 +278,6 @@ pub(crate) fn execute(
         &manifest_path,
         verbosity,
         !skip_bundle,
-        optimize_contract,
         unstable_options,
         total_steps,
     )?;

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -339,7 +339,7 @@ mod tests {
             cmd::new::execute("new_project", Some(path)).expect("new project creation failed");
             let manifest_path =
                 ManifestPath::new(&path.join("new_project").join("Cargo.toml")).unwrap();
-            super::execute(&manifest_path, None, UnstableFlags::default(), true, true)
+            super::execute(&manifest_path, None, true, false, false, UnstableFlags::default())
                 .expect("build failed");
             Ok(())
         })

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -257,11 +257,13 @@ pub(crate) fn execute(
 ) -> Result<BuildResult> {
     let crate_metadata = CrateMetadata::collect(manifest_path)?;
     if skip_metadata {
+        let total_steps = 3;
         let dest_wasm = execute_with_metadata(
             &crate_metadata,
             verbosity,
             optimize_contract,
             unstable_options,
+            total_steps,
         )?;
         let res = BuildResult {
             dest_wasm: dest_wasm,
@@ -271,12 +273,14 @@ pub(crate) fn execute(
         return Ok(res);
     }
 
+    let total_steps = if skip_bundle { 4 } else { 5 };
     let metadata_result = super::metadata::execute(
         &manifest_path,
         verbosity,
         !skip_bundle,
         optimize_contract,
         unstable_options,
+        total_steps,
     )?;
     let res = BuildResult {
         dest_wasm: Some(metadata_result.wasm_file),
@@ -298,10 +302,11 @@ pub(crate) fn execute_with_metadata(
     verbosity: Option<Verbosity>,
     optimize_contract: bool,
     unstable_options: UnstableFlags,
+    total_steps: usize,
 ) -> Result<Option<PathBuf>> {
     println!(
         " {} {}",
-        "[1/3]".bold(),
+        format!("[1/{}]", total_steps).bold(),
         "Building cargo project".bright_green().bold()
     );
     build_cargo_project(&crate_metadata, verbosity, unstable_options)?;

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -81,6 +81,18 @@ pub struct BuildResult {
     pub dest_wasm: Option<PathBuf>,
     /// Path to the bundled file.
     pub dest_bundle: Option<PathBuf>,
+    /// Path to the directory where output files are written to.
+    pub target_directory: PathBuf,
+}
+
+impl BuildResult {
+    /// Returns the base name of the path.
+    pub fn display(path: &PathBuf) -> &str {
+        path.file_name()
+            .expect("file name must exist")
+            .to_str()
+            .expect("must be valid utf-8")
+    }
 }
 
 /// Builds the project in the specified directory, defaults to the current directory.
@@ -307,6 +319,7 @@ pub(crate) fn execute(
             dest_wasm,
             dest_metadata: None,
             dest_bundle: None,
+            target_directory: crate_metadata.cargo_meta.target_directory,
         };
         return Ok(res);
     }
@@ -317,6 +330,7 @@ pub(crate) fn execute(
         dest_wasm: Some(metadata_result.wasm_file),
         dest_metadata: Some(metadata_result.metadata_file),
         dest_bundle: metadata_result.bundle_file,
+        target_directory: crate_metadata.cargo_meta.target_directory.clone(),
     };
     Ok(res)
 }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -242,11 +242,8 @@ pub(crate) fn execute(
     verbosity: Option<Verbosity>,
     unstable_options: UnstableFlags,
     optimize_contract: bool,
-) -> Result<PathBuf> {
-    let mut crate_metadata = CrateMetadata::collect(manifest_path)?;
-    if !optimize_contract {
-        crate_metadata.dest_wasm.set_extension("wasm.unoptimized");
-    }
+) -> Result<Option<PathBuf>> {
+    let crate_metadata = CrateMetadata::collect(manifest_path)?;
     execute_with_metadata(
         &crate_metadata,
         verbosity,
@@ -267,7 +264,7 @@ pub(crate) fn execute_with_metadata(
     verbosity: Option<Verbosity>,
     unstable_options: UnstableFlags,
     optimize_contract: bool,
-) -> Result<PathBuf> {
+) -> Result<Option<PathBuf>> {
     println!(
         " {} {}",
         "[1/3]".bold(),
@@ -280,15 +277,16 @@ pub(crate) fn execute_with_metadata(
         "Post processing wasm file".bright_green().bold()
     );
     post_process_wasm(&crate_metadata)?;
-    if optimize_contract {
-        println!(
-            " {} {}",
-            "[3/3]".bold(),
-            "Optimizing wasm file".bright_green().bold()
-        );
-        optimize_wasm(&crate_metadata)?;
+    if !optimize_contract {
+        return Ok(None);
     }
-    Ok(crate_metadata.dest_wasm.clone())
+    println!(
+        " {} {}",
+        "[3/3]".bold(),
+        "Optimizing wasm file".bright_green().bold()
+    );
+    optimize_wasm(&crate_metadata)?;
+    Ok(Some(crate_metadata.dest_wasm.clone()))
 }
 
 #[cfg(feature = "test-ci-only")]

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -312,7 +312,7 @@ pub(crate) fn execute_with_metadata(
     build_cargo_project(&crate_metadata, verbosity, unstable_options)?;
     println!(
         " {} {}",
-        "[2/3]".bold(),
+        format!("[2/{}]", total_steps).bold(),
         "Post processing wasm file".bright_green().bold()
     );
     post_process_wasm(&crate_metadata)?;
@@ -321,7 +321,7 @@ pub(crate) fn execute_with_metadata(
     }
     println!(
         " {} {}",
-        "[3/3]".bold(),
+        format!("[3/{}]", total_steps).bold(),
         "Optimizing wasm file".bright_green().bold()
     );
     optimize_wasm(&crate_metadata)?;

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -241,9 +241,15 @@ pub(crate) fn execute(
     manifest_path: &ManifestPath,
     verbosity: Option<Verbosity>,
     unstable_options: UnstableFlags,
+    optimize_contract: bool,
 ) -> Result<PathBuf> {
     let crate_metadata = CrateMetadata::collect(manifest_path)?;
-    execute_with_metadata(&crate_metadata, verbosity, unstable_options)
+    execute_with_metadata(
+        &crate_metadata,
+        verbosity,
+        unstable_options,
+        optimize_contract,
+    )
 }
 
 /// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.
@@ -257,6 +263,7 @@ pub(crate) fn execute_with_metadata(
     crate_metadata: &CrateMetadata,
     verbosity: Option<Verbosity>,
     unstable_options: UnstableFlags,
+    optimize_contract: bool,
 ) -> Result<PathBuf> {
     println!(
         " {} {}",
@@ -270,12 +277,14 @@ pub(crate) fn execute_with_metadata(
         "Post processing wasm file".bright_green().bold()
     );
     post_process_wasm(&crate_metadata)?;
-    println!(
-        " {} {}",
-        "[3/3]".bold(),
-        "Optimizing wasm file".bright_green().bold()
-    );
-    optimize_wasm(&crate_metadata)?;
+    if optimize_contract {
+        println!(
+            " {} {}",
+            "[3/3]".bold(),
+            "Optimizing wasm file".bright_green().bold()
+        );
+        optimize_wasm(&crate_metadata)?;
+    }
     Ok(crate_metadata.dest_wasm.clone())
 }
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -219,12 +219,6 @@ fn optimize_wasm(crate_metadata: &CrateMetadata) -> Result<OptimizationResult> {
 
     let original_size = metadata(&crate_metadata.dest_wasm)?.len() as f64 / 1000.0;
     let optimized_size = metadata(&optimized)?.len() as f64 / 1000.0;
-    /*
-    println!(
-        " Original wasm size: {:.1}K, Optimized: {:.1}K",
-        original_size, optimized_size
-    );
-    */
 
     // overwrite existing destination wasm file with the optimised version
     std::fs::rename(&optimized, &crate_metadata.dest_wasm)?;

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -223,10 +223,10 @@ pub(crate) fn execute(
 #[cfg(feature = "test-ci-only")]
 #[cfg(test)]
 mod tests {
+    use crate::cmd::metadata::blake2_hash;
     use crate::{
         cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, ManifestPath, UnstableFlags,
     };
-    use blake2::digest::{Update as _, VariableOutput as _};
     use contract_metadata::*;
     use serde_json::{Map, Value};
     use std::{fmt::Write, fs};
@@ -320,11 +320,12 @@ mod tests {
 
             let crate_metadata = CrateMetadata::collect(&test_manifest.manifest_path)?;
             let metadata_file = cmd::metadata::execute(
-                test_manifest.manifest_path,
+                &test_manifest.manifest_path,
                 None,
                 true,
                 UnstableFlags::default(),
-            )?;
+            )?
+            .metadata_file;
             let metadata_json: Map<String, Value> =
                 serde_json::from_slice(&fs::read(&metadata_file)?)?;
 
@@ -387,7 +388,7 @@ mod tests {
                 ),
             );
 
-            assert_eq!(expected_hash, hash.as_str().unwrap());
+            assert_eq!(build_byte_str(&expected_hash[..]), hash.as_str().unwrap());
             assert_eq!(expected_wasm, wasm.as_str().unwrap());
             assert_eq!(expected_language, language.as_str().unwrap());
             assert_eq!(expected_compiler, compiler.as_str().unwrap());

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -357,7 +357,9 @@ mod tests {
                 &test_manifest.manifest_path,
                 None,
                 false,
+                false,
                 UnstableFlags::default(),
+                3,
             )?
             .bundle_file
             .expect("bundle file not found");

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -46,7 +46,12 @@ impl GenerateMetadataCommand {
         println!("  Generating metadata");
 
         let cargo_meta = &self.crate_metadata.cargo_meta;
-        let out_path = cargo_meta.target_directory.join(METADATA_FILE);
+        let out_path = if self.include_wasm {
+            let fname = format!("{}.pack", self.crate_metadata.package_name);
+            cargo_meta.target_directory.join(fname)
+        } else {
+            cargo_meta.target_directory.join(METADATA_FILE)
+        };
         let target_dir = cargo_meta.target_directory.clone();
 
         // build the extended contract project metadata

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -48,7 +48,6 @@ struct GenerateMetadataCommand {
     crate_metadata: CrateMetadata,
     verbosity: Option<Verbosity>,
     create_bundle: bool,
-    optimize_contract: bool,
     unstable_options: UnstableFlags,
     total_steps: usize,
 }
@@ -210,7 +209,7 @@ impl GenerateMetadataCommand {
         let dest_wasm = super::build::execute_with_metadata(
             &self.crate_metadata,
             self.verbosity,
-            self.optimize_contract,
+            true, // for the hash we always use the optimized version of the contract
             self.unstable_options.clone(),
             self.total_steps,
         )?
@@ -237,7 +236,6 @@ pub(crate) fn execute(
     manifest_path: &ManifestPath,
     verbosity: Option<Verbosity>,
     create_bundle: bool,
-    optimize_contract: bool,
     unstable_options: UnstableFlags,
     total_steps: usize,
 ) -> Result<GenerateMetadataResult> {
@@ -246,7 +244,6 @@ pub(crate) fn execute(
         crate_metadata,
         verbosity,
         create_bundle,
-        optimize_contract,
         unstable_options,
         total_steps,
     }

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -92,7 +92,7 @@ impl GenerateMetadataCommand {
             let mut metadata =
                 ContractMetadata::new(source_meta, contract_meta, user_meta, ink_meta);
             let contents = serde_json::to_string_pretty(&metadata)?;
-            fs::write(&out_path_bundle, contents)?;
+            fs::write(&out_path_wasm, contents)?;
 
             if self.create_bundle {
                 println!(
@@ -102,7 +102,7 @@ impl GenerateMetadataCommand {
                 );
                 metadata.remove_source_wasm_attribute();
                 let contents = serde_json::to_string_pretty(&metadata)?;
-                fs::write(&out_path_wasm, contents)?;
+                fs::write(&out_path_bundle, contents)?;
             }
             Ok(())
         };

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -103,19 +103,15 @@ impl GenerateMetadataCommand {
                 current_progress += 1;
             }
 
-            if self.build_artifact == GenerateArtifacts::MetadataOnly {
-                println!(
-                    " {} {}",
-                    format!("[{}/{}]", 1, self.build_artifact.steps()).bold(),
-                    "Generating metadata".bright_green().bold()
-                );
-            } else {
-                println!(
-                    " {} {}",
-                    format!("[{}/{}]", current_progress, self.build_artifact.steps()).bold(),
-                    "Generating metadata".bright_green().bold()
-                );
-            }
+            let curr_step = match self.build_artifact {
+                GenerateArtifacts::MetadataOnly => 1,
+                _ => current_progress,
+            };
+            println!(
+                " {} {}",
+                format!("[{}/{}]", curr_step, self.build_artifact.steps()).bold(),
+                "Generating metadata".bright_green().bold()
+            );
             metadata.remove_source_wasm_attribute();
             let contents = serde_json::to_string_pretty(&metadata)?;
             fs::write(&out_path_wasm, contents)?;

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -115,14 +115,13 @@ impl GenerateMetadataCommand {
         let source = {
             let lang = SourceLanguage::new(Language::Ink, ink_version.clone());
             let compiler = SourceCompiler::new(Compiler::RustC, rust_version);
-            let maybe_wasm = match self.include_wasm {
-                true => {
-                    let wasm = fs::read(&self.crate_metadata.dest_wasm)?;
-                    // The Wasm which we read must have the same hash as `source.hash`
-                    debug_assert_eq!(blake2_hash(wasm.clone().as_slice()), hash);
-                    Some(SourceWasm::new(wasm))
-                }
-                false => None,
+            let maybe_wasm = if self.include_wasm {
+                let wasm = fs::read(&self.crate_metadata.dest_wasm)?;
+                // The Wasm which we read must have the same hash as `source.hash`
+                debug_assert_eq!(blake2_hash(wasm.clone().as_slice()), hash);
+                Some(SourceWasm::new(wasm))
+            } else {
+                None
             };
             Source::new(maybe_wasm, hash, lang, compiler)
         };

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -186,7 +186,8 @@ impl GenerateMetadataCommand {
             self.verbosity,
             self.unstable_options.clone(),
             true,
-        )?;
+        )?
+        .expect("dest_wasm must exist");
 
         let wasm = fs::read(&self.crate_metadata.dest_wasm)?;
         Ok((dest_wasm, blake2_hash(wasm.as_slice())))

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -354,7 +354,6 @@ mod tests {
                 &test_manifest.manifest_path,
                 None,
                 false,
-                false,
                 UnstableFlags::default(),
                 3,
             )?

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -354,7 +354,7 @@ mod tests {
             let bundle_file = cmd::metadata::execute(
                 &test_manifest.manifest_path,
                 None,
-                BuildArtifacts::MetadataOnly,
+                BuildArtifacts::All,
                 UnstableFlags::default(),
             )?
             .bundle_file

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -55,7 +55,7 @@ impl GenerateMetadataCommand {
 
         let cargo_meta = &self.crate_metadata.cargo_meta;
         let out_path = if self.include_wasm {
-            let fname = format!("{}.pack", self.crate_metadata.package_name);
+            let fname = format!("{}.contract", self.crate_metadata.package_name);
             cargo_meta.target_directory.join(fname)
         } else {
             cargo_meta.target_directory.join(METADATA_FILE)

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -32,6 +32,14 @@ use url::Url;
 
 const METADATA_FILE: &str = "metadata.json";
 
+/// Result of the metadata generation process.
+pub struct GenerateMetadataResult {
+    /// Path to the resulting metadata file.
+    pub metadata_file: PathBuf,
+    /// Path to the resulting Wasm file.
+    pub wasm_file: PathBuf,
+}
+
 /// Executes the metadata generation process
 struct GenerateMetadataCommand {
     crate_metadata: CrateMetadata,
@@ -41,7 +49,7 @@ struct GenerateMetadataCommand {
 }
 
 impl GenerateMetadataCommand {
-    pub fn exec(&self) -> Result<(PathBuf, PathBuf)> {
+    pub fn exec(&self) -> Result<GenerateMetadataResult> {
         util::assert_channel()?;
         println!("  Generating metadata");
 
@@ -94,7 +102,10 @@ impl GenerateMetadataCommand {
                 .using_temp(generate_metadata)?;
         }
 
-        Ok((out_path, dest_wasm))
+        Ok(GenerateMetadataResult {
+            metadata_file: out_path,
+            wasm_file: dest_wasm,
+        })
     }
 
     /// Generate the extended contract project metadata
@@ -198,7 +209,7 @@ pub(crate) fn execute(
     verbosity: Option<Verbosity>,
     include_wasm: bool,
     unstable_options: UnstableFlags,
-) -> Result<(PathBuf, PathBuf)> {
+) -> Result<GenerateMetadataResult> {
     let crate_metadata = CrateMetadata::collect(manifest_path)?;
     GenerateMetadataCommand {
         crate_metadata,

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -168,7 +168,6 @@ impl GenerateMetadataCommand {
             .transpose()?;
         let homepage = self.crate_metadata.homepage.clone();
         let license = contract_package.license.clone();
-        //{
         let (dest_wasm, hash, optimization_result) =
             if self.build_artifact != GenerateArtifacts::MetadataOnly {
                 let (wasm, hash, optimization) = self.wasm_hash()?;
@@ -189,8 +188,6 @@ impl GenerateMetadataCommand {
             };
             Source::new(maybe_wasm, hash, lang, compiler)
         };
-        //(dest_wasm, hash, optimization_result, source)
-        //}
 
         // Required contract fields
         let mut builder = Contract::builder();

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -309,8 +309,7 @@ mod tests {
                 None,
                 true,
                 UnstableFlags::default(),
-            )
-            .expect("generate metadata failed");
+            )?;
             let metadata_json: Map<String, Value> =
                 serde_json::from_slice(&fs::read(&metadata_file)?)?;
 

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -185,6 +185,7 @@ impl GenerateMetadataCommand {
             &self.crate_metadata,
             self.verbosity,
             self.unstable_options.clone(),
+            true,
         )?;
 
         let wasm = fs::read(&self.crate_metadata.dest_wasm)?;

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -189,12 +189,12 @@ fn blake2_hash(code: &[u8]) -> [u8; 32] {
 ///
 /// It does so by generating and invoking a temporary workspace member.
 pub(crate) fn execute(
-    manifest_path: ManifestPath,
+    manifest_path: &ManifestPath,
     verbosity: Option<Verbosity>,
     include_wasm: bool,
     unstable_options: UnstableFlags,
 ) -> Result<PathBuf> {
-    let crate_metadata = CrateMetadata::collect(&manifest_path)?;
+    let crate_metadata = CrateMetadata::collect(manifest_path)?;
     GenerateMetadataCommand {
         crate_metadata,
         verbosity,

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -208,7 +208,7 @@ impl GenerateMetadataCommand {
 
     /// Compile the contract and then hash the resulting wasm
     fn wasm_hash(&self) -> Result<(PathBuf, [u8; 32])> {
-        let dest_wasm = super::build::execute_with_metadata(
+        let dest_wasm = super::build::execute_with_crate_metadata(
             &self.crate_metadata,
             self.verbosity,
             true, // for the hash we always use the optimized version of the contract

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -353,11 +353,7 @@ mod tests {
 
             // calculate wasm hash
             let fs_wasm = fs::read(&crate_metadata.dest_wasm)?;
-            let mut output = [0u8; 32];
-            let mut blake2 = blake2::VarBlake2b::new_keyed(&[], 32);
-            blake2.update(fs_wasm.clone());
-            blake2.finalize_variable(|result| output.copy_from_slice(result));
-            let expected_hash = build_byte_str(&output);
+            let expected_hash = blake2_hash(&fs_wasm[..]);
             let expected_wasm = build_byte_str(&fs_wasm);
 
             let expected_language =

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -160,7 +160,7 @@ impl GenerateMetadataCommand {
             let maybe_wasm = if self.create_bundle {
                 let wasm = fs::read(&self.crate_metadata.dest_wasm)?;
                 // The Wasm which we read must have the same hash as `source.hash`
-                debug_assert_eq!(blake2_hash(wasm.clone().as_slice()), hash);
+                debug_assert_eq!(blake2_hash(wasm.as_slice()), hash);
                 Some(SourceWasm::new(wasm))
             } else {
                 None

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -288,7 +288,7 @@ pub(crate) fn execute(
 mod tests {
     use crate::cmd::metadata::blake2_hash;
     use crate::{
-        cmd, cmd::BuildArtifacts, crate_metadata::CrateMetadata, util::tests::with_tmp_dir,
+        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, GenerateArtifacts,
         ManifestPath, UnstableFlags,
     };
     use contract_metadata::*;
@@ -383,20 +383,20 @@ mod tests {
             test_manifest.write()?;
 
             let crate_metadata = CrateMetadata::collect(&test_manifest.manifest_path)?;
-            let bundle_file = cmd::metadata::execute(
+            let dest_bundle = cmd::metadata::execute(
                 &test_manifest.manifest_path,
                 None,
-                BuildArtifacts::All,
+                GenerateArtifacts::All,
                 UnstableFlags::default(),
             )?
-            .bundle_file
+            .dest_bundle
             .expect("bundle file not found");
             let metadata_json: Map<String, Value> =
-                serde_json::from_slice(&fs::read(&bundle_file)?)?;
+                serde_json::from_slice(&fs::read(&dest_bundle)?)?;
 
             assert!(
-                bundle_file.exists(),
-                format!("Missing metadata file '{}'", bundle_file.display())
+                dest_bundle.exists(),
+                format!("Missing metadata file '{}'", dest_bundle.display())
             );
 
             let source = metadata_json.get("source").expect("source not found");

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -353,7 +353,7 @@ mod tests {
             let bundle_file = cmd::metadata::execute(
                 &test_manifest.manifest_path,
                 None,
-                false,
+                true,
                 UnstableFlags::default(),
                 3,
             )?

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -453,7 +453,7 @@ mod tests {
                 ),
             );
 
-            assert_eq!(build_byte_str(&expected_hash[..]), hash.as_str().unwrap());
+            assert_eq!(build_byte_str(&expected_hash.0[..]), hash.as_str().unwrap());
             assert_eq!(expected_wasm, wasm.as_str().unwrap());
             assert_eq!(expected_language, language.as_str().unwrap());
             assert_eq!(expected_compiler, compiler.as_str().unwrap());

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,10 +283,10 @@ fn exec(cmd: Command) -> Result<String> {
 
             let mut out = format!(
                 "\nOriginal wasm size: {:.1}K, Optimized: {:.1}K\n\n\
-                Your contract artifacts are ready. You can find them in:\n{}\n",
+                Your contract artifacts are ready. You can find them in:\n{}\n\n",
                 cmd::build::BuildResult::display_optimization(&build_result).0,
                 cmd::build::BuildResult::display_optimization(&build_result).1,
-                build_result.target_directory.display().to_string().bold()
+                build_result.target_directory.display().to_string()
             );
             if let Some(dest_bundle) = build_result.dest_bundle {
                 let bundle = format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,9 +292,9 @@ fn exec(cmd: Command) -> Result<String> {
                 unstable_options.try_into()?,
             )?;
             Ok(format!(
-                "\nYour contract is ready. You can find it here:\n{}
-                \nYour metadata file is ready. You can find it here:\n{}
-                \nYour packed contract is ready. You can find it here:\n{}",
+                "\nYour contract's code is ready. You can find it here:\n{}
+                \nYour contract's metadata is ready. You can find it here:\n{}
+                \nYour contract bundle (code + metadata) is ready. You can find it here:\n{}",
                 pack_result.wasm_file.display().to_string().bold(),
                 metadata_result.metadata_file.display().to_string().bold(),
                 pack_result.metadata_file.display().to_string().bold()
@@ -313,7 +313,7 @@ fn exec(cmd: Command) -> Result<String> {
                 unstable_options.try_into()?,
             )?;
             Ok(format!(
-                "\nYour metadata file is ready.\nYou can find it here:\n{}",
+                "\nYour metadata is ready.\nYou can find it here:\n{}",
                 res.metadata_file.display().to_string().bold(),
             ))
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,6 +276,7 @@ fn exec(cmd: Command) -> Result<String> {
                     &manifest_path,
                     verbosity.try_into()?,
                     unstable_options.try_into()?,
+                    true,
                 )?;
                 return Ok(format!(
                     "\nYour contract's code is ready. You can find it here:\n{}",
@@ -322,6 +323,7 @@ fn exec(cmd: Command) -> Result<String> {
                 &manifest_path,
                 verbosity.try_into()?,
                 unstable_options.try_into()?,
+                false,
             )?;
             Ok(format!(
                 "\nYour contract's code was built successfully. You can find it here:\n{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,16 +162,16 @@ enum Command {
         #[structopt(short, long, parse(from_os_str))]
         target_dir: Option<PathBuf>,
     },
-    /// Compiles the contract, generates metadata, bundles both together in a '.contract' file
+    /// Compiles the contract, generates metadata, bundles both together in a `<name>.contract` file
     #[structopt(name = "build")]
     Build {
         /// Path to the Cargo.toml of the contract to build
         #[structopt(long, parse(from_os_str))]
         manifest_path: Option<PathBuf>,
-        /// Only the Wasm and the metadata are generated, no bundled .contract file is created
+        /// Only the Wasm and the metadata are generated, no bundled `<name>.contract` file is created
         #[structopt(long = "skip-bundle", conflicts_with = "skip-metadata")]
         skip_bundle: bool,
-        /// Only the Wasm is created, generation of metadata and a bundled .contract file is skipped
+        /// Only the Wasm is created, generation of metadata and a bundled `<name>.contract` file is skipped
         #[structopt(long = "skip-metadata", conflicts_with = "skip-bundle")]
         skip_metadata: bool,
         #[structopt(flatten)]
@@ -179,7 +179,7 @@ enum Command {
         #[structopt(flatten)]
         unstable_options: UnstableOptions,
     },
-    /// Command has been deprecated, use 'cargo contract build' instead
+    /// Command has been deprecated, use `cargo contract build` instead
     #[structopt(name = "generate-metadata")]
     GenerateMetadata {
         /// Path to the Cargo.toml of the contract to build
@@ -190,7 +190,7 @@ enum Command {
         #[structopt(flatten)]
         unstable_options: UnstableOptions,
     },
-    /// Check that the Wasm builds; does not optimize, generate metadata, or bundle
+    /// Check that the code builds as Wasm; does not output any build artifact to the top level `target/` directory
     #[structopt(name = "check")]
     Check {
         /// Path to the Cargo.toml of the contract to build
@@ -210,7 +210,7 @@ enum Command {
     Deploy {
         #[structopt(flatten)]
         extrinsic_opts: ExtrinsicOpts,
-        /// Path to wasm contract code, defaults to ./target/<name>-pruned.wasm
+        /// Path to wasm contract code, defaults to `./target/<name>-pruned.wasm`
         #[structopt(parse(from_os_str))]
         wasm_path: Option<PathBuf>,
     },
@@ -334,7 +334,7 @@ fn exec(cmd: Command) -> Result<String> {
             verbosity: _,
             unstable_options: _,
         } => Err(anyhow::anyhow!(format!(
-            "Command deprecated, use 'cargo contract build' instead"
+            "Command deprecated, use `cargo contract build` instead"
         ))),
         Command::Test {} => Err(anyhow::anyhow!("Command unimplemented")),
         #[cfg(feature = "extrinsics")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,8 +274,8 @@ fn exec(cmd: Command) -> Result<String> {
                 unstable_options.try_into()?,
             )?;
             Ok(format!(
-                "Your metadata file is ready.\nYou can find it here:\n{}",
-                metadata_file.display()
+                "\nYour metadata file is ready.\nYou can find it here:\n{}",
+                metadata_file.display().to_string().bold()
             ))
         }
         Command::Test {} => Err(anyhow::anyhow!("Command unimplemented")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,16 +319,13 @@ fn exec(cmd: Command) -> Result<String> {
             unstable_options,
         } => {
             let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
-            let dest_wasm = cmd::build::execute(
+            let _dest_unoptimized_wasm = cmd::build::execute(
                 &manifest_path,
                 verbosity.try_into()?,
                 unstable_options.try_into()?,
                 false,
             )?;
-            Ok(format!(
-                "\nYour contract's code was built successfully. You can find it here:\n{}",
-                dest_wasm.display().to_string().bold()
-            ))
+            Ok(format!("\nYour contract's code was built successfully."))
         }
         Command::GenerateMetadata {
             manifest_path: _,

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,15 +181,7 @@ enum Command {
     },
     /// Command has been deprecated, use `cargo contract build` instead
     #[structopt(name = "generate-metadata")]
-    GenerateMetadata {
-        /// Path to the Cargo.toml of the contract to build
-        #[structopt(long, parse(from_os_str))]
-        manifest_path: Option<PathBuf>,
-        #[structopt(flatten)]
-        verbosity: VerbosityFlags,
-        #[structopt(flatten)]
-        unstable_options: UnstableOptions,
-    },
+    GenerateMetadata {},
     /// Check that the code builds as Wasm; does not output any build artifact to the top level `target/` directory
     #[structopt(name = "check")]
     Check {
@@ -329,11 +321,7 @@ fn exec(cmd: Command) -> Result<String> {
             assert!(maybe_dest_wasm.is_none(), "no dest_wasm should exist");
             Ok(format!("\nYour contract's code was built successfully."))
         }
-        Command::GenerateMetadata {
-            manifest_path: _,
-            verbosity: _,
-            unstable_options: _,
-        } => Err(anyhow::anyhow!(format!(
+        Command::GenerateMetadata {} => Err(anyhow::anyhow!(format!(
             "Command deprecated, use `cargo contract build` instead"
         ))),
         Command::Test {} => Err(anyhow::anyhow!("Command unimplemented")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,14 +279,22 @@ fn exec(cmd: Command) -> Result<String> {
             unstable_options,
         } => {
             let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
+            let metadata_file = cmd::metadata::execute(
+                &manifest_path,
+                verbosity.try_into()?,
+                false,
+                unstable_options.try_into()?,
+            )?;
             let pack_file = cmd::metadata::execute(
-                manifest_path,
+                &manifest_path,
                 verbosity.try_into()?,
                 true,
                 unstable_options.try_into()?,
             )?;
             Ok(format!(
-                "\nYour packed contract is ready. You can find it here:\n{}",
+                "\nYour metadata file is ready.\nYou can find it here:\n{}
+                \nYour packed contract is ready. You can find it here:\n{}",
+                metadata_file.display().to_string().bold(),
                 pack_file.display().to_string().bold()
             ))
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,21 +279,23 @@ fn exec(cmd: Command) -> Result<String> {
             unstable_options,
         } => {
             let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
-            let metadata_file = cmd::metadata::execute(
+            let (metadata_file, _dest_wasm) = cmd::metadata::execute(
                 &manifest_path,
                 verbosity.try_into()?,
                 false,
                 unstable_options.try_into()?,
             )?;
-            let pack_file = cmd::metadata::execute(
+            let (pack_file, dest_wasm) = cmd::metadata::execute(
                 &manifest_path,
                 verbosity.try_into()?,
                 true,
                 unstable_options.try_into()?,
             )?;
             Ok(format!(
-                "\nYour metadata file is ready.\nYou can find it here:\n{}
+                "\nYour contract is ready. You can find it here:\n{}
+                \nYour metadata file is ready. You can find it here:\n{}
                 \nYour packed contract is ready. You can find it here:\n{}",
+                dest_wasm.display().to_string().bold(),
                 metadata_file.display().to_string().bold(),
                 pack_file.display().to_string().bold()
             ))
@@ -304,7 +306,7 @@ fn exec(cmd: Command) -> Result<String> {
             unstable_options,
         } => {
             let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
-            let metadata_file = cmd::metadata::execute(
+            let (metadata_file, _dest_wasm) = cmd::metadata::execute(
                 &manifest_path,
                 verbosity.try_into()?,
                 false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,17 +162,17 @@ enum Command {
         #[structopt(short, long, parse(from_os_str))]
         target_dir: Option<PathBuf>,
     },
-    /// Compiles the contract, generates metadata, packs both together in one <package-name>.contract file
+    /// Compiles the contract, generates metadata, bundles both together in one <package-name>.contract file
     #[structopt(name = "build")]
     Build {
         /// Path to the Cargo.toml of the contract to build
         #[structopt(long, parse(from_os_str))]
         manifest_path: Option<PathBuf>,
-        /// Only the Wasm and the metadata are generated, no packed .contract file is created
-        #[structopt(long = "skip-packing", conflicts_with = "skip-metadata")]
-        skip_packing: bool,
+        /// Only the Wasm and the metadata are generated, no bundled .contract file is created
+        #[structopt(long = "skip-bundle", conflicts_with = "skip-metadata")]
+        skip_bundle: bool,
         /// Only the Wasm is created, generation of metadata and a packed .contract file is skipped
-        #[structopt(long = "skip-metadata", conflicts_with = "skip-packing")]
+        #[structopt(long = "skip-metadata", conflicts_with = "skip-bundle")]
         skip_metadata: bool,
         #[structopt(flatten)]
         verbosity: VerbosityFlags,
@@ -244,7 +244,7 @@ fn exec(cmd: Command) -> Result<String> {
         Command::Build {
             manifest_path,
             verbosity,
-            skip_packing,
+            skip_bundle,
             skip_metadata,
             unstable_options,
         } => {
@@ -256,7 +256,7 @@ fn exec(cmd: Command) -> Result<String> {
                     unstable_options.try_into()?,
                 )?;
                 return Ok(format!(
-                    "\nYour contract is ready. You can find it here:\n{}",
+                    "\nYour contract's code is ready. You can find it here:\n{}",
                     dest_wasm.display().to_string().bold()
                 ));
             }
@@ -267,7 +267,7 @@ fn exec(cmd: Command) -> Result<String> {
                 false,
                 unstable_options.try_into()?,
             )?;
-            if *(skip_packing) {
+            if *(skip_bundle) {
                 return Ok(format!(
                     "\nYour contract's code is ready. You can find it here:\n{}
                     \nYour contract's metadata is ready. You can find it here:\n{}",
@@ -275,7 +275,7 @@ fn exec(cmd: Command) -> Result<String> {
                     metadata_result.metadata_file.display().to_string().bold(),
                 ));
             }
-            let pack_result = cmd::metadata::execute(
+            let bundle_result = cmd::metadata::execute(
                 &manifest_path,
                 verbosity.try_into()?,
                 true,
@@ -285,9 +285,9 @@ fn exec(cmd: Command) -> Result<String> {
                 "\nYour contract's code is ready. You can find it here:\n{}
                 \nYour contract's metadata is ready. You can find it here:\n{}
                 \nYour contract bundle (code + metadata) is ready. You can find it here:\n{}",
-                pack_result.wasm_file.display().to_string().bold(),
+                bundle_result.wasm_file.display().to_string().bold(),
                 metadata_result.metadata_file.display().to_string().bold(),
-                pack_result.metadata_file.display().to_string().bold()
+                bundle_result.metadata_file.display().to_string().bold()
             ))
         }
         Command::Test {} => Err(anyhow::anyhow!("Command unimplemented")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,16 +192,16 @@ impl GenerateArtifacts {
         }
 
         let optimization = GenerationResult::display_optimization(result);
-        let mut out = format!(
-            "\nOriginal wasm size: {}, Optimized: {}\n\nYour contract artifacts are ready. You can find them in:\n{}\n\n",
+        let size_diff = format!(
+            "\nOriginal wasm size: {}, Optimized: {}\n\n",
             format!("{:.1}K", optimization.0).bold(),
             format!("{:.1}K", optimization.1).bold(),
-            result.target_directory.display().to_string().bold()
         );
 
         if self == &GenerateArtifacts::CodeOnly {
             let out = format!(
-                "\nYour contract's code is ready. You can find it here:\n{}",
+                "{}Your contract's code is ready. You can find it here:\n{}",
+                size_diff,
                 result
                     .dest_wasm
                     .as_ref()
@@ -213,6 +213,11 @@ impl GenerateArtifacts {
             return out;
         };
 
+        let mut out = format!(
+            "{}Your contract artifacts are ready. You can find them in:\n{}\n\n",
+            size_diff,
+            result.target_directory.display().to_string().bold(),
+        );
         if let Some(dest_bundle) = result.dest_bundle.as_ref() {
             let bundle = format!(
                 "  - {} (code + metadata)\n",

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,17 @@ enum Command {
         #[structopt(flatten)]
         unstable_options: UnstableOptions,
     },
+    /// Check that the Wasm builds; does not optimize, generate metadata, or bundle
+    #[structopt(name = "check")]
+    Check {
+        /// Path to the Cargo.toml of the contract to build
+        #[structopt(long, parse(from_os_str))]
+        manifest_path: Option<PathBuf>,
+        #[structopt(flatten)]
+        verbosity: VerbosityFlags,
+        #[structopt(flatten)]
+        unstable_options: UnstableOptions,
+    },
     /// Test the smart contract off-chain
     #[structopt(name = "test")]
     Test {},
@@ -299,6 +310,22 @@ fn exec(cmd: Command) -> Result<String> {
                 bundle_result.wasm_file.display().to_string().bold(),
                 metadata_result.metadata_file.display().to_string().bold(),
                 bundle_result.metadata_file.display().to_string().bold()
+            ))
+        }
+        Command::Check {
+            manifest_path,
+            verbosity,
+            unstable_options,
+        } => {
+            let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
+            let dest_wasm = cmd::build::execute(
+                &manifest_path,
+                verbosity.try_into()?,
+                unstable_options.try_into()?,
+            )?;
+            Ok(format!(
+                "\nYour contract's code was built successfully. You can find it here:\n{}",
+                dest_wasm.display().to_string().bold()
             ))
         }
         Command::GenerateMetadata {

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,7 +162,7 @@ enum Command {
         #[structopt(short, long, parse(from_os_str))]
         target_dir: Option<PathBuf>,
     },
-    /// Compiles the contract, generates metadata, bundles both together in one <package-name>.contract file
+    /// Compiles the contract, generates metadata, bundles both together in a '.contract' file
     #[structopt(name = "build")]
     Build {
         /// Path to the Cargo.toml of the contract to build

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,7 +311,7 @@ fn exec(cmd: Command) -> Result<String> {
                 unstable_options.try_into()?,
             )?;
             assert!(res.dest_wasm.is_none(), "no dest_wasm should exist");
-            Ok(format!("\nYour contract's code was built successfully."))
+            Ok("\nYour contract's code was built successfully.".to_string())
         }
         Command::GenerateMetadata {} => Err(anyhow::anyhow!(
             "Command deprecated, use `cargo contract build` instead"

--- a/src/main.rs
+++ b/src/main.rs
@@ -279,13 +279,13 @@ fn exec(cmd: Command) -> Result<String> {
             unstable_options,
         } => {
             let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
-            let (metadata_file, _dest_wasm) = cmd::metadata::execute(
+            let metadata_result = cmd::metadata::execute(
                 &manifest_path,
                 verbosity.try_into()?,
                 false,
                 unstable_options.try_into()?,
             )?;
-            let (pack_file, dest_wasm) = cmd::metadata::execute(
+            let pack_result = cmd::metadata::execute(
                 &manifest_path,
                 verbosity.try_into()?,
                 true,
@@ -295,9 +295,9 @@ fn exec(cmd: Command) -> Result<String> {
                 "\nYour contract is ready. You can find it here:\n{}
                 \nYour metadata file is ready. You can find it here:\n{}
                 \nYour packed contract is ready. You can find it here:\n{}",
-                dest_wasm.display().to_string().bold(),
-                metadata_file.display().to_string().bold(),
-                pack_file.display().to_string().bold()
+                pack_result.wasm_file.display().to_string().bold(),
+                metadata_result.metadata_file.display().to_string().bold(),
+                pack_result.metadata_file.display().to_string().bold()
             ))
         }
         Command::GenerateMetadata {
@@ -306,7 +306,7 @@ fn exec(cmd: Command) -> Result<String> {
             unstable_options,
         } => {
             let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
-            let (metadata_file, _dest_wasm) = cmd::metadata::execute(
+            let res = cmd::metadata::execute(
                 &manifest_path,
                 verbosity.try_into()?,
                 false,
@@ -314,7 +314,7 @@ fn exec(cmd: Command) -> Result<String> {
             )?;
             Ok(format!(
                 "\nYour metadata file is ready.\nYou can find it here:\n{}",
-                metadata_file.display().to_string().bold()
+                res.metadata_file.display().to_string().bold(),
             ))
         }
         Command::Test {} => Err(anyhow::anyhow!("Command unimplemented")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,8 +438,7 @@ fn exec(cmd: Command) -> Result<String> {
                 )?
             };
 
-            let out = build_artifact.display(&result);
-            return Ok(out);
+            build_artifact.display(&result)
         }
         Command::Check {
             manifest_path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ enum Command {
         /// Only the Wasm and the metadata are generated, no bundled .contract file is created
         #[structopt(long = "skip-bundle", conflicts_with = "skip-metadata")]
         skip_bundle: bool,
-        /// Only the Wasm is created, generation of metadata and a packed .contract file is skipped
+        /// Only the Wasm is created, generation of metadata and a bundled .contract file is skipped
         #[structopt(long = "skip-metadata", conflicts_with = "skip-bundle")]
         skip_metadata: bool,
         #[structopt(flatten)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,25 +281,28 @@ fn exec(cmd: Command) -> Result<String> {
                 unstable_options.try_into()?,
             )?;
 
-            let mut out = "".to_string();
+            let mut out = format!(
+                "\nYour contract artifacts are ready. You can find them in:\n{}\n",
+                build_result.target_directory.display().to_string().bold()
+            );
             if let Some(dest_bundle) = build_result.dest_bundle {
                 let bundle = format!(
-                    "\nYour contract bundle (code + metadata) is ready. You can find it here:\n{}",
-                    dest_bundle.display().to_string().bold()
+                    "  - {} (code + metadata)\n",
+                    cmd::build::BuildResult::display(&dest_bundle)
                 );
                 out.push_str(&bundle);
             }
             if let Some(dest_wasm) = build_result.dest_wasm {
                 let wasm = format!(
-                    "\nYour contract's code is ready. You can find it here:\n{}",
-                    dest_wasm.display().to_string().bold()
+                    "  - {} (the contract's code)\n",
+                    cmd::build::BuildResult::display(&dest_wasm)
                 );
                 out.push_str(&wasm);
             }
             if let Some(dest_metadata) = build_result.dest_metadata {
                 let metadata = format!(
-                    "\nYour contract's metadata is ready. You can find it here:\n{}",
-                    dest_metadata.display().to_string().bold()
+                    "  - {} (the contract's metadata)",
+                    cmd::build::BuildResult::display(&dest_metadata)
                 );
                 out.push_str(&metadata);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,7 +277,8 @@ fn exec(cmd: Command) -> Result<String> {
                     verbosity.try_into()?,
                     unstable_options.try_into()?,
                     true,
-                )?;
+                )?
+                .expect("dest_wasm must exist");
                 return Ok(format!(
                     "\nYour contract's code is ready. You can find it here:\n{}",
                     dest_wasm.display().to_string().bold()
@@ -319,12 +320,13 @@ fn exec(cmd: Command) -> Result<String> {
             unstable_options,
         } => {
             let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
-            let _dest_unoptimized_wasm = cmd::build::execute(
+            let maybe_dest_wasm = cmd::build::execute(
                 &manifest_path,
                 verbosity.try_into()?,
                 unstable_options.try_into()?,
                 false,
             )?;
+            assert!(maybe_dest_wasm.is_none(), "no dest_wasm should exist");
             Ok(format!("\nYour contract's code was built successfully."))
         }
         Command::GenerateMetadata {

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,13 +186,17 @@ impl GenerateArtifacts {
                     .as_ref()
                     .expect("metadata path must exist")
                     .display()
+                    .to_string()
+                    .bold()
             );
         }
 
         let optimization = GenerationResult::display_optimization(result);
-        let mut out = format!("\nOriginal wasm size: {:.1}K, Optimized: {:.1}K\n\nYour contract artifacts are ready. You can find them in:\n{}\n\n",
-                              optimization.0, optimization.1,
-                              result.target_directory.display().to_string()
+        let mut out = format!(
+            "\nOriginal wasm size: {}, Optimized: {}\n\nYour contract artifacts are ready. You can find them in:\n{}\n\n",
+            format!("{:.1}K", optimization.0).bold(),
+            format!("{:.1}K", optimization.1).bold(),
+            result.target_directory.display().to_string().bold()
         );
 
         if self == &GenerateArtifacts::CodeOnly {
@@ -203,6 +207,8 @@ impl GenerateArtifacts {
                     .as_ref()
                     .expect("wasm path must exist")
                     .display()
+                    .to_string()
+                    .bold()
             );
             return out;
         };
@@ -210,21 +216,21 @@ impl GenerateArtifacts {
         if let Some(dest_bundle) = result.dest_bundle.as_ref() {
             let bundle = format!(
                 "  - {} (code + metadata)\n",
-                GenerationResult::display(&dest_bundle)
+                GenerationResult::display(&dest_bundle).bold()
             );
             out.push_str(&bundle);
         }
         if let Some(dest_wasm) = result.dest_wasm.as_ref() {
             let wasm = format!(
                 "  - {} (the contract's code)\n",
-                GenerationResult::display(&dest_wasm)
+                GenerationResult::display(&dest_wasm).bold()
             );
             out.push_str(&wasm);
         }
         if let Some(dest_metadata) = result.dest_metadata.as_ref() {
             let metadata = format!(
                 "  - {} (the contract's metadata)",
-                GenerationResult::display(&dest_metadata)
+                GenerationResult::display(&dest_metadata).bold()
             );
             out.push_str(&metadata);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,7 @@ fn exec(cmd: Command) -> Result<String> {
         } => {
             let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
             let metadata_file = cmd::metadata::execute(
-                manifest_path,
+                &manifest_path,
                 verbosity.try_into()?,
                 false,
                 unstable_options.try_into()?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,7 +282,10 @@ fn exec(cmd: Command) -> Result<String> {
             )?;
 
             let mut out = format!(
-                "\nYour contract artifacts are ready. You can find them in:\n{}\n",
+                "\nOriginal wasm size: {:.1}K, Optimized: {:.1}K\n\n\
+                Your contract artifacts are ready. You can find them in:\n{}\n",
+                cmd::build::BuildResult::display_optimization(&build_result).0,
+                cmd::build::BuildResult::display_optimization(&build_result).1,
                 build_result.target_directory.display().to_string().bold()
             );
             if let Some(dest_bundle) = build_result.dest_bundle {

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,17 @@ enum Command {
         #[structopt(flatten)]
         unstable_options: UnstableOptions,
     },
+    /// Command has been deprecated, use 'cargo contract build' instead
+    #[structopt(name = "generate-metadata")]
+    GenerateMetadata {
+        /// Path to the Cargo.toml of the contract to build
+        #[structopt(long, parse(from_os_str))]
+        manifest_path: Option<PathBuf>,
+        #[structopt(flatten)]
+        verbosity: VerbosityFlags,
+        #[structopt(flatten)]
+        unstable_options: UnstableOptions,
+    },
     /// Test the smart contract off-chain
     #[structopt(name = "test")]
     Test {},
@@ -290,6 +301,13 @@ fn exec(cmd: Command) -> Result<String> {
                 bundle_result.metadata_file.display().to_string().bold()
             ))
         }
+        Command::GenerateMetadata {
+            manifest_path: _,
+            verbosity: _,
+            unstable_options: _,
+        } => Err(anyhow::anyhow!(format!(
+            "Command deprecated, use 'cargo contract build' instead"
+        ))),
         Command::Test {} => Err(anyhow::anyhow!("Command unimplemented")),
         #[cfg(feature = "extrinsics")]
         Command::Deploy {

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,9 +319,9 @@ fn exec(cmd: Command) -> Result<String> {
             assert!(maybe_dest_wasm.is_none(), "no dest_wasm should exist");
             Ok(format!("\nYour contract's code was built successfully."))
         }
-        Command::GenerateMetadata {} => Err(anyhow::anyhow!(format!(
+        Command::GenerateMetadata {} => Err(anyhow::anyhow!(
             "Command deprecated, use `cargo contract build` instead"
-        ))),
+        )),
         Command::Test {} => Err(anyhow::anyhow!("Command unimplemented")),
         #[cfg(feature = "extrinsics")]
         Command::Deploy {

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,7 +438,7 @@ fn exec(cmd: Command) -> Result<String> {
                 )?
             };
 
-            build_artifact.display(&result)
+            Ok(build_artifact.display(&result))
         }
         Command::Check {
             manifest_path,


### PR DESCRIPTION
Closes #96 by implementing

* a new command `cargo contract build`, which results in a `target/metadata.json`, a `target/<name>.wasm`, and a `target/<name>.contract` (the .pack file mentioned in the issue).
* a new command `cargo contract check`, which just tries to build the contract without generating metadata or optimizing the Wasm.
* deprecates `cargo contract generate-metadata` for `cargo contract build` (which implicitly does this or via `--metadata-only` skips unnecessary operations not strictly needes for generating metadata).