### PR TITLE
Upgrade: `pwasm-utils` ➜ 0.16.1, `parity-wasm` ➜ 0.42.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ dependencies = [
  "hex",
  "log",
  "parity-scale-codec",
- "parity-wasm",
+ "parity-wasm 0.42.1",
  "pretty_assertions",
  "pwasm-utils",
  "rustc_version 0.3.0",
@@ -2443,6 +2443,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 
 [[package]]
+name = "parity-wasm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17797de36b94bc5f73edad736fd0a77ce5ab64dd622f809c1eead8c91fa6564"
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2839,13 +2845,13 @@ dependencies = [
 
 [[package]]
 name = "pwasm-utils"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8ac87af529432d3a4f0e2b3bbf08af49f28f09cc73ed7e551161bdaef5f78d"
+checksum = "07e524bbe4be824caa2761b0b7b6dc21200c4cfa162db9cade31c0a75feb13b0"
 dependencies = [
  "byteorder",
  "log",
- "parity-wasm",
+ "parity-wasm 0.42.1",
 ]
 
 [[package]]
@@ -4851,7 +4857,7 @@ dependencies = [
  "memory_units",
  "num-rational",
  "num-traits",
- "parity-wasm",
+ "parity-wasm 0.41.0",
  "wasmi-validation",
 ]
 
@@ -4861,7 +4867,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea78c597064ba73596099281e2f4cfc019075122a65cdda3205af94f0b264d93"
 dependencies = [
- "parity-wasm",
+ "parity-wasm 0.41.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ structopt = "0.3.20"
 log = "0.4.11"
 heck = "0.3.1"
 zip = { version = "0.5.8", default-features = false }
-pwasm-utils = "0.16.0"
-parity-wasm = "0.41.0"
+pwasm-utils = "0.16.1"
+parity-wasm = "0.42.1"
 cargo_metadata = "0.12.1"
 codec = { package = "parity-scale-codec", version = "1.3.5" }
 which = "4.0.2"


### PR DESCRIPTION
My PR https://github.com/paritytech/wasm-utils/pull/145 has been merged and a new release is out. Hence we can upgrade now.