### PR TITLE
ink::test attributes in new template

### DIFF
--- a/templates/new/lib.rs
+++ b/templates/new/lib.rs
@@ -52,6 +52,7 @@ mod {{name}} {
         /// Imports all the definitions from the outer scope so we can use them here.
         use super::*;
 
+        /// Imports `ink_lang` so we can use `#[ink::test]`.
         use ink_lang as ink;
 
         /// We test if the default constructor does its job.

--- a/templates/new/lib.rs
+++ b/templates/new/lib.rs
@@ -52,6 +52,8 @@ mod {{name}} {
         /// Imports all the definitions from the outer scope so we can use them here.
         use super::*;
 
+        use ink_lang as ink;
+
         /// We test if the default constructor does its job.
         #[ink::test]
         fn default_works() {

--- a/templates/new/lib.rs
+++ b/templates/new/lib.rs
@@ -53,14 +53,14 @@ mod {{name}} {
         use super::*;
 
         /// We test if the default constructor does its job.
-        #[test]
+        #[ink::test]
         fn default_works() {
             let {{name}} = {{camel_name}}::default();
             assert_eq!({{name}}.get(), false);
         }
 
         /// We test a simple use case of our contract.
-        #[test]
+        #[ink::test]
         fn it_works() {
             let mut {{name}} = {{camel_name}}::new(false);
             assert_eq!({{name}}.get(), false);


### PR DESCRIPTION
Just adding the ink prefix to the test attributes in the new template. Pretty minor, but if you don't notice and you copy the `#[test]` attribute for a more complex test, your test will break in a confusing way.