### PR TITLE
Only allow new contract names beginning with an alphabetic character

### DIFF
--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -31,6 +31,10 @@ where
         anyhow::bail!("Contract names can only contain alphanumeric characters and underscores");
     }
 
+    if !name.chars().next().map(|c| c.is_alphabetic()).unwrap_or(false) {
+        anyhow::bail!("Contract names must begin with an alphabetic character");
+    }
+
     let out_dir = dir
         .map_or(env::current_dir()?, |p| p.as_ref().to_path_buf())
         .join(name);

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -31,7 +31,12 @@ where
         anyhow::bail!("Contract names can only contain alphanumeric characters and underscores");
     }
 
-    if !name.chars().next().map(|c| c.is_alphabetic()).unwrap_or(false) {
+    if !name
+        .chars()
+        .next()
+        .map(|c| c.is_alphabetic())
+        .unwrap_or(false)
+    {
         anyhow::bail!("Contract names must begin with an alphabetic character");
     }
 

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -132,6 +132,19 @@ mod tests {
     }
 
     #[test]
+    fn rejects_name_beginning_with_number() {
+        with_tmp_dir(|path| {
+            let result = execute("1xxx", Some(path));
+            assert!(result.is_err(), "Should fail");
+            assert_eq!(
+                result.err().unwrap().to_string(),
+                "Contract names must begin with an alphabetic character"
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
     fn contract_cargo_project_already_exists() {
         with_tmp_dir(|path| {
             let name = "test_contract_cargo_project_already_exists";


### PR DESCRIPTION
Fixes #218 