### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,82 @@
-# Version v0.8.0 (2020-11-27)
+# Changelog
+All notable changes to this project will be documented in this file.
 
-* Exit with 1 on Err [#109](https://github.com/paritytech/cargo-contract/pull/109)
-* Use package name instead of lib name for metadata dependency [#107](https://github.com/paritytech/cargo-contract/pull/107)
-* Do not prettify JSON for bundle [#105](https://github.com/paritytech/cargo-contract/pull/105)
-* Make `source.hash` non-optional, remove metadata-only [#104](https://github.com/paritytech/cargo-contract/pull/104)
-* Implement new commands `build` and `check` + introduce bundles (.contract files) [#97](https://github.com/paritytech/cargo-contract/pull/97)
-* Replace xbuild with cargo build-std [#99](https://github.com/paritytech/cargo-contract/pull/99)
-* Use binaryen-rs as dep instead of requiring manual wasm-opt installation [#95](https://github.com/paritytech/cargo-contract/pull/95)
-* Specify optional --manifest-path for build and generate-metadata [#93](https://github.com/paritytech/cargo-contract/pull/93)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Version v0.7.1 (2020-10-26)
+## [Unreleased]
 
-* Update new command template to ink! 3.0-rc2 [#85](https://github.com/paritytech/cargo-contract/pull/85)
+## [0.9.0] - 2021-02-22
 
-# Version v0.7.0 (2020-10-13)
+### Added
+- Implement Wasm validation for known issues/markers - [#171](https://github.com/paritytech/cargo-contract/pull/171)
 
-* Fix deprecation warnings [#82](https://github.com/paritytech/cargo-contract/pull/82)
-* Use ink 3.0.0-rc1 [#82](https://github.com/paritytech/cargo-contract/pull/82)
-* [template] now uses ink_env and ink_storage [#81](https://github.com/paritytech/cargo-contract/pull/81)
-* Update new command template to ink! 3.0 syntax [#80](https://github.com/paritytech/cargo-contract/pull/80)
-* Extract contract metadata to its own crate [#69](https://github.com/paritytech/cargo-contract/pull/69)
-* Fix ManifestPath compiler errors [#73](https://github.com/paritytech/cargo-contract/pull/73)
-* Upgrade cargo-xbuild and other dependencies [#71](https://github.com/paritytech/cargo-contract/pull/71)
-* Update subxt and async-std dependencies [#66](https://github.com/paritytech/cargo-contract/pull/66)
-* Generate extended contract metadata [#62](https://github.com/paritytech/cargo-contract/pull/62)
-* Autogenerate abi/metadata package [#58](https://github.com/paritytech/cargo-contract/pull/58)
-* Extract workspace to module directory [#59](https://github.com/paritytech/cargo-contract/pull/59)
-* Add preferred default release profile settings [#55](https://github.com/paritytech/cargo-contract/pull/55)
-* Add option to build with unmodified original manifest [#51](https://github.com/paritytech/cargo-contract/pull/51)
-* Update cargo-xbuild [#54](https://github.com/paritytech/cargo-contract/pull/54)
+### Changed
+- Use either `binaryen-rs` dep or `wasm-opt` binary - [#168](https://github.com/paritytech/cargo-contract/pull/168)
+- Update to scale-info 0.5 and codec 2.0 - [#164](https://github.com/paritytech/cargo-contract/pull/164)
+- Put build artifacts under `target/ink/` - [#122](https://github.com/paritytech/cargo-contract/pull/122)
 
-# Version 0.6.1 (2020-05-12)
+### Removed
+
+### Fixed
+- Fix `wasm-opt` regression - [#187](https://github.com/paritytech/cargo-contract/pull/187)
+- Generate metadata explicitly for the contract which is build - [#174](https://github.com/paritytech/cargo-contract/pull/174)
+- Fix bug with empty Wasm file when using system binaryen for optimization - [#179](https://github.com/paritytech/cargo-contract/pull/179)
+- Suppress output on `--quiet` - [#165](https://github.com/paritytech/cargo-contract/pull/165)
+- Do not generate build artifacts under `target` for `check` - [#124](https://github.com/paritytech/cargo-contract/pull/124)
+- update wasm-path usage name - [#135](https://github.com/paritytech/cargo-contract/pull/135)
+
+## [0.8.0] - 2020-11-27
+
+- Exit with 1 on Err [#109](https://github.com/paritytech/cargo-contract/pull/109)
+- Use package name instead of lib name for metadata dependency [#107](https://github.com/paritytech/cargo-contract/pull/107)
+- Do not prettify JSON for bundle [#105](https://github.com/paritytech/cargo-contract/pull/105)
+- Make `source.hash` non-optional, remove metadata-only [#104](https://github.com/paritytech/cargo-contract/pull/104)
+- Implement new commands `build` and `check` + introduce bundles (.contract files) [#97](https://github.com/paritytech/cargo-contract/pull/97)
+- Replace xbuild with cargo build-std [#99](https://github.com/paritytech/cargo-contract/pull/99)
+- Use binaryen-rs as dep instead of requiring manual wasm-opt installation [#95](https://github.com/paritytech/cargo-contract/pull/95)
+- Specify optional --manifest-path for build and generate-metadata [#93](https://github.com/paritytech/cargo-contract/pull/93)
+
+## [0.7.1] - 2020-10-26
+
+- Update new command template to ink! 3.0-rc2 [#85](https://github.com/paritytech/cargo-contract/pull/85)
+
+## [0.7.0] - 2020-10-13
+
+- Fix deprecation warnings [#82](https://github.com/paritytech/cargo-contract/pull/82)
+- Use ink 3.0.0-rc1 [#82](https://github.com/paritytech/cargo-contract/pull/82)
+- [template] now uses ink_env and ink_storage [#81](https://github.com/paritytech/cargo-contract/pull/81)
+- Update new command template to ink! 3.0 syntax [#80](https://github.com/paritytech/cargo-contract/pull/80)
+- Extract contract metadata to its own crate [#69](https://github.com/paritytech/cargo-contract/pull/69)
+- Fix ManifestPath compiler errors [#73](https://github.com/paritytech/cargo-contract/pull/73)
+- Upgrade cargo-xbuild and other dependencies [#71](https://github.com/paritytech/cargo-contract/pull/71)
+- Update subxt and async-std dependencies [#66](https://github.com/paritytech/cargo-contract/pull/66)
+- Generate extended contract metadata [#62](https://github.com/paritytech/cargo-contract/pull/62)
+- Autogenerate abi/metadata package [#58](https://github.com/paritytech/cargo-contract/pull/58)
+- Extract workspace to module directory [#59](https://github.com/paritytech/cargo-contract/pull/59)
+- Add preferred default release profile settings [#55](https://github.com/paritytech/cargo-contract/pull/55)
+- Add option to build with unmodified original manifest [#51](https://github.com/paritytech/cargo-contract/pull/51)
+- Update cargo-xbuild [#54](https://github.com/paritytech/cargo-contract/pull/54)
+
+## [0.6.1] - 2020-05-12
 
 - Fix LTO regressions in nightly toolchain [#52](https://github.com/paritytech/cargo-contract/pull/52)
 
-# Version 0.6.0 (2020-03-25)
+## [0.6.0] - 2020-03-25
 
 - First release to crates.io
 - Use `subxt` release from [crates.io](https://crates.io/crates/substrate-subxt)
 
-# Version 0.5.0 (2020-03-18)
+## [0.5.0] - 2020-03-18
 
 - Upgrades dependencies [#45](https://github.com/paritytech/cargo-contract/pull/45)
 - Update template to ink! 2.0 dependencies [#47](https://github.com/paritytech/cargo-contract/pull/47)
 
-# Version 0.4.1 (2020-02-26)
+## [0.4.1] - 2020-02-26
 
 - Fix: fail the whole build process if the contract build fails.
 
-# Version 0.4.0 (2020-02-26)
+## [0.4.0] - 2020-02-26
 
 - Minimize contract wasm binary size:
   - Run `wasm-opt` on the contract Wasm binary.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cargo-contract"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "metadata"]
 
 [package]
 name = "cargo-contract"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"


### PR DESCRIPTION
### Added
- Implement Wasm validation for known issues/markers - [#171](https://github.com/paritytech/cargo-contract/pull/171)

### Changed
- Use either `binaryen-rs` dep or `wasm-opt` binary - [#168](https://github.com/paritytech/cargo-contract/pull/168)
- Update to scale-info 0.5 and codec 2.0 - [#164](https://github.com/paritytech/cargo-contract/pull/164)
- Put build artifacts under `target/ink/` - [#122](https://github.com/paritytech/cargo-contract/pull/122)

### Fixed
- Fix `wasm-opt` regression - [#187](https://github.com/paritytech/cargo-contract/pull/187)
- Generate metadata explicitly for the contract which is build - [#174](https://github.com/paritytech/cargo-contract/pull/174)
- Fix bug with empty Wasm file when using system binaryen for optimization - [#179](https://github.com/paritytech/cargo-contract/pull/179)
- Suppress output on `--quiet` - [#165](https://github.com/paritytech/cargo-contract/pull/165)
- Do not generate build artifacts under `target` for `check` - [#124](https://github.com/paritytech/cargo-contract/pull/124)
- update wasm-path usage name - [#135](https://github.com/paritytech/cargo-contract/pull/135)