### PR TITLE
Use either `binaryen-rs` dep or `wasm-opt` binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.123", default-features = false, features = ["derive"] }
 serde_json = "1.0.61"
 tempfile = "3.2.0"
 url = { version = "2.2.0", features = ["serde"] }
-binaryen = "0.12.0"
+binaryen = { version = "0.12.0", optional = true }
 
 # dependencies for optional extrinsics feature
 async-std = { version = "1.9.0", optional = true }
@@ -61,6 +61,7 @@ wabt = "0.10.0"
 
 [features]
 default = []
+wasm-opt-unavailable = ["binaryen"]
 
 # Enable this for (experimental) commands to deploy, instantiate and call contracts.
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ wabt = "0.10.0"
 
 [features]
 default = []
-wasm-opt-unavailable = ["binaryen"]
+binaryen-as-dependency = ["binaryen"]
 
 # Enable this for (experimental) commands to deploy, instantiate and call contracts.
 #

--- a/README.md
+++ b/README.md
@@ -10,15 +10,14 @@ A CLI tool for helping setting up and managing WebAssembly smart contracts writt
 
 `rust-src` is a prerequisite: `rustup component add rust-src`.
 
-We optimize the resulting contract Wasm using `binaryen`. You have two options of how
-to invoke `binaryen`:
+We optimize the resulting contract Wasm using `binaryen`. You have two options for installing it:
 
