### PR TITLE
Bring `test-ci-only` back

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,9 +79,7 @@ test:
   stage:                           test
   <<:                              *docker-env
   script:
-    # We are temporarily removing `--all-features` here for the build to succeed
-    # until our substrate dependencies are released in newer versions.
-    - cargo test --verbose --workspace
+    - cargo test --verbose --workspace --all-features
 
 #### stage:                        build (default features)
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,6 +81,11 @@ test:
   script:
     - cargo test --verbose --workspace --all-features
 
+    # we also run the tests with the feature `binaryen-as-dependency` disabled
+    # in order to test that everything also works with a `binaryen` provided
+    # by the system.
+    - cargo test --verbose --workspace --features=test-ci-only
+
 #### stage:                        build (default features)
 
 build:

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -439,7 +439,7 @@ pub(crate) fn execute_with_crate_metadata(
 #[cfg(feature = "test-ci-only")]
 #[cfg(test)]
 mod tests_ci_only {
-    use crate::{cmd, util::tests::with_tmp_dir, BuildArtifacts, ManifestPath, UnstableFlags};
+    use crate::{cmd, util::tests::with_tmp_dir, BuildArtifacts, ManifestPath, UnstableFlags, Verbosity};
 
     #[test]
     fn build_template() {
@@ -449,7 +449,7 @@ mod tests_ci_only {
                 ManifestPath::new(&path.join("new_project").join("Cargo.toml")).unwrap();
             let res = super::execute(
                 &manifest_path,
-                None,
+                Verbosity::Default,
                 true,
                 BuildArtifacts::All,
                 UnstableFlags::default(),
@@ -477,7 +477,7 @@ mod tests_ci_only {
             // when
             super::execute(
                 &manifest_path,
-                None,
+                Verbosity::Default,
                 true,
                 BuildArtifacts::CheckOnly,
                 UnstableFlags::default(),

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -439,7 +439,9 @@ pub(crate) fn execute_with_crate_metadata(
 #[cfg(feature = "test-ci-only")]
 #[cfg(test)]
 mod tests_ci_only {
-    use crate::{cmd, util::tests::with_tmp_dir, BuildArtifacts, ManifestPath, UnstableFlags, Verbosity};
+    use crate::{
+        cmd, util::tests::with_tmp_dir, BuildArtifacts, ManifestPath, UnstableFlags, Verbosity,
+    };
 
     #[test]
     fn build_template() {

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -281,10 +281,7 @@ pub(crate) fn execute(
 #[cfg(test)]
 mod tests {
     use crate::cmd::metadata::blake2_hash;
-    use crate::{
-        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, BuildArtifacts,
-        ManifestPath, UnstableFlags,
-    };
+    use crate::{cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, BuildArtifacts, ManifestPath, UnstableFlags, Verbosity};
     use contract_metadata::*;
     use serde_json::{Map, Value};
     use std::{fmt::Write, fs};
@@ -379,7 +376,7 @@ mod tests {
             let crate_metadata = CrateMetadata::collect(&test_manifest.manifest_path)?;
             let dest_bundle = cmd::metadata::execute(
                 &test_manifest.manifest_path,
-                None,
+                Verbosity::Default,
                 BuildArtifacts::All,
                 UnstableFlags::default(),
             )?

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -281,7 +281,10 @@ pub(crate) fn execute(
 #[cfg(test)]
 mod tests {
     use crate::cmd::metadata::blake2_hash;
-    use crate::{cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, BuildArtifacts, ManifestPath, UnstableFlags, Verbosity};
+    use crate::{
+        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, BuildArtifacts,
+        ManifestPath, UnstableFlags, Verbosity,
+    };
     use contract_metadata::*;
     use serde_json::{Map, Value};
     use std::{fmt::Write, fs};

--- a/templates/new/_Cargo.toml
+++ b/templates/new/_Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc2", default-features = false }
 ink_lang = { version = "3.0.0-rc2", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "{{name}}"


### PR DESCRIPTION
We actually temporarily removed testing our CI with the feature `test-ci-only` in https://github.com/paritytech/cargo-contract/pull/114/files.