### PR TITLE
Fix `cargo contract new` template build

### DIFF
--- a/templates/new/_Cargo.toml
+++ b/templates/new/_Cargo.toml
@@ -14,6 +14,9 @@ ink_lang = { version = "3.0.0-rc2", default-features = false }
 scale = { package = "parity-scale-codec", version = "2.0.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
 
+# Should be removed once bitvecto-rs/bitvec#105 is resolved
+funty = "=1.1.0"
+
 [lib]
 name = "{{name}}"
 path = "lib.rs"

--- a/templates/new/_Cargo.toml
+++ b/templates/new/_Cargo.toml
@@ -5,11 +5,11 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc2", default-features = false }
-ink_metadata = { version = "3.0.0-rc2", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc2", default-features = false }
-ink_storage = { version = "3.0.0-rc2", default-features = false }
-ink_lang = { version = "3.0.0-rc2", default-features = false }
+ink_primitives = { version = "3.0.0-rc3", default-features = false }
+ink_metadata = { version = "3.0.0-rc3", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc3", default-features = false }
+ink_storage = { version = "3.0.0-rc3", default-features = false }
+ink_lang = { version = "3.0.0-rc3", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }

--- a/templates/new/_Cargo.toml
+++ b/templates/new/_Cargo.toml
@@ -12,7 +12,7 @@ ink_storage = { version = "3.0.0-rc3", default-features = false }
 ink_lang = { version = "3.0.0-rc3", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.0.1", default-features = false, features = ["derive"] }
-scale-info = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # Should be removed once bitvecto-rs/bitvec#105 is resolved
 funty = "=1.1.0"

--- a/templates/new/_Cargo.toml
+++ b/templates/new/_Cargo.toml
@@ -11,7 +11,7 @@ ink_env = { version = "3.0.0-rc2", default-features = false }
 ink_storage = { version = "3.0.0-rc2", default-features = false }
 ink_lang = { version = "3.0.0-rc2", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive"] }
+scale = { package = "parity-scale-codec", version = "2.0.1", default-features = false, features = ["derive"] }
 scale-info = { version = "0.5.0", default-features = false, features = ["derive"], optional = true }
 
 [lib]


### PR DESCRIPTION
Closes https://github.com/paritytech/ink/issues/705.

We have a test for `cargo contract new`, but the test is currently not run in CI. I've created https://github.com/paritytech/cargo-contract/pull/180 to fix this. This PR here is a pre-requirement to make the test run in CI again though. So after we have merged this PR I can update the other one.