### PR TITLE
Test new project template in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,6 +81,23 @@ test:
   script:
     - cargo test --verbose --workspace --all-features
 
+test-new-project-template:
+  stage:                           test
+  <<:                              *docker-env
+  script:
+    - cargo run -- contract new new_project
+    - cargo run -- contract build --manifest-path new_project/Cargo.toml
+    - cargo run -- contract check --manifest-path new_project/Cargo.toml
+    - cd new_project
+
+    # needed because otherwise:
+    # `error: current package believes it's in a workspace when it's not`
+    - echo "[workspace]" >> Cargo.toml
+
+    - cargo check --verbose
+    - cargo test --verbose --all
+    - cargo fmt --verbose --all -- --check
+
 #### stage:                        build (default features)
 
 build:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,13 +86,14 @@ test-new-project-template:
   <<:                              *docker-env
   script:
     - cargo run -- contract new new_project
-    - cargo run -- contract build --manifest-path new_project/Cargo.toml
-    - cargo run -- contract check --manifest-path new_project/Cargo.toml
-    - cd new_project
 
     # needed because otherwise:
     # `error: current package believes it's in a workspace when it's not`
-    - echo "[workspace]" >> Cargo.toml
+    - echo "[workspace]" >> new_project/Cargo.toml
+
+    - cargo run -- contract build --manifest-path new_project/Cargo.toml
+    - cargo run -- contract check --manifest-path new_project/Cargo.toml
+    - cd new_project
 
     - cargo check --verbose
     - cargo test --verbose --all

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,8 +91,8 @@ test-new-project-template:
     # `error: current package believes it's in a workspace when it's not`
     - echo "[workspace]" >> new_project/Cargo.toml
 
-    - cargo run -- contract build --manifest-path new_project/Cargo.toml
-    - cargo run -- contract check --manifest-path new_project/Cargo.toml
+    - cargo run --all-features -- contract build --manifest-path new_project/Cargo.toml
+    - cargo run --all-features -- contract check --manifest-path new_project/Cargo.toml
     - cd new_project
 
     - cargo check --verbose


### PR DESCRIPTION
We should ensure that the project template always works. 

Having this as a CI stage ensures that the template will work with changes to the template, to dependencies, and with recent Rust versions.

The tests which we already have in the codebase execute functions in `cmd` directly. The CI stage on the other hand is a proper end-to-end test. Also the tests in the codebase don't run `cargo test`/`cargo check`/`cargo fmt`.