### PR TITLE
Replace xbuild with cargo build-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,8 +500,7 @@ dependencies = [
  "async-std",
  "binaryen",
  "blake2",
- "cargo-xbuild",
- "cargo_metadata 0.11.4",
+ "cargo_metadata",
  "colored",
  "contract-metadata",
  "env_logger",
@@ -527,37 +526,6 @@ dependencies = [
  "walkdir",
  "which 4.0.2",
  "zip",
-]
-
-[[package]]
-name = "cargo-xbuild"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55737d6e19978db84c0365fe0717e2bc20bb0c941a80d7686c8daa88ce5594d"
-dependencies = [
- "cargo_metadata 0.9.1",
- "error-chain",
- "libc",
- "rustc_version",
- "serde",
- "serde_derive",
- "serde_json",
- "tempfile",
- "toml",
- "walkdir",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
-dependencies = [
- "semver 0.9.0",
- "serde",
- "serde_derive",
- "serde_json",
 ]
 
 [[package]]
@@ -904,15 +872,6 @@ name = "environmental"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6576a1755ddffd988788025e75bce9e74b018f7cc226198fe931d077911c6d7e"
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "event-listener"
@@ -2820,7 +2779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ codec = { package = "parity-scale-codec", version = "1.3.4" }
 which = "4.0.2"
 colored = "2.0.0"
 toml = "0.5.6"
-cargo-xbuild = "0.6.0"
 rustc_version = "0.2.3"
 blake2 = "0.9.0"
 contract-metadata = { version = "0.1.0", path = "./metadata" }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -35,8 +35,9 @@ const MAX_MEMORY_PAGES: u32 = 16;
 
 /// Builds the project in the specified directory, defaults to the current directory.
 ///
-/// Uses [`cargo-xbuild`](https://github.com/rust-osdev/cargo-xbuild) for maximum optimization of
-/// the resulting Wasm binary.
+/// Uses the unstable cargo feature [`build-std`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std)
+/// to build the standard library with [`panic_immediate_abort`](https://github.com/johnthagen/min-sized-rust#remove-panic-string-formatting-with-panic_immediate_abort)
+/// which reduces the size of the Wasm binary by not including panic strings and formatting code.
 ///
 /// # Cargo.toml optimizations
 ///
@@ -60,36 +61,21 @@ fn build_cargo_project(
         "-C link-arg=-z -C link-arg=stack-size=65536 -C link-arg=--import-memory",
     );
 
-    let verbosity = verbosity.map(|v| match v {
-        Verbosity::Verbose => xargo_lib::Verbosity::Verbose,
-        Verbosity::Quiet => xargo_lib::Verbosity::Quiet,
-    });
-
-    let xbuild = |manifest_path: &ManifestPath| {
-        let manifest_path = Some(manifest_path);
-        let target = Some("wasm32-unknown-unknown");
+    let cargo_build = |manifest_path: &ManifestPath| {
         let target_dir = &crate_metadata.cargo_meta.target_directory;
-        let other_args = [
-            "--no-default-features",
-            "--release",
-            &format!("--target-dir={}", target_dir.to_string_lossy()),
-        ];
-        let args = xargo_lib::Args::new(target, manifest_path, verbosity, &other_args)
-            .map_err(|e| anyhow::anyhow!("{}", e))
-            .context("Creating xargo args")?;
-
-        let config = xargo_lib::Config {
-            sysroot_path: target_dir.join("sysroot"),
-            memcpy: false,
-            panic_immediate_abort: true,
-        };
-
-        let exit_status = xargo_lib::build(args, "build", Some(config))
-            .map_err(|e| anyhow::anyhow!("{}", e))
-            .context("Building with xbuild")?;
-        if !exit_status.success() {
-            anyhow::bail!("xbuild failed with status {}", exit_status)
-        }
+        util::invoke_cargo(
+            "build",
+            &[
+                "--target=wasm32-unknown-unknown",
+                "-Zbuild-std",
+                "-Zbuild-std-features=panic_immediate_abort",
+                "--no-default-features",
+                "--release",
+                &format!("--target-dir={}", target_dir.to_string_lossy()),
+            ],
+            manifest_path.directory(),
+            verbosity,
+        )?;
         Ok(())
     };
 
@@ -100,7 +86,7 @@ fn build_cargo_project(
             "with 'original-manifest' enabled, the contract binary may not be of optimal size."
                 .bold()
         );
-        xbuild(&crate_metadata.manifest_path)?;
+        cargo_build(&crate_metadata.manifest_path)?;
     } else {
         Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
             .with_root_package_manifest(|manifest| {
@@ -109,7 +95,7 @@ fn build_cargo_project(
                     .with_profile_release_defaults(Profile::default_contract_release())?;
                 Ok(())
             })?
-            .using_temp(xbuild)?;
+            .using_temp(cargo_build)?;
     }
 
     // clear RUSTFLAGS

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -55,7 +55,8 @@ fn build_cargo_project(
 ) -> Result<()> {
     util::assert_channel()?;
 
-    // set RUSTFLAGS, read from environment var by cargo-xbuild
+    // set linker args via RUSTFLAGS.
+    // Currently will override user defined RUSTFLAGS from .cargo/config. See https://github.com/paritytech/cargo-contract/issues/98.
     std::env::set_var(
         "RUSTFLAGS",
         "-C link-arg=-z -C link-arg=stack-size=65536 -C link-arg=--import-memory",


### PR DESCRIPTION
The [`build-std`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std) feature of cargo now allows to specify the `panic-immediate-abort` feature. See: https://github.com/rust-osdev/cargo-xbuild#alternative-the-build-std-feature-of-cargo.

So we can use that (unstable) feature instead of depending on `xbuild`

Produces the same size wasm output as with `xbuild` e.g. flipper:

![image](https://user-images.githubusercontent.com/75586/98118889-c6dff280-1ea3-11eb-9c54-0a0aceab85a9.png)