### PR TITLE
Update to scale-info 0.5 and codec 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
 dependencies = [
  "either",
- "radium",
+ "radium 0.3.0",
+]
+
+[[package]]
+name = "bitvec"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5011ffc90248764d7005b0e10c7294f5aa1bd87d9dd7248f4ad475b347c294d"
+dependencies = [
+ "funty",
+ "radium 0.6.2",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -521,6 +533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,7 +579,7 @@ dependencies = [
  "heck",
  "hex",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 2.0.0",
  "parity-wasm 0.42.1",
  "pretty_assertions",
  "pwasm-utils",
@@ -984,7 +1002,7 @@ dependencies = [
  "futures-timer 2.0.2",
  "log",
  "num-traits",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "parking_lot 0.9.0",
 ]
 
@@ -1031,7 +1049,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "linregress",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "paste",
  "sp-api",
  "sp-io",
@@ -1047,7 +1065,7 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b5640bfcb7111643807c63cd38ecdcc923d3253e525f23ab6b366002bf8ecd5"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-core",
  "sp-std",
@@ -1065,7 +1083,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "once_cell",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "paste",
  "serde",
  "smallvec 1.5.1",
@@ -1123,7 +1141,7 @@ checksum = "d172404f0e44b867f5fd14465a27f298b8828b53d7a7a555d3759e1dec3c8f0d"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-core",
  "sp-io",
@@ -1153,6 +1171,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1583,7 +1607,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
 ]
 
 [[package]]
@@ -2279,7 +2303,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-authorship",
  "sp-inherents",
  "sp-runtime",
@@ -2296,7 +2320,7 @@ dependencies = [
  "frame-system",
  "pallet-authorship",
  "pallet-session",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-application-crypto",
  "sp-core",
@@ -2314,7 +2338,7 @@ checksum = "4d234bf46076a835b473a987f089299ffa3efd961a92b5be9384cc280fcc8c8f"
 dependencies = [
  "frame-support",
  "frame-system",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-core",
  "sp-io",
@@ -2333,7 +2357,7 @@ dependencies = [
  "frame-system",
  "impl-trait-for-tuples",
  "pallet-timestamp",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-core",
  "sp-io",
@@ -2354,7 +2378,7 @@ dependencies = [
  "frame-system",
  "pallet-authorship",
  "pallet-session",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-application-crypto",
  "sp-io",
@@ -2375,7 +2399,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-inherents",
  "sp-runtime",
@@ -2408,9 +2432,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
 dependencies = [
  "arrayvec 0.5.2",
- "bitvec",
- "byte-slice-cast",
+ "bitvec 0.17.4",
+ "byte-slice-cast 0.3.5",
  "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c823fdae1bb5ff5708ee61a62697e6296175dc671710876871c853f48592b3"
+dependencies = [
+ "arrayvec 0.5.2",
+ "bitvec 0.20.1",
+ "byte-slice-cast 1.0.0",
  "serde",
 ]
 
@@ -2852,6 +2888,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
 name = "rand"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,7 +3293,7 @@ dependencies = [
  "jsonrpc-derive",
  "jsonrpc-pubsub",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "parking_lot 0.10.2",
  "serde",
  "serde_json",
@@ -3527,7 +3569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953a3296335d9761311763dbe6855109ea4bea915e27cf5633d8b01057898302"
 dependencies = [
  "hash-db",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-api-proc-macro",
  "sp-core",
  "sp-runtime",
@@ -3555,7 +3597,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "885eca124aa6ce0bba57c08bc48c4357096996d630a77f572580ef8e2e4df034"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-core",
  "sp-io",
@@ -3570,7 +3612,7 @@ checksum = "667775bc50eb214225df18c92e4ec57acc7e2dc78d7d210eb4dd930db1a73995"
 dependencies = [
  "integer-sqrt",
  "num-traits",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -3582,7 +3624,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b7748c0e859bf4c3dda84849a72af83c9f85bb21a7b7c085ed161516fa00d1e"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-api",
  "sp-application-crypto",
  "sp-runtime",
@@ -3595,7 +3637,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58623adee1ed41752d76151762c80801758f88f85e4016d0338f2b01f4e7bd44"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
@@ -3607,7 +3649,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07d7fca8aa126a9d295843d592f44b48d8cf93880862baeff2968164598ab26c"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-api",
  "sp-inherents",
  "sp-runtime",
@@ -3623,7 +3665,7 @@ dependencies = [
  "derive_more",
  "log",
  "lru",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "parking_lot 0.10.2",
  "sp-block-builder",
  "sp-consensus",
@@ -3653,7 +3695,7 @@ dependencies = [
  "futures-timer 3.0.2",
  "libp2p",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "parking_lot 0.10.2",
  "serde",
  "sp-api",
@@ -3676,7 +3718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8050a73302f354f45d0dee610e69ed39aadf43ab8a7528bdf3df8427276dc739"
 dependencies = [
  "merlin",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus",
@@ -3695,7 +3737,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83ea323ccf4ec8aad353fbc9016a1cb8cbf0d872d33bc8874cb0753b014fb7fc"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-runtime",
 ]
 
@@ -3705,7 +3747,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3345ee42ea5319bd6e3329bc3b5ee68b09f14d677378b27409a3a52d5ebe9990"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "schnorrkel",
  "sp-core",
  "sp-runtime",
@@ -3734,7 +3776,7 @@ dependencies = [
  "log",
  "merlin",
  "num-traits",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "parity-util-mem",
  "parking_lot 0.10.2",
  "primitive-types",
@@ -3785,7 +3827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d87fcd0e0fc5e025459cfe769803488d4894e36d0f8cef80b5239d2e7ef6580"
 dependencies = [
  "environmental",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-std",
  "sp-storage",
 ]
@@ -3798,7 +3840,7 @@ checksum = "789d960506306f34fb0a2da547956ba1f23d6a29032291a7284c943906feddcb"
 dependencies = [
  "finality-grandpa",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-api",
  "sp-application-crypto",
@@ -3814,7 +3856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "365e5aee23640631e63e8634f1d804e33c8fcb521f4052910f29abaa2df1c1cf"
 dependencies = [
  "derive_more",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "parking_lot 0.10.2",
  "sp-core",
  "sp-std",
@@ -3830,7 +3872,7 @@ dependencies = [
  "hash-db",
  "libsecp256k1",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "parking_lot 0.10.2",
  "sp-core",
  "sp-externalities",
@@ -3862,7 +3904,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54bb6d3d49dccf6ee26586a29ce8aabade8e102e51ed5009660ef7abb973eb7d"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-arithmetic",
  "sp-npos-elections-compact",
@@ -3911,7 +3953,7 @@ dependencies = [
  "hash256-std-hasher",
  "impl-trait-for-tuples",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "parity-util-mem",
  "paste",
  "rand 0.7.3",
@@ -3930,7 +3972,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7e363c480cc8c9019b84f85d10c0b56a184079d5d840d2d1d55087ad835dc6"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
@@ -3960,7 +4002,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d138b1f548933003feaa967de49ed87066643073bcc41be45ef2daaa0991c133"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-api",
  "sp-core",
  "sp-runtime",
@@ -3974,7 +4016,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b06f9839d8b4312486626bde31d6cd7763dd9b7d93ea9e70c01ca30f0998032"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-runtime",
  "sp-std",
 ]
@@ -3988,7 +4030,7 @@ dependencies = [
  "hash-db",
  "log",
  "num-traits",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "parking_lot 0.10.2",
  "rand 0.7.3",
  "smallvec 1.5.1",
@@ -4014,7 +4056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f4625e6f8f40995939560f48f89028f658b7929657c68d01c571c81ab5619ff"
 dependencies = [
  "impl-serde",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "ref-cast",
  "serde",
  "sp-debug-derive",
@@ -4028,7 +4070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cb398f0a5d2798ad4e02450b3089534547b448d22ebe6f3b2c03f74170f58d1"
 dependencies = [
  "impl-trait-for-tuples",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-api",
  "sp-inherents",
  "sp-runtime",
@@ -4043,7 +4085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9a5c42c5450991ca3a28c190e75122f5ccedbcb024953e7c357e7aa2afd8534"
 dependencies = [
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-std",
  "tracing",
  "tracing-core",
@@ -4059,7 +4101,7 @@ dependencies = [
  "derive_more",
  "futures 0.3.11",
  "log",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-api",
  "sp-blockchain",
@@ -4074,7 +4116,7 @@ checksum = "f3aae57c8ae81ba978503137a8c625d2963eb425dd90dec0d96b4ed18d8bfd55"
 dependencies = [
  "hash-db",
  "memory-db",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-core",
  "sp-std",
  "trie-db",
@@ -4101,7 +4143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21935199c8765f0d02facc718f9c83149a70ea684fb03612e5161c682b38a301"
 dependencies = [
  "impl-serde",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "serde",
  "sp-runtime",
  "sp-std",
@@ -4114,7 +4156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c28225e8b7ec7e260f8b46443f8731abda206334cb75c740d2407693f38167"
 dependencies = [
  "impl-trait-for-tuples",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sp-std",
  "wasmi",
 ]
@@ -4235,7 +4277,7 @@ dependencies = [
  "pallet-im-online",
  "pallet-indices",
  "pallet-staking",
- "parity-scale-codec",
+ "parity-scale-codec 1.3.5",
  "sc-rpc-api",
  "serde",
  "serde_json",
@@ -4303,6 +4345,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "tempfile"
@@ -5006,6 +5054,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ zip = { version = "0.5.8", default-features = false }
 pwasm-utils = "0.17.0"
 parity-wasm = "0.42.1"
 cargo_metadata = "0.12.3"
-codec = { package = "parity-scale-codec", version = "1.3.5" }
+codec = { package = "parity-scale-codec", version = "2.0.0" }
 which = "4.0.2"
 colored = "2.0.0"
 toml = "0.5.8"

--- a/templates/new/_Cargo.toml
+++ b/templates/new/_Cargo.toml
@@ -11,7 +11,7 @@ ink_env = { version = "3.0.0-rc2", default-features = false }
 ink_storage = { version = "3.0.0-rc2", default-features = false }
 ink_lang = { version = "3.0.0-rc2", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
 scale-info = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
 
 [lib]

--- a/templates/new/_Cargo.toml
+++ b/templates/new/_Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", default-features = false }
 ink_lang = { version = "3.0.0-rc2", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
-scale-info = { version = "0.4.1", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "{{name}}"


### PR DESCRIPTION
Related: https://github.com/paritytech/ink/pull/663