### PR TITLE
Refactor build command

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -412,7 +412,7 @@ pub(crate) fn execute(
             format!("[3/{}]", build_artifact.steps()).bold(),
             "Optimizing wasm file".bright_green().bold()
         );
-        let optimization_result = optimize_wasm(&crate_metadata)?;
+        let optimization_result = optimize_wasm(&crate_metadata, optimization_passes)?;
 
         Ok(optimization_result)
     };

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -371,7 +371,7 @@ fn do_optimization(
 /// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.
 ///
 /// It does so by invoking `cargo build` and then post processing the final binary.
-fn execute(
+pub(crate) fn execute(
     manifest_path: &ManifestPath,
     verbosity: Verbosity,
     build_artifact: BuildArtifacts,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -448,7 +448,7 @@ mod tests_ci_only {
     };
 
     #[test]
-    fn build_template() {
+    fn build_code_only() {
         with_tmp_dir(|path| {
             cmd::new::execute("new_project", Some(path)).expect("new project creation failed");
             let manifest_path =
@@ -456,7 +456,7 @@ mod tests_ci_only {
             let res = super::execute(
                 &manifest_path,
                 Verbosity::Default,
-                BuildArtifacts::All,
+                BuildArtifacts::CodeOnly,
                 UnstableFlags::default(),
             )
             .expect("build failed");
@@ -468,6 +468,11 @@ mod tests_ci_only {
             // we also can't match for `/ink` here, since this would match
             // for `/ink` being the root path.
             assert!(res.target_directory.ends_with("ink"));
+
+            assert!(
+                res.metadata_result.is_none(),
+                "CodeOnly should not generate the metadata"
+            );
 
             let optimized_size = res.optimization_result.unwrap().optimized_size;
             assert!(optimized_size > 0.0);

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -224,10 +224,7 @@ fn blake2_hash(code: &[u8]) -> CodeHash {
 #[cfg(test)]
 mod tests {
     use crate::cmd::metadata::blake2_hash;
-    use crate::{
-        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, ManifestPath, UnstableFlags,
-        Verbosity,
-    };
+    use crate::{cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, ManifestPath, UnstableFlags, Verbosity, BuildArtifacts};
     use contract_metadata::*;
     use serde_json::{Map, Value};
     use std::{fmt::Write, fs};
@@ -326,14 +323,15 @@ mod tests {
             fs::create_dir_all(final_contract_wasm_path.parent().unwrap()).unwrap();
             fs::write(final_contract_wasm_path, "TEST FINAL WASM BLOB").unwrap();
 
-            let dest_bundle = cmd::metadata::execute(
-                &crate_metadata,
-                &final_contract_wasm_path,
+            let build_result = cmd::build::execute(
+                &test_manifest.manifest_path,
                 Verbosity::Default,
-                5,
-                &UnstableFlags::default(),
-            )?
-            .dest_bundle;
+                BuildArtifacts::All,
+                UnstableFlags::default(),
+            )?;
+            let dest_bundle = build_result.metadata_result
+                .expect("Metadata should be generated")
+                .dest_bundle;
 
             let metadata_json: Map<String, Value> =
                 serde_json::from_slice(&fs::read(&dest_bundle)?)?;

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -135,7 +135,10 @@ pub(crate) fn execute(
             .using_temp(generate_metadata)?;
     }
 
-    Ok(MetadataResult { dest_metadata: out_path_metadata, dest_bundle: out_path_bundle })
+    Ok(MetadataResult {
+        dest_metadata: out_path_metadata,
+        dest_bundle: out_path_bundle,
+    })
 }
 
 /// Generate the extended contract project metadata
@@ -222,8 +225,8 @@ fn blake2_hash(code: &[u8]) -> CodeHash {
 mod tests {
     use crate::cmd::metadata::blake2_hash;
     use crate::{
-        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir,
-        ManifestPath, UnstableFlags, Verbosity,
+        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, ManifestPath, UnstableFlags,
+        Verbosity,
     };
     use contract_metadata::*;
     use serde_json::{Map, Value};

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -18,7 +18,7 @@ use crate::{
     crate_metadata::CrateMetadata,
     maybe_println, util,
     workspace::{ManifestPath, Workspace},
-    BuildArtifacts, BuildResult, OptimizationResult, UnstableFlags, Verbosity,
+    UnstableFlags, Verbosity,
 };
 
 use anyhow::Result;
@@ -29,223 +29,172 @@ use contract_metadata::{
     SourceLanguage, SourceWasm, User,
 };
 use semver::Version;
-use std::{fs, path::PathBuf};
+use std::{fs, path::{PathBuf, Path}};
 use url::Url;
 
 const METADATA_FILE: &str = "metadata.json";
 
-/// Executes the metadata generation process
-struct GenerateMetadataCommand {
-    crate_metadata: CrateMetadata,
-    verbosity: Verbosity,
-    build_artifact: BuildArtifacts,
-    unstable_options: UnstableFlags,
-}
-
 /// Result of generating the extended contract project metadata
 struct ExtendedMetadataResult {
-    dest_wasm: Option<PathBuf>,
     source: Source,
     contract: Contract,
     user: Option<User>,
-    optimization_result: Option<OptimizationResult>,
 }
 
-impl GenerateMetadataCommand {
-    pub fn exec(&self) -> Result<BuildResult> {
-        util::assert_channel()?;
+/// Generates a file with metadata describing the ABI of the smart-contract.
+///
+/// It does so by generating and invoking a temporary workspace member.
+pub(crate) fn execute(
+    crate_metadata: &CrateMetadata,
+    final_contract_wasm: &Path,
+    verbosity: Verbosity,
+    unstable_options: &UnstableFlags,
+) -> Result<(PathBuf, PathBuf)> {
+    util::assert_channel()?;
 
-        let target_directory = self.crate_metadata.target_directory.clone();
-        let out_path_metadata = target_directory.join(METADATA_FILE);
+    let target_directory = crate_metadata.target_directory.clone();
+    let out_path_metadata = target_directory.join(METADATA_FILE);
 
-        let fname_bundle = format!("{}.contract", self.crate_metadata.package_name);
-        let out_path_bundle = target_directory.join(fname_bundle);
+    let fname_bundle = format!("{}.contract", crate_metadata.package_name);
+    let out_path_bundle = target_directory.join(fname_bundle);
 
-        // build the extended contract project metadata
-        let ExtendedMetadataResult {
-            dest_wasm,
-            source,
-            contract,
-            user,
-            optimization_result,
-        } = self.extended_metadata()?;
+    // build the extended contract project metadata
+    let ExtendedMetadataResult {
+        source,
+        contract,
+        user,
+    } = extended_metadata(crate_metadata, final_contract_wasm)?;
 
-        let generate_metadata = |manifest_path: &ManifestPath| -> Result<()> {
-            let mut current_progress = 4;
-            maybe_println!(
-                self.verbosity,
-                " {} {}",
-                format!("[{}/{}]", current_progress, self.build_artifact.steps()).bold(),
-                "Generating metadata".bright_green().bold()
-            );
-            let target_dir_arg = format!("--target-dir={}", target_directory.to_string_lossy());
-            let stdout = util::invoke_cargo(
-                "run",
-                &[
-                    "--package",
-                    "metadata-gen",
-                    &manifest_path.cargo_arg(),
-                    &target_dir_arg,
-                    "--release",
-                ],
-                self.crate_metadata.manifest_path.directory(),
-                self.verbosity,
-            )?;
-
-            let ink_meta: serde_json::Map<String, serde_json::Value> =
-                serde_json::from_slice(&stdout)?;
-            let metadata = ContractMetadata::new(source, contract, user, ink_meta);
-            {
-                let mut metadata = metadata.clone();
-                metadata.remove_source_wasm_attribute();
-                let contents = serde_json::to_string_pretty(&metadata)?;
-                fs::write(&out_path_metadata, contents)?;
-                current_progress += 1;
-            }
-
-            if self.build_artifact == BuildArtifacts::All {
-                maybe_println!(
-                    self.verbosity,
-                    " {} {}",
-                    format!("[{}/{}]", current_progress, self.build_artifact.steps()).bold(),
-                    "Generating bundle".bright_green().bold()
-                );
-                let contents = serde_json::to_string(&metadata)?;
-                fs::write(&out_path_bundle, contents)?;
-            }
-
-            Ok(())
-        };
-
-        if self.unstable_options.original_manifest {
-            generate_metadata(&self.crate_metadata.manifest_path)?;
-        } else {
-            Workspace::new(
-                &self.crate_metadata.cargo_meta,
-                &self.crate_metadata.root_package.id,
-            )?
-            .with_root_package_manifest(|manifest| {
-                manifest
-                    .with_added_crate_type("rlib")?
-                    .with_profile_release_lto(false)?;
-                Ok(())
-            })?
-            .with_metadata_gen_package(self.crate_metadata.manifest_path.absolute_directory()?)?
-            .using_temp(generate_metadata)?;
-        }
-
-        let dest_bundle = if self.build_artifact == BuildArtifacts::All {
-            Some(out_path_bundle)
-        } else {
-            None
-        };
-        Ok(BuildResult {
-            dest_metadata: Some(out_path_metadata),
-            dest_wasm,
-            dest_bundle,
-            optimization_result,
-            target_directory,
-            build_artifact: self.build_artifact,
-            verbosity: self.verbosity,
-        })
-    }
-
-    /// Generate the extended contract project metadata
-    fn extended_metadata(&self) -> Result<ExtendedMetadataResult> {
-        let contract_package = &self.crate_metadata.root_package;
-        let ink_version = &self.crate_metadata.ink_version;
-        let rust_version = Version::parse(&rustc_version::version()?.to_string())?;
-        let contract_name = contract_package.name.clone();
-        let contract_version = Version::parse(&contract_package.version.to_string())?;
-        let contract_authors = contract_package.authors.clone();
-        // optional
-        let description = contract_package.description.clone();
-        let documentation = self.crate_metadata.documentation.clone();
-        let repository = contract_package
-            .repository
-            .as_ref()
-            .map(|repo| Url::parse(&repo))
-            .transpose()?;
-        let homepage = self.crate_metadata.homepage.clone();
-        let license = contract_package.license.clone();
-        let (dest_wasm, hash, optimization_result) = self.wasm_hash()?;
-        let source = {
-            let lang = SourceLanguage::new(Language::Ink, ink_version.clone());
-            let compiler = SourceCompiler::new(Compiler::RustC, rust_version);
-            let maybe_wasm = if self.build_artifact == BuildArtifacts::All {
-                let wasm = fs::read(&self.crate_metadata.dest_wasm)?;
-                // The Wasm which we read must have the same hash as `source.hash`
-                debug_assert!({
-                    let expected = blake2_hash(wasm.as_slice());
-                    expected == hash
-                });
-                Some(SourceWasm::new(wasm))
-            } else {
-                None
-            };
-            Source::new(maybe_wasm, hash, lang, compiler)
-        };
-
-        // Required contract fields
-        let mut builder = Contract::builder();
-        builder
-            .name(contract_name)
-            .version(contract_version)
-            .authors(contract_authors);
-
-        if let Some(description) = description {
-            builder.description(description);
-        }
-
-        if let Some(documentation) = documentation {
-            builder.documentation(documentation);
-        }
-
-        if let Some(repository) = repository {
-            builder.repository(repository);
-        }
-
-        if let Some(homepage) = homepage {
-            builder.homepage(homepage);
-        }
-
-        if let Some(license) = license {
-            builder.license(license);
-        }
-
-        let contract = builder
-            .build()
-            .map_err(|err| anyhow::anyhow!("Invalid contract metadata builder state: {}", err))?;
-
-        // user defined metadata
-        let user = self.crate_metadata.user.clone().map(User::new);
-
-        Ok(ExtendedMetadataResult {
-            dest_wasm: Some(dest_wasm),
-            source,
-            contract,
-            user,
-            optimization_result: Some(optimization_result),
-        })
-    }
-
-    /// Compile the contract and then hash the resulting Wasm.
-    ///
-    /// Return a tuple of `(dest_wasm, hash, optimization_result)`.
-    fn wasm_hash(&self) -> Result<(PathBuf, CodeHash, OptimizationResult)> {
-        let (maybe_dest_wasm, maybe_optimization_res) = super::build::execute_with_crate_metadata(
-            &self.crate_metadata,
-            self.verbosity,
-            true, // for the hash we always use the optimized version of the contract
-            self.build_artifact,
-            self.unstable_options.clone(),
+    let generate_metadata = |manifest_path: &ManifestPath| -> Result<()> {
+        let mut current_progress = 4;
+        maybe_println!(
+            verbosity,
+            " {} {}",
+            format!("[{}/{}]", current_progress, 5).bold(),
+            "Generating metadata".bright_green().bold()
+        );
+        let target_dir_arg = format!("--target-dir={}", target_directory.to_string_lossy());
+        let stdout = util::invoke_cargo(
+            "run",
+            &[
+                "--package",
+                "metadata-gen",
+                &manifest_path.cargo_arg(),
+                &target_dir_arg,
+                "--release",
+            ],
+            crate_metadata.manifest_path.directory(),
+            verbosity,
         )?;
 
-        let wasm = fs::read(&self.crate_metadata.dest_wasm)?;
-        let dest_wasm = maybe_dest_wasm.expect("dest wasm must exist");
-        let optimization_res = maybe_optimization_res.expect("optimization result must exist");
-        Ok((dest_wasm, blake2_hash(wasm.as_slice()), optimization_res))
+        let ink_meta: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_slice(&stdout)?;
+        let metadata = ContractMetadata::new(source, contract, user, ink_meta);
+        {
+            let mut metadata = metadata.clone();
+            metadata.remove_source_wasm_attribute();
+            let contents = serde_json::to_string_pretty(&metadata)?;
+            fs::write(&out_path_metadata, contents)?;
+            current_progress += 1;
+        }
+
+        maybe_println!(
+            verbosity,
+            " {} {}",
+            format!("[{}/{}]", current_progress, 5).bold(),
+            "Generating bundle".bright_green().bold()
+        );
+        let contents = serde_json::to_string(&metadata)?;
+        fs::write(&out_path_bundle, contents)?;
+
+        Ok(())
+    };
+
+    if unstable_options.original_manifest {
+        generate_metadata(&crate_metadata.manifest_path)?;
+    } else {
+        Workspace::new(
+            &crate_metadata.cargo_meta,
+            &crate_metadata.root_package.id,
+        )?
+        .with_root_package_manifest(|manifest| {
+            manifest
+                .with_added_crate_type("rlib")?
+                .with_profile_release_lto(false)?;
+            Ok(())
+        })?
+        .with_metadata_gen_package(crate_metadata.manifest_path.absolute_directory()?)?
+        .using_temp(generate_metadata)?;
     }
+
+    Ok((out_path_metadata, out_path_bundle))
+}
+
+/// Generate the extended contract project metadata
+fn extended_metadata(crate_metadata: &CrateMetadata, final_contract_wasm: &Path) -> Result<ExtendedMetadataResult> {
+    let contract_package = &crate_metadata.root_package;
+    let ink_version = &crate_metadata.ink_version;
+    let rust_version = Version::parse(&rustc_version::version()?.to_string())?;
+    let contract_name = contract_package.name.clone();
+    let contract_version = Version::parse(&contract_package.version.to_string())?;
+    let contract_authors = contract_package.authors.clone();
+    // optional
+    let description = contract_package.description.clone();
+    let documentation = crate_metadata.documentation.clone();
+    let repository = contract_package
+        .repository
+        .as_ref()
+        .map(|repo| Url::parse(&repo))
+        .transpose()?;
+    let homepage = crate_metadata.homepage.clone();
+    let license = contract_package.license.clone();
+    let source = {
+        let lang = SourceLanguage::new(Language::Ink, ink_version.clone());
+        let compiler = SourceCompiler::new(Compiler::RustC, rust_version);
+        let wasm = fs::read(final_contract_wasm)?;
+        let hash = blake2_hash(wasm.as_slice());
+        Source::new(Some(SourceWasm::new(wasm)), hash, lang, compiler)
+    };
+
+    // Required contract fields
+    let mut builder = Contract::builder();
+    builder
+        .name(contract_name)
+        .version(contract_version)
+        .authors(contract_authors);
+
+    if let Some(description) = description {
+        builder.description(description);
+    }
+
+    if let Some(documentation) = documentation {
+        builder.documentation(documentation);
+    }
+
+    if let Some(repository) = repository {
+        builder.repository(repository);
+    }
+
+    if let Some(homepage) = homepage {
+        builder.homepage(homepage);
+    }
+
+    if let Some(license) = license {
+        builder.license(license);
+    }
+
+    let contract = builder
+        .build()
+        .map_err(|err| anyhow::anyhow!("Invalid contract metadata builder state: {}", err))?;
+
+    // user defined metadata
+    let user = crate_metadata.user.clone().map(User::new);
+
+    Ok(ExtendedMetadataResult {
+        source,
+        contract,
+        user,
+    })
 }
 
 /// Returns the blake2 hash of the submitted slice.
@@ -255,26 +204,6 @@ fn blake2_hash(code: &[u8]) -> CodeHash {
     blake2.update(code);
     blake2.finalize_variable(|result| output.copy_from_slice(result));
     CodeHash(output)
-}
-
-/// Generates a file with metadata describing the ABI of the smart-contract.
-///
-/// It does so by generating and invoking a temporary workspace member.
-pub(crate) fn execute(
-    manifest_path: &ManifestPath,
-    verbosity: Verbosity,
-    build_artifact: BuildArtifacts,
-    unstable_options: UnstableFlags,
-) -> Result<BuildResult> {
-    let crate_metadata = CrateMetadata::collect(manifest_path)?;
-    let res = GenerateMetadataCommand {
-        crate_metadata,
-        verbosity,
-        build_artifact,
-        unstable_options,
-    }
-    .exec()?;
-    Ok(res)
 }
 
 #[cfg(feature = "test-ci-only")]
@@ -377,10 +306,15 @@ mod tests {
             test_manifest.write()?;
 
             let crate_metadata = CrateMetadata::collect(&test_manifest.manifest_path)?;
+
+            // usually this file will be produced by a previous build step
+            let final_contract_wasm_path = crate_metadata.dest_wasm;
+            fs::write(final_contract_wasm_path, "TEST FINAL WASM BLOB");
+
             let dest_bundle = cmd::metadata::execute(
-                &test_manifest.manifest_path,
+                &crate_metadata,
+                &final_contract_wasm_path,
                 Verbosity::Default,
-                BuildArtifacts::All,
                 UnstableFlags::default(),
             )?
             .dest_bundle

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -224,7 +224,10 @@ fn blake2_hash(code: &[u8]) -> CodeHash {
 #[cfg(test)]
 mod tests {
     use crate::cmd::metadata::blake2_hash;
-    use crate::{cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, ManifestPath, UnstableFlags, Verbosity, BuildArtifacts};
+    use crate::{
+        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, BuildArtifacts,
+        ManifestPath, UnstableFlags, Verbosity,
+    };
     use contract_metadata::*;
     use serde_json::{Map, Value};
     use std::{fmt::Write, fs};
@@ -329,7 +332,8 @@ mod tests {
                 BuildArtifacts::All,
                 UnstableFlags::default(),
             )?;
-            let dest_bundle = build_result.metadata_result
+            let dest_bundle = build_result
+                .metadata_result
                 .expect("Metadata should be generated")
                 .dest_bundle;
 

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -18,7 +18,7 @@ use crate::{
     crate_metadata::CrateMetadata,
     maybe_println, util,
     workspace::{ManifestPath, Workspace},
-    OptimizationPasses, UnstableFlags, Verbosity,
+    UnstableFlags, Verbosity,
 };
 
 use anyhow::Result;

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -323,6 +323,7 @@ mod tests {
 
             // usually this file will be produced by a previous build step
             let final_contract_wasm_path = &crate_metadata.dest_wasm;
+            fs::create_dir_all(final_contract_wasm_path.parent().unwrap()).unwrap();
             fs::write(final_contract_wasm_path, "TEST FINAL WASM BLOB").unwrap();
 
             let dest_bundle = cmd::metadata::execute(

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -29,7 +29,10 @@ use contract_metadata::{
     SourceLanguage, SourceWasm, User,
 };
 use semver::Version;
-use std::{fs, path::{PathBuf, Path}};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use url::Url;
 
 const METADATA_FILE: &str = "metadata.json";
@@ -87,8 +90,7 @@ pub(crate) fn execute(
             verbosity,
         )?;
 
-        let ink_meta: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_slice(&stdout)?;
+        let ink_meta: serde_json::Map<String, serde_json::Value> = serde_json::from_slice(&stdout)?;
         let metadata = ContractMetadata::new(source, contract, user, ink_meta);
         {
             let mut metadata = metadata.clone();
@@ -113,25 +115,25 @@ pub(crate) fn execute(
     if unstable_options.original_manifest {
         generate_metadata(&crate_metadata.manifest_path)?;
     } else {
-        Workspace::new(
-            &crate_metadata.cargo_meta,
-            &crate_metadata.root_package.id,
-        )?
-        .with_root_package_manifest(|manifest| {
-            manifest
-                .with_added_crate_type("rlib")?
-                .with_profile_release_lto(false)?;
-            Ok(())
-        })?
-        .with_metadata_gen_package(crate_metadata.manifest_path.absolute_directory()?)?
-        .using_temp(generate_metadata)?;
+        Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
+            .with_root_package_manifest(|manifest| {
+                manifest
+                    .with_added_crate_type("rlib")?
+                    .with_profile_release_lto(false)?;
+                Ok(())
+            })?
+            .with_metadata_gen_package(crate_metadata.manifest_path.absolute_directory()?)?
+            .using_temp(generate_metadata)?;
     }
 
     Ok((out_path_metadata, out_path_bundle))
 }
 
 /// Generate the extended contract project metadata
-fn extended_metadata(crate_metadata: &CrateMetadata, final_contract_wasm: &Path) -> Result<ExtendedMetadataResult> {
+fn extended_metadata(
+    crate_metadata: &CrateMetadata,
+    final_contract_wasm: &Path,
+) -> Result<ExtendedMetadataResult> {
     let contract_package = &crate_metadata.root_package;
     let ink_version = &crate_metadata.ink_version;
     let rust_version = Version::parse(&rustc_version::version()?.to_string())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,10 @@ mod workspace;
 
 use self::workspace::ManifestPath;
 
-use crate::cmd::{BuildCommand, CheckCommand};
+use crate::cmd::{
+    BuildCommand, CheckCommand,
+    metadata::MetadataResult,
+};
 
 #[cfg(feature = "extrinsics")]
 use sp_core::{crypto::Pair, sr25519, H256};
@@ -206,12 +209,10 @@ impl std::str::FromStr for BuildArtifacts {
 
 /// Result of the metadata generation process.
 pub struct BuildResult {
-    /// Path to the resulting metadata file.
-    pub dest_metadata: Option<PathBuf>,
     /// Path to the resulting Wasm file.
     pub dest_wasm: Option<PathBuf>,
-    /// Path to the bundled file.
-    pub dest_bundle: Option<PathBuf>,
+    /// Result of the metadata generation.
+    pub metadata_result: Option<MetadataResult>,
     /// Path to the directory where output files are written to.
     pub target_directory: PathBuf,
     /// If existent the result of the optimization.
@@ -264,10 +265,10 @@ impl BuildResult {
             size_diff,
             self.target_directory.display().to_string().bold(),
         );
-        if let Some(dest_bundle) = self.dest_bundle.as_ref() {
+        if let Some(metadata_result) = self.metadata_result.as_ref() {
             let bundle = format!(
                 "  - {} (code + metadata)\n",
-                util::base_name(&dest_bundle).bold()
+                util::base_name(&metadata_result.dest_bundle).bold()
             );
             out.push_str(&bundle);
         }
@@ -278,10 +279,10 @@ impl BuildResult {
             );
             out.push_str(&wasm);
         }
-        if let Some(dest_metadata) = self.dest_metadata.as_ref() {
+        if let Some(metadata_result) = self.metadata_result.as_ref() {
             let metadata = format!(
                 "  - {} (the contract's metadata)",
-                util::base_name(&dest_metadata).bold()
+                util::base_name(&metadata_result.dest_metadata).bold()
             );
             out.push_str(&metadata);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,7 @@ mod workspace;
 
 use self::workspace::ManifestPath;
 
-use crate::cmd::{
-    BuildCommand, CheckCommand,
-    metadata::MetadataResult,
-};
+use crate::cmd::{metadata::MetadataResult, BuildCommand, CheckCommand};
 
 #[cfg(feature = "extrinsics")]
 use sp_core::{crypto::Pair, sr25519, H256};

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,8 @@ pub struct BuildResult {
 
 /// Result of the optimization process.
 pub struct OptimizationResult {
+    /// The path of the optimized wasm file.
+    pub dest_wasm: PathBuf,
     /// The original Wasm size.
     pub original_size: f64,
     /// The Wasm size after optimizations have been applied.

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,7 @@ impl TryFrom<&OptimizationFlags> for OptimizationPasses {
 
 impl OptimizationPasses {
     /// Returns the string representation of `OptimizationPasses`
+    #[cfg(not(feature = "binaryen-as-dependency"))]
     pub(crate) fn to_str(&self) -> &str {
         match self {
             OptimizationPasses::Zero => "0",


### PR DESCRIPTION
Refactor triggered by discussion around https://github.com/paritytech/cargo-contract/pull/180/files#r591270056

- Refactor the build command in order to consolidate the logic around `BuildArtifacts` to a single place.
- No longer executes the build from within `metadata.rs`
- Replaces the `MetadataCommand` with free functions since it is no longer a top level command (this explains much of the diff in `metadata.rs`, but the code is mostly unchanged apart from the above mentioned change).