### PR TITLE
fix clippy ==0 be replaced is_empty()

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -101,7 +101,7 @@ fn zip_dir(src_dir: &PathBuf, dst_file: &PathBuf, method: CompressionMethod) -> 
             f.read_to_end(&mut buffer)?;
             zip.write_all(&*buffer)?;
             buffer.clear();
-        } else if name.as_os_str().len() != 0 {
+        } else if !name.as_os_str().is_empty() {
             zip.add_directory(file_path, options)?;
         }
     }

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -349,7 +349,7 @@ impl ContractBuilder {
             .map(|s| s.as_ref().to_string())
             .collect::<Vec<_>>();
 
-        if authors.len() == 0 {
+        if authors.is_empty() {
             panic!("must have at least one author")
         }
 


### PR DESCRIPTION
warning: length comparison to zero
   --> build.rs:104:19
    |
104 |         } else if name.as_os_str().len() != 0 {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!name.as_os_str().is_empty()`

ok_or be replaeced ok_or_else. You do it, or I'll do it when I have time.