### PR TITLE
Refactorings for `build` and `check`

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -39,11 +39,6 @@ const MAX_MEMORY_PAGES: u32 = 16;
 /// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.
 ///
 /// It does so by invoking `cargo build` and then post processing the final binary.
-///
-/// # Note
-///
-/// Collects the contract crate's metadata using the supplied manifest (`Cargo.toml`) path. Use
-/// [`execute_with_crate_metadata`] if an instance is already available.
 #[derive(Debug, StructOpt)]
 #[structopt(name = "build")]
 pub struct BuildCommand {
@@ -298,11 +293,6 @@ fn optimize_wasm(crate_metadata: &CrateMetadata) -> Result<OptimizationResult> {
 /// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.
 ///
 /// It does so by invoking `cargo build` and then post processing the final binary.
-///
-/// # Note
-///
-/// Collects the contract crate's metadata using the supplied manifest (`Cargo.toml`) path. Use
-/// [`execute_with_crate_metadata`] if an instance is already available.
 fn execute(
     manifest_path: &ManifestPath,
     verbosity: Option<Verbosity>,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -36,6 +36,14 @@ use structopt::StructOpt;
 /// This is the maximum number of pages available for a contract to allocate.
 const MAX_MEMORY_PAGES: u32 = 16;
 
+/// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.
+///
+/// It does so by invoking `cargo build` and then post processing the final binary.
+///
+/// # Note
+///
+/// Collects the contract crate's metadata using the supplied manifest (`Cargo.toml`) path. Use
+/// [`execute_with_crate_metadata`] if an instance is already available.
 #[derive(Debug, StructOpt)]
 #[structopt(name = "build")]
 pub struct BuildCommand {
@@ -62,14 +70,6 @@ pub struct BuildCommand {
 }
 
 impl BuildCommand {
-    /// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.
-    ///
-    /// It does so by invoking `cargo build` and then post processing the final binary.
-    ///
-    /// # Note
-    ///
-    /// Collects the contract crate's metadata using the supplied manifest (`Cargo.toml`) path. Use
-    /// [`execute_with_crate_metadata`] if an instance is already available.
     pub fn exec(&self) -> Result<BuildResult> {
         let manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
         let unstable_flags: UnstableFlags =

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -69,7 +69,7 @@ impl BuildCommand {
     /// # Note
     ///
     /// Collects the contract crate's metadata using the supplied manifest (`Cargo.toml`) path. Use
-    /// [`execute_build_with_metadata`] if an instance is already available.
+    /// [`execute_with_crate_metadata`] if an instance is already available.
     pub fn exec(&self) -> Result<BuildResult> {
         let manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
         let unstable_flags: UnstableFlags =
@@ -302,7 +302,7 @@ fn optimize_wasm(crate_metadata: &CrateMetadata) -> Result<OptimizationResult> {
 /// # Note
 ///
 /// Collects the contract crate's metadata using the supplied manifest (`Cargo.toml`) path. Use
-/// [`execute_build_with_metadata`] if an instance is already available.
+/// [`execute_with_crate_metadata`] if an instance is already available.
 fn execute(
     manifest_path: &ManifestPath,
     verbosity: Option<Verbosity>,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -51,7 +51,7 @@ const MAX_MEMORY_PAGES: u32 = 16;
 fn build_cargo_project(
     crate_metadata: &CrateMetadata,
     verbosity: Option<Verbosity>,
-    unstable_options: UnstableFlags,
+    unstable_flags: UnstableFlags,
 ) -> Result<()> {
     util::assert_channel()?;
 
@@ -80,7 +80,7 @@ fn build_cargo_project(
         Ok(())
     };
 
-    if unstable_options.original_manifest {
+    if unstable_flags.original_manifest {
         println!(
             "{} {}",
             "warning:".yellow().bold(),
@@ -228,7 +228,7 @@ pub(crate) fn execute(
     verbosity: Option<Verbosity>,
     optimize_contract: bool,
     build_artifact: GenerateArtifacts,
-    unstable_options: UnstableFlags,
+    unstable_flags: UnstableFlags,
 ) -> Result<GenerationResult> {
     let crate_metadata = CrateMetadata::collect(manifest_path)?;
     if build_artifact == GenerateArtifacts::CodeOnly {
@@ -237,7 +237,7 @@ pub(crate) fn execute(
             verbosity,
             optimize_contract,
             build_artifact,
-            unstable_options,
+            unstable_flags,
         )?;
         let res = GenerationResult {
             dest_wasm: maybe_dest_wasm,
@@ -249,8 +249,7 @@ pub(crate) fn execute(
         return Ok(res);
     }
 
-    let res =
-        super::metadata::execute(&manifest_path, verbosity, build_artifact, unstable_options)?;
+    let res = super::metadata::execute(&manifest_path, verbosity, build_artifact, unstable_flags)?;
     Ok(res)
 }
 
@@ -268,14 +267,14 @@ pub(crate) fn execute_with_crate_metadata(
     verbosity: Option<Verbosity>,
     optimize_contract: bool,
     build_artifact: GenerateArtifacts,
-    unstable_options: UnstableFlags,
+    unstable_flags: UnstableFlags,
 ) -> Result<(Option<PathBuf>, Option<OptimizationResult>)> {
     println!(
         " {} {}",
         format!("[1/{}]", build_artifact.steps()).bold(),
         "Building cargo project".bright_green().bold()
     );
-    build_cargo_project(&crate_metadata, verbosity, unstable_options)?;
+    build_cargo_project(&crate_metadata, verbosity, unstable_flags)?;
     println!(
         " {} {}",
         format!("[2/{}]", build_artifact.steps()).bold(),

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -25,7 +25,7 @@ use crate::{
     crate_metadata::CrateMetadata,
     util,
     workspace::{ManifestPath, Profile, Workspace},
-    GenerateArtifacts, BuildResult, UnstableFlags, UnstableOptions, VerbosityFlags,
+    BuildArtifacts, BuildResult, UnstableFlags, UnstableOptions, VerbosityFlags,
 };
 use crate::{OptimizationResult, Verbosity};
 use anyhow::{Context, Result};
@@ -54,7 +54,7 @@ pub struct BuildCommand {
         value_name = "all | code-only",
         verbatim_doc_comment
     )]
-    build_artifact: GenerateArtifacts,
+    build_artifact: BuildArtifacts,
     #[structopt(flatten)]
     verbosity: VerbosityFlags,
     #[structopt(flatten)]
@@ -107,7 +107,7 @@ impl CheckCommand {
             &manifest_path,
             verbosity,
             false,
-            GenerateArtifacts::CheckOnly,
+            BuildArtifacts::CheckOnly,
             unstable_flags,
         )
     }
@@ -307,13 +307,11 @@ fn execute(
     manifest_path: &ManifestPath,
     verbosity: Option<Verbosity>,
     optimize_contract: bool,
-    build_artifact: GenerateArtifacts,
+    build_artifact: BuildArtifacts,
     unstable_flags: UnstableFlags,
 ) -> Result<BuildResult> {
     let crate_metadata = CrateMetadata::collect(manifest_path)?;
-    if build_artifact == GenerateArtifacts::CodeOnly
-        || build_artifact == GenerateArtifacts::CheckOnly
-    {
+    if build_artifact == BuildArtifacts::CodeOnly || build_artifact == BuildArtifacts::CheckOnly {
         let (maybe_dest_wasm, maybe_optimization_result) = execute_with_crate_metadata(
             &crate_metadata,
             verbosity,
@@ -349,7 +347,7 @@ pub(crate) fn execute_with_crate_metadata(
     crate_metadata: &CrateMetadata,
     verbosity: Option<Verbosity>,
     optimize_contract: bool,
-    build_artifact: GenerateArtifacts,
+    build_artifact: BuildArtifacts,
     unstable_flags: UnstableFlags,
 ) -> Result<(Option<PathBuf>, Option<OptimizationResult>)> {
     println!(
@@ -382,7 +380,7 @@ pub(crate) fn execute_with_crate_metadata(
 #[cfg(feature = "test-ci-only")]
 #[cfg(test)]
 mod tests {
-    use crate::{cmd, util::tests::with_tmp_dir, GenerateArtifacts, ManifestPath, UnstableFlags};
+    use crate::{cmd, util::tests::with_tmp_dir, BuildArtifacts, ManifestPath, UnstableFlags};
 
     #[test]
     fn build_template() {
@@ -394,7 +392,7 @@ mod tests {
                 &manifest_path,
                 None,
                 true,
-                GenerateArtifacts::All,
+                BuildArtifacts::All,
                 UnstableFlags::default(),
             )
             .expect("build failed");

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -25,7 +25,7 @@ use crate::{
     crate_metadata::CrateMetadata,
     util,
     workspace::{ManifestPath, Profile, Workspace},
-    GenerateArtifacts, GenerationResult, UnstableFlags, UnstableOptions, VerbosityFlags,
+    GenerateArtifacts, BuildResult, UnstableFlags, UnstableOptions, VerbosityFlags,
 };
 use crate::{OptimizationResult, Verbosity};
 use anyhow::{Context, Result};
@@ -70,7 +70,7 @@ impl BuildCommand {
     ///
     /// Collects the contract crate's metadata using the supplied manifest (`Cargo.toml`) path. Use
     /// [`execute_build_with_metadata`] if an instance is already available.
-    pub fn exec(&self) -> Result<GenerationResult> {
+    pub fn exec(&self) -> Result<BuildResult> {
         let manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
         let unstable_flags: UnstableFlags =
             TryFrom::<&UnstableOptions>::try_from(&self.unstable_options)?;
@@ -98,7 +98,7 @@ pub struct CheckCommand {
 }
 
 impl CheckCommand {
-    pub fn exec(&self) -> Result<GenerationResult> {
+    pub fn exec(&self) -> Result<BuildResult> {
         let manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
         let unstable_flags: UnstableFlags =
             TryFrom::<&UnstableOptions>::try_from(&self.unstable_options)?;
@@ -309,7 +309,7 @@ fn execute(
     optimize_contract: bool,
     build_artifact: GenerateArtifacts,
     unstable_flags: UnstableFlags,
-) -> Result<GenerationResult> {
+) -> Result<BuildResult> {
     let crate_metadata = CrateMetadata::collect(manifest_path)?;
     if build_artifact == GenerateArtifacts::CodeOnly
         || build_artifact == GenerateArtifacts::CheckOnly
@@ -321,7 +321,7 @@ fn execute(
             build_artifact,
             unstable_flags,
         )?;
-        let res = GenerationResult {
+        let res = BuildResult {
             dest_wasm: maybe_dest_wasm,
             dest_metadata: None,
             dest_bundle: None,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -231,7 +231,9 @@ pub(crate) fn execute(
     unstable_flags: UnstableFlags,
 ) -> Result<GenerationResult> {
     let crate_metadata = CrateMetadata::collect(manifest_path)?;
-    if build_artifact == GenerateArtifacts::CodeOnly {
+    if build_artifact == GenerateArtifacts::CodeOnly
+        || build_artifact == GenerateArtifacts::CheckOnly
+    {
         let (maybe_dest_wasm, maybe_optimization_result) = execute_with_crate_metadata(
             &crate_metadata,
             verbosity,

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -18,7 +18,7 @@ use crate::{
     crate_metadata::CrateMetadata,
     util,
     workspace::{ManifestPath, Workspace},
-    GenerateArtifacts, BuildResult, OptimizationResult, UnstableFlags, Verbosity,
+    BuildArtifacts, BuildResult, OptimizationResult, UnstableFlags, Verbosity,
 };
 
 use anyhow::Result;
@@ -38,7 +38,7 @@ const METADATA_FILE: &str = "metadata.json";
 struct GenerateMetadataCommand {
     crate_metadata: CrateMetadata,
     verbosity: Option<Verbosity>,
-    build_artifact: GenerateArtifacts,
+    build_artifact: BuildArtifacts,
     unstable_options: UnstableFlags,
 }
 
@@ -104,7 +104,7 @@ impl GenerateMetadataCommand {
                 current_progress += 1;
             }
 
-            if self.build_artifact == GenerateArtifacts::All {
+            if self.build_artifact == BuildArtifacts::All {
                 println!(
                     " {} {}",
                     format!("[{}/{}]", current_progress, self.build_artifact.steps()).bold(),
@@ -131,7 +131,7 @@ impl GenerateMetadataCommand {
                 .using_temp(generate_metadata)?;
         }
 
-        let dest_bundle = if self.build_artifact == GenerateArtifacts::All {
+        let dest_bundle = if self.build_artifact == BuildArtifacts::All {
             Some(out_path_bundle)
         } else {
             None
@@ -168,7 +168,7 @@ impl GenerateMetadataCommand {
         let source = {
             let lang = SourceLanguage::new(Language::Ink, ink_version.clone());
             let compiler = SourceCompiler::new(Compiler::RustC, rust_version);
-            let maybe_wasm = if self.build_artifact == GenerateArtifacts::All {
+            let maybe_wasm = if self.build_artifact == BuildArtifacts::All {
                 let wasm = fs::read(&self.crate_metadata.dest_wasm)?;
                 // The Wasm which we read must have the same hash as `source.hash`
                 debug_assert!({
@@ -259,7 +259,7 @@ fn blake2_hash(code: &[u8]) -> CodeHash {
 pub(crate) fn execute(
     manifest_path: &ManifestPath,
     verbosity: Option<Verbosity>,
-    build_artifact: GenerateArtifacts,
+    build_artifact: BuildArtifacts,
     unstable_options: UnstableFlags,
 ) -> Result<BuildResult> {
     let crate_metadata = CrateMetadata::collect(manifest_path)?;
@@ -278,7 +278,7 @@ pub(crate) fn execute(
 mod tests {
     use crate::cmd::metadata::blake2_hash;
     use crate::{
-        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, GenerateArtifacts,
+        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, BuildArtifacts,
         ManifestPath, UnstableFlags,
     };
     use contract_metadata::*;
@@ -376,7 +376,7 @@ mod tests {
             let dest_bundle = cmd::metadata::execute(
                 &test_manifest.manifest_path,
                 None,
-                GenerateArtifacts::All,
+                BuildArtifacts::All,
                 UnstableFlags::default(),
             )?
             .dest_bundle

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -18,7 +18,7 @@ use crate::{
     crate_metadata::CrateMetadata,
     util,
     workspace::{ManifestPath, Workspace},
-    GenerateArtifacts, GenerationResult, OptimizationResult, UnstableFlags, Verbosity,
+    GenerateArtifacts, BuildResult, OptimizationResult, UnstableFlags, Verbosity,
 };
 
 use anyhow::Result;
@@ -52,7 +52,7 @@ struct ExtendedMetadataResult {
 }
 
 impl GenerateMetadataCommand {
-    pub fn exec(&self) -> Result<GenerationResult> {
+    pub fn exec(&self) -> Result<BuildResult> {
         util::assert_channel()?;
 
         let cargo_meta = &self.crate_metadata.cargo_meta;
@@ -136,7 +136,7 @@ impl GenerateMetadataCommand {
         } else {
             None
         };
-        Ok(GenerationResult {
+        Ok(BuildResult {
             dest_metadata: Some(out_path_metadata),
             dest_wasm,
             dest_bundle,
@@ -261,7 +261,7 @@ pub(crate) fn execute(
     verbosity: Option<Verbosity>,
     build_artifact: GenerateArtifacts,
     unstable_options: UnstableFlags,
-) -> Result<GenerationResult> {
+) -> Result<BuildResult> {
     let crate_metadata = CrateMetadata::collect(manifest_path)?;
     let res = GenerateMetadataCommand {
         crate_metadata,

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -142,6 +142,7 @@ impl GenerateMetadataCommand {
             dest_bundle,
             optimization_result,
             target_directory,
+            build_artifact: self.build_artifact,
         })
     }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -22,5 +22,6 @@ mod instantiate;
 pub mod metadata;
 pub mod new;
 
+pub(crate) use self::build::{BuildCommand, CheckCommand};
 #[cfg(feature = "extrinsics")]
 pub(crate) use self::{deploy::execute_deploy, instantiate::execute_instantiate};

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,12 +21,11 @@ mod workspace;
 
 use self::workspace::ManifestPath;
 
+use crate::cmd::{BuildCommand, CheckCommand};
+
 #[cfg(feature = "extrinsics")]
 use sp_core::{crypto::Pair, sr25519, H256};
-use std::{
-    convert::{TryFrom, TryInto},
-    path::PathBuf,
-};
+use std::{convert::TryFrom, path::PathBuf};
 #[cfg(feature = "extrinsics")]
 use subxt::PairSigner;
 
@@ -93,8 +92,8 @@ impl ExtrinsicOpts {
     }
 }
 
-#[derive(Debug, StructOpt)]
-struct VerbosityFlags {
+#[derive(Clone, Debug, StructOpt)]
+pub struct VerbosityFlags {
     #[structopt(long)]
     quiet: bool,
     #[structopt(long)]
@@ -120,7 +119,7 @@ impl TryFrom<&VerbosityFlags> for Option<Verbosity> {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Clone, Debug, StructOpt)]
 struct UnstableOptions {
     /// Use the original manifest (Cargo.toml), do not modify for build optimizations
     #[structopt(long = "unstable-options", short = "Z", number_of_values = 1)]
@@ -174,58 +173,6 @@ impl GenerateArtifacts {
             GenerateArtifacts::CheckOnly => 2,
         }
     }
-
-    pub fn display(&self, result: &GenerationResult) -> String {
-        let optimization = GenerationResult::display_optimization(result);
-        let size_diff = format!(
-            "\nOriginal wasm size: {}, Optimized: {}\n\n",
-            format!("{:.1}K", optimization.0).bold(),
-            format!("{:.1}K", optimization.1).bold(),
-        );
-
-        if self == &GenerateArtifacts::CodeOnly {
-            let out = format!(
-                "{}Your contract's code is ready. You can find it here:\n{}",
-                size_diff,
-                result
-                    .dest_wasm
-                    .as_ref()
-                    .expect("wasm path must exist")
-                    .display()
-                    .to_string()
-                    .bold()
-            );
-            return out;
-        };
-
-        let mut out = format!(
-            "{}Your contract artifacts are ready. You can find them in:\n{}\n\n",
-            size_diff,
-            result.target_directory.display().to_string().bold(),
-        );
-        if let Some(dest_bundle) = result.dest_bundle.as_ref() {
-            let bundle = format!(
-                "  - {} (code + metadata)\n",
-                util::base_name(&dest_bundle).bold()
-            );
-            out.push_str(&bundle);
-        }
-        if let Some(dest_wasm) = result.dest_wasm.as_ref() {
-            let wasm = format!(
-                "  - {} (the contract's code)\n",
-                util::base_name(&dest_wasm).bold()
-            );
-            out.push_str(&wasm);
-        }
-        if let Some(dest_metadata) = result.dest_metadata.as_ref() {
-            let metadata = format!(
-                "  - {} (the contract's metadata)",
-                util::base_name(&dest_metadata).bold()
-            );
-            out.push_str(&metadata);
-        }
-        out
-    }
 }
 
 impl std::str::FromStr for GenerateArtifacts {
@@ -251,6 +198,8 @@ pub struct GenerationResult {
     pub target_directory: PathBuf,
     /// If existent the result of the optimization.
     pub optimization_result: Option<OptimizationResult>,
+    /// Which build artifacts were generated.
+    pub build_artifact: GenerateArtifacts,
 }
 
 /// Result of the optimization process.
@@ -262,12 +211,62 @@ pub struct OptimizationResult {
 }
 
 impl GenerationResult {
+    pub fn display(&self) -> String {
+        let optimization = self.display_optimization();
+        let size_diff = format!(
+            "\nOriginal wasm size: {}, Optimized: {}\n\n",
+            format!("{:.1}K", optimization.0).bold(),
+            format!("{:.1}K", optimization.1).bold(),
+        );
+
+        if self.build_artifact == GenerateArtifacts::CodeOnly {
+            let out = format!(
+                "{}Your contract's code is ready. You can find it here:\n{}",
+                size_diff,
+                self.dest_wasm
+                    .as_ref()
+                    .expect("wasm path must exist")
+                    .display()
+                    .to_string()
+                    .bold()
+            );
+            return out;
+        };
+
+        let mut out = format!(
+            "{}Your contract artifacts are ready. You can find them in:\n{}\n\n",
+            size_diff,
+            self.target_directory.display().to_string().bold(),
+        );
+        if let Some(dest_bundle) = self.dest_bundle.as_ref() {
+            let bundle = format!(
+                "  - {} (code + metadata)\n",
+                util::base_name(&dest_bundle).bold()
+            );
+            out.push_str(&bundle);
+        }
+        if let Some(dest_wasm) = self.dest_wasm.as_ref() {
+            let wasm = format!(
+                "  - {} (the contract's code)\n",
+                util::base_name(&dest_wasm).bold()
+            );
+            out.push_str(&wasm);
+        }
+        if let Some(dest_metadata) = self.dest_metadata.as_ref() {
+            let metadata = format!(
+                "  - {} (the contract's metadata)",
+                util::base_name(&dest_metadata).bold()
+            );
+            out.push_str(&metadata);
+        }
+        out
+    }
 
     /// Returns a tuple of `(original_size, optimized_size)`.
     ///
     /// Panics if no optimization result is available.
-    pub fn display_optimization(res: &GenerationResult) -> (f64, f64) {
-        let optimization = res
+    fn display_optimization(&self) -> (f64, f64) {
+        let optimization = self
             .optimization_result
             .as_ref()
             .expect("optimization result must exist");
@@ -288,42 +287,13 @@ enum Command {
     },
     /// Compiles the contract, generates metadata, bundles both together in a `<name>.contract` file
     #[structopt(name = "build")]
-    Build {
-        /// Path to the Cargo.toml of the contract to build
-        #[structopt(long, parse(from_os_str))]
-        manifest_path: Option<PathBuf>,
-        /// Which build artifacts to generate.
-        ///
-        /// - `all`: Generate the Wasm, the metadata and a bundled `<name>.contract` file.
-        ///
-        /// - `code-only`: Only the Wasm is created, generation of metadata and a bundled
-        ///   `<name>.contract` file is skipped.
-        #[structopt(
-            long = "generate",
-            default_value = "all",
-            value_name = "all | code-only",
-            verbatim_doc_comment
-        )]
-        build_artifact: GenerateArtifacts,
-        #[structopt(flatten)]
-        verbosity: VerbosityFlags,
-        #[structopt(flatten)]
-        unstable_options: UnstableOptions,
-    },
+    Build(BuildCommand),
     /// Command has been deprecated, use `cargo contract build` instead
     #[structopt(name = "generate-metadata")]
     GenerateMetadata {},
     /// Check that the code builds as Wasm; does not output any build artifact to the top level `target/` directory
     #[structopt(name = "check")]
-    Check {
-        /// Path to the Cargo.toml of the contract to build
-        #[structopt(long, parse(from_os_str))]
-        manifest_path: Option<PathBuf>,
-        #[structopt(flatten)]
-        verbosity: VerbosityFlags,
-        #[structopt(flatten)]
-        unstable_options: UnstableOptions,
-    },
+    Check(CheckCommand),
     /// Test the smart contract off-chain
     #[structopt(name = "test")]
     Test {},
@@ -389,37 +359,16 @@ fn main() {
 fn exec(cmd: Command) -> Result<String> {
     match &cmd {
         Command::New { name, target_dir } => cmd::new::execute(name, target_dir.as_ref()),
-        Command::Build {
-            manifest_path,
-            verbosity,
-            build_artifact,
-            unstable_options,
-        } => {
-            let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
-            let result = cmd::build::execute(
-                &manifest_path,
-                verbosity.try_into()?,
-                true,
-                *build_artifact,
-                unstable_options.try_into()?,
-            )?;
-
-            Ok(build_artifact.display(&result))
+        Command::Build(build) => {
+            let result = build.exec()?;
+            Ok(result.display())
         }
-        Command::Check {
-            manifest_path,
-            verbosity,
-            unstable_options,
-        } => {
-            let manifest_path = ManifestPath::try_from(manifest_path.as_ref())?;
-            let res = cmd::build::execute(
-                &manifest_path,
-                verbosity.try_into()?,
-                false,
-                GenerateArtifacts::CodeOnly,
-                unstable_options.try_into()?,
-            )?;
-            assert!(res.dest_wasm.is_none(), "no dest_wasm should exist");
+        Command::Check(check) => {
+            let res = check.exec()?;
+            assert!(
+                res.dest_wasm.is_none(),
+                "no dest_wasm must be on the generation result"
+            );
             Ok("\nYour contract's code was built successfully.".to_string())
         }
         Command::GenerateMetadata {} => Err(anyhow::anyhow!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,21 +206,21 @@ impl GenerateArtifacts {
         if let Some(dest_bundle) = result.dest_bundle.as_ref() {
             let bundle = format!(
                 "  - {} (code + metadata)\n",
-                GenerationResult::display(&dest_bundle).bold()
+                util::base_name(&dest_bundle).bold()
             );
             out.push_str(&bundle);
         }
         if let Some(dest_wasm) = result.dest_wasm.as_ref() {
             let wasm = format!(
                 "  - {} (the contract's code)\n",
-                GenerationResult::display(&dest_wasm).bold()
+                util::base_name(&dest_wasm).bold()
             );
             out.push_str(&wasm);
         }
         if let Some(dest_metadata) = result.dest_metadata.as_ref() {
             let metadata = format!(
                 "  - {} (the contract's metadata)",
-                GenerationResult::display(&dest_metadata).bold()
+                util::base_name(&dest_metadata).bold()
             );
             out.push_str(&metadata);
         }
@@ -262,13 +262,6 @@ pub struct OptimizationResult {
 }
 
 impl GenerationResult {
-    /// Returns the base name of the path.
-    pub fn display(path: &PathBuf) -> &str {
-        path.file_name()
-            .expect("file name must exist")
-            .to_str()
-            .expect("must be valid utf-8")
-    }
 
     /// Returns a tuple of `(original_size, optimized_size)`.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ impl std::str::FromStr for GenerateArtifacts {
 }
 
 /// Result of the metadata generation process.
-pub struct GenerationResult {
+pub struct BuildResult {
     /// Path to the resulting metadata file.
     pub dest_metadata: Option<PathBuf>,
     /// Path to the resulting Wasm file.
@@ -210,7 +210,7 @@ pub struct OptimizationResult {
     pub optimized_size: f64,
 }
 
-impl GenerationResult {
+impl BuildResult {
     pub fn display(&self) -> String {
         let optimization = self.display_optimization();
         let size_diff = format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,7 @@ pub enum GenerateArtifacts {
     /// Only the Wasm is created, generation of metadata and a bundled `<name>.contract` file is skipped
     #[structopt(name = "code-only")]
     CodeOnly,
+    CheckOnly,
 }
 
 impl GenerateArtifacts {
@@ -170,6 +171,7 @@ impl GenerateArtifacts {
         match self {
             GenerateArtifacts::All => 5,
             GenerateArtifacts::CodeOnly => 3,
+            GenerateArtifacts::CheckOnly => 2,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ impl TryFrom<&UnstableOptions> for UnstableFlags {
 /// Describes which artifacts to generate
 #[derive(Copy, Clone, Eq, PartialEq, Debug, StructOpt)]
 #[structopt(name = "build-artifacts")]
-pub enum GenerateArtifacts {
+pub enum BuildArtifacts {
     /// Generate the Wasm, the metadata and a bundled `<name>.contract` file
     #[structopt(name = "all")]
     All,
@@ -163,24 +163,24 @@ pub enum GenerateArtifacts {
     CheckOnly,
 }
 
-impl GenerateArtifacts {
+impl BuildArtifacts {
     /// Returns the number of steps required to complete a build artifact.
     /// Used as output on the cli.
     pub fn steps(&self) -> usize {
         match self {
-            GenerateArtifacts::All => 5,
-            GenerateArtifacts::CodeOnly => 3,
-            GenerateArtifacts::CheckOnly => 2,
+            BuildArtifacts::All => 5,
+            BuildArtifacts::CodeOnly => 3,
+            BuildArtifacts::CheckOnly => 2,
         }
     }
 }
 
-impl std::str::FromStr for GenerateArtifacts {
+impl std::str::FromStr for BuildArtifacts {
     type Err = String;
     fn from_str(artifact: &str) -> Result<Self, Self::Err> {
         match artifact {
-            "all" => Ok(GenerateArtifacts::All),
-            "code-only" => Ok(GenerateArtifacts::CodeOnly),
+            "all" => Ok(BuildArtifacts::All),
+            "code-only" => Ok(BuildArtifacts::CodeOnly),
             _ => Err("Could not parse build artifact".to_string()),
         }
     }
@@ -199,7 +199,7 @@ pub struct BuildResult {
     /// If existent the result of the optimization.
     pub optimization_result: Option<OptimizationResult>,
     /// Which build artifacts were generated.
-    pub build_artifact: GenerateArtifacts,
+    pub build_artifact: BuildArtifacts,
 }
 
 /// Result of the optimization process.
@@ -219,7 +219,7 @@ impl BuildResult {
             format!("{:.1}K", optimization.1).bold(),
         );
 
-        if self.build_artifact == GenerateArtifacts::CodeOnly {
+        if self.build_artifact == BuildArtifacts::CodeOnly {
             let out = format!(
                 "{}Your contract's code is ready. You can find it here:\n{}",
                 size_diff,

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,6 +17,7 @@
 use crate::Verbosity;
 use anyhow::{Context, Result};
 use rustc_version::Channel;
+use std::path::PathBuf;
 use std::{ffi::OsStr, path::Path, process::Command};
 
 /// Check whether the current rust channel is valid: `nightly` is recommended.
@@ -82,6 +83,14 @@ where
             output.status.code()
         );
     }
+}
+
+/// Returns the base name of the path.
+pub(crate) fn base_name(path: &PathBuf) -> &str {
+    path.file_name()
+        .expect("file name must exist")
+        .to_str()
+        .expect("must be valid utf-8")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I had it in the back of my head for a while now to have `main.rs` be just the dispatcher for `build` and `check` and have the logic reside in the appropriate modules. This was something that came up in a review a while ago.

There are some more minor refactorings in here, like consistent naming and moving a function to utilities.

Also a small fix is in here: for `check` the output of the steps in the progress (`[{}/{}]`) was one off.