### PR TITLE
add build quiet and verbose usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,8 +94,10 @@ impl ExtrinsicOpts {
 
 #[derive(Clone, Debug, StructOpt)]
 pub struct VerbosityFlags {
+    /// No output printed to stdout
     #[structopt(long)]
     quiet: bool,
+    /// Use verbose output
     #[structopt(long)]
     verbose: bool,
 }


### PR DESCRIPTION
now:
FLAGS:
    -h, --help       Prints help information
        --quiet      No output printed to stdout
    -V, --version    Prints version information
        --verbose    Use verbose output

before:
FLAGS:
    -h, --help       Prints help information
        --quiet      
    -V, --version    Prints version information
        --verbose   