### PR TITLE
Suppress output on `--quiet`

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -157,7 +157,7 @@ fn build_cargo_project(
         Ok(())
     };
 
-    if unstable_flags.original_manifest {
+    if unstable_flags.original_manifest && util::is_verbose(&verbosity) {
         println!(
             "{} {}",
             "warning:".yellow().bold(),
@@ -318,6 +318,7 @@ fn execute(
             target_directory: crate_metadata.target_directory,
             optimization_result: maybe_optimization_result,
             build_artifact,
+            verbosity,
         };
         return Ok(res);
     }
@@ -342,26 +343,32 @@ pub(crate) fn execute_with_crate_metadata(
     build_artifact: BuildArtifacts,
     unstable_flags: UnstableFlags,
 ) -> Result<(Option<PathBuf>, Option<OptimizationResult>)> {
-    println!(
-        " {} {}",
-        format!("[1/{}]", build_artifact.steps()).bold(),
-        "Building cargo project".bright_green().bold()
-    );
+    if util::is_verbose(&verbosity) {
+        println!(
+            " {} {}",
+            format!("[1/{}]", build_artifact.steps()).bold(),
+            "Building cargo project".bright_green().bold()
+        );
+    }
     build_cargo_project(&crate_metadata, build_artifact, verbosity, unstable_flags)?;
-    println!(
-        " {} {}",
-        format!("[2/{}]", build_artifact.steps()).bold(),
-        "Post processing wasm file".bright_green().bold()
-    );
+    if util::is_verbose(&verbosity) {
+        println!(
+            " {} {}",
+            format!("[2/{}]", build_artifact.steps()).bold(),
+            "Post processing wasm file".bright_green().bold()
+        );
+    }
     post_process_wasm(&crate_metadata)?;
     if !optimize_contract {
         return Ok((None, None));
     }
-    println!(
-        " {} {}",
-        format!("[3/{}]", build_artifact.steps()).bold(),
-        "Optimizing wasm file".bright_green().bold()
-    );
+    if util::is_verbose(&verbosity) {
+        println!(
+            " {} {}",
+            format!("[3/{}]", build_artifact.steps()).bold(),
+            "Optimizing wasm file".bright_green().bold()
+        );
+    }
     let optimization_result = optimize_wasm(&crate_metadata)?;
     Ok((
         Some(crate_metadata.dest_wasm.clone()),

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -72,11 +72,13 @@ impl GenerateMetadataCommand {
 
         let generate_metadata = |manifest_path: &ManifestPath| -> Result<()> {
             let mut current_progress = 4;
-            println!(
-                " {} {}",
-                format!("[{}/{}]", current_progress, self.build_artifact.steps()).bold(),
-                "Generating metadata".bright_green().bold()
-            );
+            if util::is_verbose(&self.verbosity) {
+                println!(
+                    " {} {}",
+                    format!("[{}/{}]", current_progress, self.build_artifact.steps()).bold(),
+                    "Generating metadata".bright_green().bold()
+                );
+            }
             let target_dir_arg = format!("--target-dir={}", target_directory.to_string_lossy());
             let stdout = util::invoke_cargo(
                 "run",
@@ -102,7 +104,7 @@ impl GenerateMetadataCommand {
                 current_progress += 1;
             }
 
-            if self.build_artifact == BuildArtifacts::All {
+            if self.build_artifact == BuildArtifacts::All && util::is_verbose(&self.verbosity) {
                 println!(
                     " {} {}",
                     format!("[{}/{}]", current_progress, self.build_artifact.steps()).bold(),
@@ -144,6 +146,7 @@ impl GenerateMetadataCommand {
             optimization_result,
             target_directory,
             build_artifact: self.build_artifact,
+            verbosity: self.verbosity,
         })
     }
 

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -23,7 +23,7 @@ use std::{
 use anyhow::Result;
 use heck::CamelCase as _;
 
-pub(crate) fn execute<P>(name: &str, dir: Option<P>) -> Result<String>
+pub(crate) fn execute<P>(name: &str, dir: Option<P>) -> Result<Option<String>>
 where
     P: AsRef<Path>,
 {
@@ -93,7 +93,7 @@ where
         }
     }
 
-    Ok(format!("Created contract {}", name))
+    Ok(Some(format!("Created contract {}", name)))
 }
 
 #[cfg(test)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -93,6 +93,15 @@ pub(crate) fn base_name(path: &PathBuf) -> &str {
         .expect("must be valid utf-8")
 }
 
+/// Returns `true` if output should be printed (i.e. verbose output is set).
+pub(crate) fn is_verbose(verbosity: &Option<Verbosity>) -> bool {
+    if let Some(Verbosity::Verbose) = verbosity {
+        true
+    } else {
+        false
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use std::path::Path;

--- a/src/util.rs
+++ b/src/util.rs
@@ -43,7 +43,7 @@ pub(crate) fn invoke_cargo<I, S, P>(
     command: &str,
     args: I,
     working_dir: Option<P>,
-    verbosity: Option<Verbosity>,
+    verbosity: Verbosity,
 ) -> Result<Vec<u8>>
 where
     I: IntoIterator<Item = S> + std::fmt::Debug,
@@ -60,9 +60,9 @@ where
     cmd.arg(command);
     cmd.args(args);
     match verbosity {
-        Some(Verbosity::Quiet) => cmd.arg("--quiet"),
-        Some(Verbosity::Verbose) => cmd.arg("--verbose"),
-        None => &mut cmd,
+        Verbosity::Quiet => cmd.arg("--quiet"),
+        Verbosity::Verbose => cmd.arg("--verbose"),
+        Verbosity::Default => &mut cmd,
     };
 
     log::info!("invoking cargo: {:?}", cmd);
@@ -93,13 +93,14 @@ pub(crate) fn base_name(path: &PathBuf) -> &str {
         .expect("must be valid utf-8")
 }
 
-/// Returns `true` if output should be printed (i.e. verbose output is set).
-pub(crate) fn is_verbose(verbosity: &Option<Verbosity>) -> bool {
-    if let Some(Verbosity::Verbose) = verbosity {
-        true
-    } else {
-        false
-    }
+/// Prints to stdout if `verbosity.is_verbose()` is `true`.
+#[macro_export]
+macro_rules! maybe_println {
+    ($verbosity:expr, $($msg:tt)*) => {
+        if $verbosity.is_verbose() {
+            println!($($msg)*);
+        }
+    };
 }
 
 #[cfg(test)]

--- a/src/workspace/manifest.rs
+++ b/src/workspace/manifest.rs
@@ -229,7 +229,7 @@ impl Manifest {
         if members.contains(&LEGACY_METADATA_PACKAGE_PATH.into()) {
             // warn user if they have legacy metadata generation artifacts
             use colored::Colorize;
-            println!(
+            eprintln!(
                 "{} {} {} {}",
                 "warning:".yellow().bold(),
                 "please remove".bold(),


### PR DESCRIPTION
Closes #134.

Supersedes #133.

From the issue:
>[…] investigate whether we should print progress updates to stderr as I believe cargo does (needs confirming).

I investigated and the `cargo` behavior is that progress output is suppressed entirely for `--quiet`, but errors are still printed to `stderr`. This is the behavior which I implemented in this PR.