-  - The preferred way:
+  - _The preferred way:_  
     Install [`binaryen`](https://github.com/WebAssembly/binaryen#tools). Many package managers
     have it available nowadays (it's a package for e.g. Debian/Ubuntu, Homebrew, Arch Linux, etc.).
-    After you've installed `wasm-opt` execute `cargo install --force cargo-contract`.
+    After you've installed the package execute `cargo install --force cargo-contract`.
 
-  - Build `binaryen` as a dependency when installing `cargo-contract`:
+  - _Build `binaryen` as a dependency when installing `cargo-contract`:_  
     A C++14 compiler and python >= 3.5 is required.
     Execute `cargo install --force --features wasm-opt-unavailable cargo-contract`.
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,19 @@ A CLI tool for helping setting up and managing WebAssembly smart contracts writt
 
 ## Installation
 
-- **Prerequisites**
+`rust-src` is a prerequisite: `rustup component add rust-src`.
 
-  - **rust-src**: `rustup component add rust-src`
-  - A C++14 compiler and python >= 3.5 is required for building the
-    [binaryen](https://github.com/WebAssembly/binaryen) dependency.
-    `binaryen` is built automatically during the `cargo-contract` build process.
+We optimize the resulting contract Wasm using `binaryen`. You have two options of how
+to invoke `binaryen`:
 
-- **Install latest version from [crates.io](https://crates.io/crates/cargo-contract)**
-  - `cargo install cargo-contract`
+  - The preferred way:
+    Install [`binaryen`](https://github.com/WebAssembly/binaryen#tools). Many package managers
+    have it available nowadays (it's a package for e.g. Debian/Ubuntu, Homebrew, Arch Linux, etc.).
+    After you've installed `wasm-opt` execute `cargo install --force cargo-contract`.
+
+  - Build `binaryen` as a dependency when installing `cargo-contract`:
+    A C++14 compiler and python >= 3.5 is required.
+    Execute `cargo install --force --features wasm-opt-unavailable cargo-contract`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ We optimize the resulting contract Wasm using `binaryen`. You have two options f
 
   - _The preferred way:_  
     Install [`binaryen`](https://github.com/WebAssembly/binaryen#tools). Many package managers
-    have it available nowadays (it's a package for e.g. Debian/Ubuntu, Homebrew, Arch Linux, etc.).
+    have it available nowadays ‒ e.g. it's a package for [Debian/Ubuntu](https://tracker.debian.org/pkg/binaryen),
+    [Homebrew](https://formulae.brew.sh/formula/binaryen) and [Arch Linux](https://archlinux.org/packages/community/x86_64/binaryen/).
     After you've installed the package execute `cargo install --force cargo-contract`.
 
   - _Build `binaryen` as a dependency when installing `cargo-contract`:_  

--- a/build.rs
+++ b/build.rs
@@ -20,7 +20,7 @@ use std::{
     fs::File,
     io::{prelude::*, Write},
     iter::Iterator,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use anyhow::Result;
@@ -64,7 +64,7 @@ fn main() {
     );
 }
 
-fn zip_dir(src_dir: &PathBuf, dst_file: &PathBuf, method: CompressionMethod) -> Result<()> {
+fn zip_dir(src_dir: &Path, dst_file: &Path, method: CompressionMethod) -> Result<()> {
     if !src_dir.exists() {
         anyhow::bail!("src_dir '{}' does not exist", src_dir.display());
     }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -286,7 +286,7 @@ fn optimize_wasm(crate_metadata: &CrateMetadata) -> Result<OptimizationResult> {
 
 /// Optimizes the Wasm supplied as `wasm` using the `binaryen-rs` dependency.
 ///
-/// The supplied `optimization_level` denotes the number of optimization passes,
+/// The supplied `optimization_passes` denotes the number of optimization passes,
 /// resulting in potentially a lot of time spent optimizing.
 ///
 /// If successful, the optimized Wasm is returned as a `Vec<u8>`.
@@ -295,11 +295,11 @@ fn do_optimization(
     _: &CrateMetadata,
     _: &Path,
     wasm: &[u8],
-    optimization_level: u32,
+    optimization_passes: u32,
 ) -> Result<Vec<u8>> {
     let codegen_config = binaryen::CodegenConfig {
         // number of optimization passes (spends potentially a lot of time optimizing)
-        optimization_level,
+        optimization_passes,
         // the default
         shrink_level: 1,
         // the default
@@ -314,7 +314,7 @@ fn do_optimization(
 /// Optimizes the Wasm supplied as `crate_metadata.dest_wasm` using
 /// the `wasm-opt` binary.
 ///
-/// The supplied `optimization_level` denotes the number of optimization passes,
+/// The supplied `optimization_passes` denotes the number of optimization passes,
 /// resulting in potentially a lot of time spent optimizing.
 ///
 /// If successful, the optimized Wasm file is created under `optimized`
@@ -324,7 +324,7 @@ fn do_optimization(
     crate_metadata: &CrateMetadata,
     optimized_dest: &Path,
     _: &[u8],
-    optimization_level: u32,
+    optimization_passes: u32,
 ) -> Result<Vec<u8>> {
     // check `wasm-opt` is installed
     if which::which("wasm-opt").is_err() {
@@ -339,7 +339,7 @@ fn do_optimization(
 
     let output = Command::new("wasm-opt")
         .arg(crate_metadata.dest_wasm.as_os_str())
-        .arg(format!("-O{}", optimization_level))
+        .arg(format!("-O{}", optimization_passes))
         .arg("-o")
         .arg(optimized_dest.as_os_str())
         .output()?;

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -18,8 +18,11 @@ use std::{
     convert::TryFrom,
     fs::{metadata, File},
     io::{Read, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
+
+#[cfg(not(feature = "wasm-opt-unavailable"))]
+use std::{io, process::Command};
 
 use crate::{
     crate_metadata::CrateMetadata,
@@ -261,23 +264,11 @@ fn optimize_wasm(crate_metadata: &CrateMetadata) -> Result<OptimizationResult> {
     let mut optimized = crate_metadata.dest_wasm.clone();
     optimized.set_file_name(format!("{}-opt.wasm", crate_metadata.package_name));
 
-    let codegen_config = binaryen::CodegenConfig {
-        // execute -O3 optimization passes (spends potentially a lot of time optimizing)
-        optimization_level: 3,
-        // the default
-        shrink_level: 1,
-        // the default
-        debug_info: false,
-    };
-
     let mut dest_wasm_file = File::open(crate_metadata.dest_wasm.as_os_str())?;
     let mut dest_wasm_file_content = Vec::new();
     dest_wasm_file.read_to_end(&mut dest_wasm_file_content)?;
 
-    let mut module = binaryen::Module::read(&dest_wasm_file_content)
-        .map_err(|_| anyhow::anyhow!("binaryen failed to read file content"))?;
-    module.optimize(&codegen_config);
-    let optimized_wasm = module.write();
+    let optimized_wasm = get_optimized_wasm(crate_metadata, &optimized, &dest_wasm_file_content)?;
 
     let mut optimized_wasm_file = File::create(optimized.as_os_str())?;
     optimized_wasm_file.write_all(&optimized_wasm)?;
@@ -291,6 +282,63 @@ fn optimize_wasm(crate_metadata: &CrateMetadata) -> Result<OptimizationResult> {
         original_size,
         optimized_size,
     })
+}
+
+/// Optimizes the Wasm supplied as `wasm` using the `binaryen-rs` dependency.
+///
+/// If successful, the optimized Wasm is returned as a `Vec<u8>`.
+#[cfg(feature = "wasm-opt-unavailable")]
+fn get_optimized_wasm(_: &CrateMetadata, _: &Path, wasm: &[u8]) -> Result<Vec<u8>> {
+    let codegen_config = binaryen::CodegenConfig {
+        // execute -O3 optimization passes (spends potentially a lot of time optimizing)
+        optimization_level: 3,
+        // the default
+        shrink_level: 1,
+        // the default
+        debug_info: false,
+    };
+    let mut module = binaryen::Module::read(&wasm)
+        .map_err(|_| anyhow::anyhow!("binaryen failed to read file content"))?;
+    module.optimize(&codegen_config);
+    Ok(module.write())
+}
+
+/// Optimizes the Wasm supplied as `crate_metadata.dest_wasm` using
+/// the `wasm-opt` binary.
+///
+/// If successful, the optimized Wasm file is created under `optimized`
+/// and returned as a `Vec<u8>`.
+#[cfg(not(feature = "wasm-opt-unavailable"))]
+fn get_optimized_wasm(
+    crate_metadata: &CrateMetadata,
+    optimized: &Path,
+    _: &[u8],
+) -> Result<Vec<u8>> {
+    // check `wasm-opt` is installed
+    if which::which("wasm-opt").is_err() {
+        anyhow::bail!(
+            "{}",
+            "wasm-opt is not installed. Install this tool on your system in order to \n\
+             reduce the size of your contract's Wasm binary. \n\
+             See https://github.com/WebAssembly/binaryen#tools"
+                .bright_yellow()
+        );
+    }
+
+    let output = Command::new("wasm-opt")
+        .arg(crate_metadata.dest_wasm.as_os_str())
+        .arg("-O3") // execute -O3 optimization passes (spends potentially a lot of time optimizing)
+        .arg("-o")
+        .arg(optimized.as_os_str())
+        .output()?;
+
+    if !output.status.success() {
+        // Dump the output streams produced by `wasm-opt` into the stdout/stderr.
+        io::stdout().write_all(&output.stdout)?;
+        io::stderr().write_all(&output.stderr)?;
+        anyhow::bail!("wasm-opt optimization failed");
+    }
+    Ok(output.stdout)
 }
 
 /// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -286,7 +286,7 @@ fn optimize_wasm(crate_metadata: &CrateMetadata) -> Result<OptimizationResult> {
 
 /// Optimizes the Wasm supplied as `wasm` using the `binaryen-rs` dependency.
 ///
-/// The supplied `optimization_passes` denotes the number of optimization passes,
+/// The supplied `optimization_level` denotes the number of optimization passes,
 /// resulting in potentially a lot of time spent optimizing.
 ///
 /// If successful, the optimized Wasm is returned as a `Vec<u8>`.
@@ -295,11 +295,11 @@ fn do_optimization(
     _: &CrateMetadata,
     _: &Path,
     wasm: &[u8],
-    optimization_passes: u32,
+    optimization_level: u32,
 ) -> Result<Vec<u8>> {
     let codegen_config = binaryen::CodegenConfig {
         // number of optimization passes (spends potentially a lot of time optimizing)
-        optimization_passes,
+        optimization_level,
         // the default
         shrink_level: 1,
         // the default
@@ -314,7 +314,7 @@ fn do_optimization(
 /// Optimizes the Wasm supplied as `crate_metadata.dest_wasm` using
 /// the `wasm-opt` binary.
 ///
-/// The supplied `optimization_passes` denotes the number of optimization passes,
+/// The supplied `optimization_level` denotes the number of optimization passes,
 /// resulting in potentially a lot of time spent optimizing.
 ///
 /// If successful, the optimized Wasm file is created under `optimized`
@@ -324,7 +324,7 @@ fn do_optimization(
     crate_metadata: &CrateMetadata,
     optimized_dest: &Path,
     _: &[u8],
-    optimization_passes: u32,
+    optimization_level: u32,
 ) -> Result<Vec<u8>> {
     // check `wasm-opt` is installed
     if which::which("wasm-opt").is_err() {
@@ -339,7 +339,7 @@ fn do_optimization(
 
     let output = Command::new("wasm-opt")
         .arg(crate_metadata.dest_wasm.as_os_str())
-        .arg(format!("-O{}", optimization_passes))
+        .arg(format!("-O{}", optimization_level))
         .arg("-o")
         .arg(optimized_dest.as_os_str())
         .output()?;


### PR DESCRIPTION
Closes #113.

Soo, this will get a bit hairy and I expect discussion in this PR.

Our initial idea of using our build script to dynamically enable the `binaryen-rs` dependency based on availability of the `wasm-opt` binary won't work:

>The build script is run (once) after the dependencies are built, so without time travel it can not add dependencies.

(from https://github.com/rust-lang/cargo/issues/5499)

What we could do instead is to install `cargo-contract` either with
* `cargo install --features wasm-opt-unavailable`, if we want to use the `binaryen-rs` dep.
* or via the usual `cargo install`, if the `wasm-opt` binary is available.

This is currently implemented by this PR ‒ if the feature `wasm-opt-unavailable` is enabled the `binaryen-rs` dep is built and used for optimization.

To automate the decision which installation parameters to use we could e.g. build something like the Substrate installation script  (`curl https://getsubstrate.io -sSf | bash`). I'm also not super-happy with this approach, but it's the best workaround I've found so far. Open for other ideas, of course.