### PR TITLE
Check explicitly for error message

### DIFF
--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -105,9 +105,10 @@ mod tests {
     fn rejects_hyphenated_name() {
         with_tmp_dir(|path| {
             let result = cmd::new::execute("rejects-hyphenated-name", Some(path));
+            assert!(result.is_err(), "Should fail");
             assert_eq!(
-                format!("{:?}", result),
-                r#"Err(Contract names cannot contain hyphens)"#
+                result.err().unwrap().to_string(),
+                "Contract names cannot contain hyphens"
             );
             Ok(())
         })


### PR DESCRIPTION
During https://github.com/paritytech/ci_cd/issues/75 we ran into issues where this test always failed:

```
thread 'cmd::new::tests::rejects_hyphenated_name' panicked at 'assertion failed: `(left == right)`
  left: `"Err(Contract names cannot contain hyphens\n\nStack backtrace:\n   0: anyhow::private::new_adhoc\n             at /ci-cache/cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.33/src/lib.rs:610\n   1: cargo_contract::cmd::new::execute\n             at ./src/cmd/new.rs:31\n   2: cargo_contract::cmd::new::tests::rejects_hyphenated_name::{{closure}}\n             at ./src/cmd/new.rs:107\n   3: cargo_contract::util::tests::with_tmp_dir\n             at ./src/util.rs:101\n   4: cargo_contract::cmd::new::tests::rejects_hyphenated_name\n             at ./src/cmd/new.rs:106\n   5: cargo_contract::cmd::new::tests::rejects_hyphenated_name::{{closure}}\n             at ./src/cmd/new.rs:105\n   6: core::ops::function::FnOnce::call_once\n             at /usr/local/rustup/toolchains/nightly-2020-10-01-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:227\n   7: core::ops::function::FnOnce::call_once\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/core/src/ops/function.rs:227\n      test::__rust_begin_short_backtrace\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/test/src/lib.rs:518\n   8: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/alloc/src/boxed.rs:1042\n      <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/panic.rs:308\n      std::panicking::try::do_call\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/panicking.rs:381\n      std::panicking::try\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/panicking.rs:345\n      std::panic::catch_unwind\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/panic.rs:382\n      test::run_test_in_process\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/test/src/lib.rs:545\n      test::run_test::run_test_inner::{{closure}}\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/test/src/lib.rs:451\n   9: std::sys_common::backtrace::__rust_begin_short_backtrace\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/sys_common/backtrace.rs:137\n  10: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/thread/mod.rs:465\n      <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/panic.rs:308\n      std::panicking::try::do_call\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/panicking.rs:381\n      std::panicking::try\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/panicking.rs:345\n      std::panic::catch_unwind\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/panic.rs:382\n      std::thread::Builder::spawn_unchecked::{{closure}}\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/thread/mod.rs:464\n      core::ops::function::FnOnce::call_once{{vtable.shim}}\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/core/src/ops/function.rs:227\n  11: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/alloc/src/boxed.rs:1042\n      <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/alloc/src/boxed.rs:1042\n      std::sys::unix::thread::Thread::new::thread_start\n             at /rustc/ef663a8a48ea6b98b43cbfaefd99316b36b16825/library/std/src/sys/unix/thread.rs:87\n  12: start_thread\n  13: clone)"`,
 right: `"Err(Contract names cannot contain hyphens)"`', src/cmd/new.rs:108:13
stack backtrace:
   0: rust_begin_unwind
…
```

Further investigation showed that the CI container has `export RUST_BACKTRACE=1` and the `format!("{:?}", result)` subsequentlty then included this backtrace in the expected error message. Hence the test always failed.

I changed the test now (in the same way the one below is written), it only checks the explicit error message now.