### PR TITLE
feat expect warning

### DIFF
--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -52,10 +52,12 @@ impl Workspace {
                 .packages
                 .iter()
                 .find(|p| p.id == *package_id)
-                .expect(&format!(
-                    "Package '{}' is a member and should be in the packages list",
-                    package_id
-                ));
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Package '{}' is a member and should be in the packages list",
+                        package_id
+                    )
+                });
             let manifest = Manifest::new(&package.manifest_path)?;
             Ok((package_id.clone(), (package.clone(), manifest)))
         };


### PR DESCRIPTION
warning: use of `expect` followed by a function call
  --> src/workspace/mod.rs:55:18
   |
55 |                   .expect(&format!(
   |  __________________^
56 | |                     "Package '{}' is a member and should be in the packages list",
57 | |                     package_id
58 | |                 ));
   | |__________________^ help: try this: `unwrap_or_else(|| panic!("Package '{}' is a member and should be in the packages list", package_id))`
   |
   = note: `#[warn(clippy::expect_fun_call)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call