### PR TITLE
Fix linker error when building complex contracts

### DIFF
--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -29,10 +29,7 @@ use contract_metadata::{
     SourceLanguage, SourceWasm, User,
 };
 use semver::Version;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::PathBuf};
 use url::Url;
 
 const METADATA_FILE: &str = "metadata.json";
@@ -123,12 +120,6 @@ impl GenerateMetadataCommand {
         if self.unstable_options.original_manifest {
             generate_metadata(&self.crate_metadata.manifest_path)?;
         } else {
-            let manifest_dir = match self.crate_metadata.manifest_path.directory() {
-                Some(dir) => dir,
-                None => Path::new("./"),
-            };
-            let absolute_package_path = manifest_dir.canonicalize()?;
-
             Workspace::new(
                 &self.crate_metadata.cargo_meta,
                 &self.crate_metadata.root_package.id,
@@ -139,7 +130,7 @@ impl GenerateMetadataCommand {
                     .with_profile_release_lto(false)?;
                 Ok(())
             })?
-            .with_metadata_gen_package(absolute_package_path)?
+            .with_metadata_gen_package(util::absolute_path(&self.crate_metadata.manifest_path)?)?
             .using_temp(generate_metadata)?;
         }
 

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -130,7 +130,7 @@ impl GenerateMetadataCommand {
                     .with_profile_release_lto(false)?;
                 Ok(())
             })?
-            .with_metadata_gen_package(util::absolute_path(&self.crate_metadata.manifest_path)?)?
+            .with_metadata_gen_package(self.crate_metadata.manifest_path.absolute_directory()?)?
             .using_temp(generate_metadata)?;
         }
 

--- a/src/crate_metadata.rs
+++ b/src/crate_metadata.rs
@@ -15,7 +15,6 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::ManifestPath;
-
 use anyhow::{Context, Result};
 use cargo_metadata::{Metadata as CargoMetadata, MetadataCommand, Package};
 use semver::Version;

