### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2021-03-02
+
+### Fixed
+- no periods in new contract names - [#192](https://github.com/paritytech/cargo-contract/pull/192)
+
+### Changed
+- Update `cargo contract new` template dependencies for `ink!` `rc3` - [#204](https://github.
+  com/paritytech/cargo-contract/pull/204)
+
 ## [0.9.1] - 2021-02-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - no periods in new contract names - [#192](https://github.com/paritytech/cargo-contract/pull/192)
 
 ### Changed
-- Update `cargo contract new` template dependencies for `ink!` `rc3` - [#204](https://github.
-  com/paritytech/cargo-contract/pull/204)
+- Update `cargo contract new` template dependencies for `ink!` `rc3` - [#204](https://github.com/paritytech/cargo-contract/pull/204)
 
 ## [0.9.1] - 2021-02-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cargo-contract"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "metadata"]
 
 [package]
 name = "cargo-contract"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"


### PR DESCRIPTION
### Fixed
- no periods in new contract names - [#192](https://github.com/paritytech/cargo-contract/pull/192)

### Changed
- Update `cargo contract new` template dependencies for `ink!` `rc3` - [#204](https://github.com/paritytech/cargo-contract/pull/204)