### PR TITLE
Exit with 1 on Err

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -380,11 +380,14 @@ fn main() {
     let Opts::Contract(args) = Opts::from_args();
     match exec(args.cmd) {
         Ok(msg) => println!("\t{}", msg),
-        Err(err) => eprintln!(
-            "{} {}",
-            "ERROR:".bright_red().bold(),
-            format!("{:?}", err).bright_red()
-        ),
+        Err(err) => {
+            eprintln!(
+                "{} {}",
+                "ERROR:".bright_red().bold(),
+                format!("{:?}", err).bright_red()
+            );
+            std::process::exit(1);
+        }
     }
 }
 


### PR DESCRIPTION
You can provoke this by e.g. applying this patch to `ink/examples/dns/Cargo.toml`:
```
 [lib]
-name = "dns"
+name = "d ns"
```

and then
```
cargo run -- contract build --manifest-path ../ink/examples/dns/Cargo.toml 
echo $?
```

After the merge we should move the `ink-ci-v0.8.0` tag ahead to this commit.

This is another reason why some of the stages in the ink! CI succeed even though `cargo-contract` fails.