### PR TITLE
Add Makefile for new project creation template

### DIFF
--- a/templates/new/Makefile
+++ b/templates/new/Makefile
@@ -1,0 +1,11 @@
+.PHONY: build
+build:
+	cargo +nightly contract build
+
+.PHONY: test
+test:
+	cargo +nightly test
+
+.PHONY: canvas
+canvas:
+	canvas --dev --tmp


### PR DESCRIPTION
When I first worked with smart contracts, I noticed that the testing and build teams are quite long. And I thought, why not collect them in Makefile, to make the work easier. This is already done in the Substrate. I think this idea is not a bad one. Perhaps you can also add more commands.