### PR TITLE
Do not prettify JSON for bundle

### DIFF
--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -110,7 +110,7 @@ impl GenerateMetadataCommand {
                     format!("[{}/{}]", current_progress, self.build_artifact.steps()).bold(),
                     "Generating bundle".bright_green().bold()
                 );
-                let contents = serde_json::to_string_pretty(&metadata)?;
+                let contents = serde_json::to_string(&metadata)?;
                 fs::write(&out_path_bundle, contents)?;
             }
 


### PR DESCRIPTION
Makes quite a difference.

`flipper.contract` with `serde_json::to_string_pretty()`: `7.0K`
`flipper.contract` with `serde_json::to_string()`: `6.1K`

