### PR TITLE
Use `#[ink::test]` instead of `#[test]`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,6 +81,21 @@ test:
   script:
     - cargo test --verbose --workspace --all-features
 
+test-new-project-template:
+  stage:                           test
+  <<:                              *docker-env
+  script:
+    - cargo run -- contract new new_project
+    - cd new_project
+
+    # needed because otherwise:
+    # `error: current package believes it's in a workspace when it's not`
+    - echo "[workspace]" >> Cargo.toml
+
+    - cargo check --verbose
+    - cargo test --verbose --all
+    - cargo fmt --verbose --all -- --check
+
 #### stage:                        build (default features)
 
 build:

--- a/templates/new/lib.rs
+++ b/templates/new/lib.rs
@@ -52,15 +52,18 @@ mod {{name}} {
         /// Imports all the definitions from the outer scope so we can use them here.
         use super::*;
 
+        /// Imports `ink_lang` so that we can use `#[ink::test]`.
+        use ink_lang as ink;
+
         /// We test if the default constructor does its job.
-        #[test]
+        #[ink::test]
         fn default_works() {
             let {{name}} = {{camel_name}}::default();
             assert_eq!({{name}}.get(), false);
         }
 
         /// We test a simple use case of our contract.
-        #[test]
+        #[ink::test]
         fn it_works() {
             let mut {{name}} = {{camel_name}}::new(false);
             assert_eq!({{name}}.get(), false);

--- a/templates/new/lib.rs
+++ b/templates/new/lib.rs
@@ -52,7 +52,7 @@ mod {{name}} {
         /// Imports all the definitions from the outer scope so we can use them here.
         use super::*;
 
-        /// Imports `ink_lang` so that we can use `#[ink::test]`.
+        /// Imports `ink_lang` so we can use `#[ink::test]`.
         use ink_lang as ink;
 
         /// We test if the default constructor does its job.

--- a/templates/new/lib.rs
+++ b/templates/new/lib.rs
@@ -52,18 +52,15 @@ mod {{name}} {
         /// Imports all the definitions from the outer scope so we can use them here.
         use super::*;
 
-        /// Imports `ink_lang` so we can use `#[ink::test]`.
-        use ink_lang as ink;
-
         /// We test if the default constructor does its job.
-        #[ink::test]
+        #[test]
         fn default_works() {
             let {{name}} = {{camel_name}}::default();
             assert_eq!({{name}}.get(), false);
         }
 
         /// We test a simple use case of our contract.
-        #[ink::test]
+        #[test]
         fn it_works() {
             let mut {{name}} = {{camel_name}}::new(false);
             assert_eq!({{name}}.get(), false);


### PR DESCRIPTION
Needed for https://github.com/paritytech/ink/issues/714.