--- a/src/crate_metadata.rs
+++ b/src/crate_metadata.rs
@@ -49,7 +49,8 @@ impl CrateMetadata {
         let package_name = root_package.name.replace("-", "_");
 
         let absolute_manifest_path = manifest_path.absolute_directory()?;
-        if absolute_manifest_path != metadata.workspace_root {
+        let absolute_workspace_root = metadata.workspace_root.canonicalize()?;
+        if absolute_manifest_path != absolute_workspace_root {
             target_directory = target_directory.join(package_name.clone());
         }
 

--- a/src/crate_metadata.rs
+++ b/src/crate_metadata.rs
@@ -14,15 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::util;
 use crate::ManifestPath;
+
 use anyhow::{Context, Result};
 use cargo_metadata::{Metadata as CargoMetadata, MetadataCommand, Package};
 use semver::Version;
 use serde_json::{Map, Value};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::PathBuf};
 use toml::value;
 use url::Url;
 
@@ -51,11 +50,7 @@ impl CrateMetadata {
         // Normalize the package name.
         let package_name = root_package.name.replace("-", "_");
 
-        let manifest_dir = match manifest_path.directory() {
-            Some(dir) => dir,
-            None => Path::new("./"),
-        };
-        let absolute_manifest_path = manifest_dir.canonicalize()?;
+        let absolute_manifest_path = util::absolute_path(&manifest_path)?;
         if absolute_manifest_path != metadata.workspace_root {
             target_directory = target_directory.join(package_name.clone());
         }

--- a/src/crate_metadata.rs
+++ b/src/crate_metadata.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::util;
 use crate::ManifestPath;
 
 use anyhow::{Context, Result};
@@ -50,7 +49,7 @@ impl CrateMetadata {
         // Normalize the package name.
         let package_name = root_package.name.replace("-", "_");
 
-        let absolute_manifest_path = util::absolute_path(&manifest_path)?;
+        let absolute_manifest_path = manifest_path.absolute_directory()?;
         if absolute_manifest_path != metadata.workspace_root {
             target_directory = target_directory.join(package_name.clone());
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,16 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::workspace::ManifestPath;
 use crate::Verbosity;
 
 use anyhow::{Context, Result};
 use rustc_version::Channel;
-use std::{
-    ffi::OsStr,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{ffi::OsStr, path::Path, process::Command};
 
 /// Check whether the current rust channel is valid: `nightly` is recommended.
 pub fn assert_channel() -> Result<()> {
@@ -98,15 +93,6 @@ pub(crate) fn base_name(path: &Path) -> &str {
         .expect("must be valid utf-8")
 }
 
-/// Returns the absolute path to the manifest directory.
-pub(crate) fn absolute_path(manifest_path: &ManifestPath) -> Result<PathBuf, std::io::Error> {
-    let directory = match manifest_path.directory() {
-        Some(dir) => dir,
-        None => Path::new("./"),
-    };
-    directory.canonicalize()
-}
-
 /// Prints to stdout if `verbosity.is_verbose()` is `true`.
 #[macro_export]
 macro_rules! maybe_println {
@@ -119,8 +105,7 @@ macro_rules! maybe_println {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::workspace::ManifestPath;
-    use std::{fs, path::Path};
+    use std::path::Path;
 
     pub fn with_tmp_dir<F>(f: F)
     where
@@ -133,24 +118,5 @@ pub mod tests {
 
         // catch test panics in order to clean up temp dir which will be very large
         f(tmp_dir.path()).expect("Error executing test with tmp dir")
-    }
-
-    #[test]
-    fn must_return_absolute_path_from_absolute_path() {
-        with_tmp_dir(|path| {
-            // given
-            let cargo_toml_path = path.join("Cargo.toml");
-            let _ = fs::File::create(&cargo_toml_path).expect("file creation failed");
-            let manifest_path =
-                ManifestPath::new(cargo_toml_path).expect("manifest path creation failed");
-
-            // when
-            let absolute_path =
-                super::absolute_path(&manifest_path).expect("absolute path extraction failed");
-
-            // then
-            assert_eq!(absolute_path.as_path(), path);
-            Ok(())
-        })
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,7 +15,6 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::Verbosity;
-
 use anyhow::{Context, Result};
 use rustc_version::Channel;
 use std::{ffi::OsStr, path::Path, process::Command};

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,10 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::workspace::ManifestPath;
 use crate::Verbosity;
+
 use anyhow::{Context, Result};
 use rustc_version::Channel;
-use std::{ffi::OsStr, path::Path, process::Command};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 /// Check whether the current rust channel is valid: `nightly` is recommended.
 pub fn assert_channel() -> Result<()> {
@@ -92,6 +98,15 @@ pub(crate) fn base_name(path: &Path) -> &str {
         .expect("must be valid utf-8")
 }
 
+/// Returns the absolute path to the manifest directory.
+pub(crate) fn absolute_path(manifest_path: &ManifestPath) -> Result<PathBuf, std::io::Error> {
+    let directory = match manifest_path.directory() {
+        Some(dir) => dir,
+        None => Path::new("./"),
+    };
+    directory.canonicalize()
+}
+
 /// Prints to stdout if `verbosity.is_verbose()` is `true`.
 #[macro_export]
 macro_rules! maybe_println {
@@ -104,7 +119,8 @@ macro_rules! maybe_println {
 
 #[cfg(test)]
 pub mod tests {
-    use std::path::Path;
+    use crate::workspace::ManifestPath;
+    use std::{fs, path::Path};
 
     pub fn with_tmp_dir<F>(f: F)
     where
@@ -117,5 +133,24 @@ pub mod tests {
 
         // catch test panics in order to clean up temp dir which will be very large
         f(tmp_dir.path()).expect("Error executing test with tmp dir")
+    }
+
+    #[test]
+    fn must_return_absolute_path_from_absolute_path() {
+        with_tmp_dir(|path| {
+            // given
+            let cargo_toml_path = path.join("Cargo.toml");
+            let _ = fs::File::create(&cargo_toml_path).expect("file creation failed");
+            let manifest_path =
+                ManifestPath::new(cargo_toml_path).expect("manifest path creation failed");
+
+            // when
+            let absolute_path =
+                super::absolute_path(&manifest_path).expect("absolute path extraction failed");
+
+            // then
+            assert_eq!(absolute_path.as_path(), path);
+            Ok(())
+        })
     }
 }


### PR DESCRIPTION
Closes https://github.com/paritytech/cargo-contract/issues/198 and https://github.com/paritytech/ink/issues/701.

My understanding is that the linker error was a result of conflicting build artifacts in the `target` directory. 

The root contract is build with the `ink-as-dependency` feature enabled for sub-contracts, whereas the sub-contracts are build without this flag. This results in the external function `__ink_generate_metadata` (which is only build when `ink-as-dependency` is disabled) not being available in the artifacts, but cargo still tries to reuse the artifacts. Hence the linker error.

I fixed it now by building sub-contracts into sub-folders of `target/ink/`. This way all artifacts are separate.