### PR TITLE
Detect compatible `wasm-opt` versions and improve error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "parity-wasm 0.42.2",
  "pretty_assertions",
  "pwasm-utils",
+ "regex",
  "rustc_version 0.3.3",
  "semver 0.11.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tempfile = "3.2.0"
 url = { version = "2.2.1", features = ["serde"] }
 binaryen = { version = "0.12.0", optional = true }
 impl-serde = "0.3.1"
+regex = "1.4"
 
 # dependencies for optional extrinsics feature
 async-std = { version = "1.9.0", optional = true }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -413,10 +413,7 @@ fn do_optimization(
         .as_ref()
         .expect("we just checked if which returned an err; qed")
         .as_path();
-    log::info!(
-        "Path to wasm-opt executable: {}",
-        wasm_opt_path.display()
-    );
+    log::info!("Path to wasm-opt executable: {}", wasm_opt_path.display());
 
     let _ = check_wasm_opt_version_compatibility(wasm_opt_path)?;
 
@@ -434,7 +431,13 @@ fn do_optimization(
         // memory-packing pre-pass.
         .arg("--zero-filled-memory")
         .output()
-        .map_err(|err| anyhow::anyhow!("Executing {} failed with {:?}", wasm_opt_path.display(), err))?;
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "Executing {} failed with {:?}",
+                wasm_opt_path.display(),
+                err
+            )
+        })?;
 
     if !output.status.success() {
         let err = str::from_utf8(&output.stderr)

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -429,7 +429,7 @@ fn do_optimization(
         // memory-packing pre-pass.
         .arg("--zero-filled-memory")
         .output()
-        .map_err(|err| anyhow::anyhow!("Executing {:?} failed with {:?}", wasm_opt_path, err))?;
+        .map_err(|err| anyhow::anyhow!("Executing {} failed with {:?}", wasm_opt_path.display(), err))?;
 
     if !output.status.success() {
         let err = str::from_utf8(&output.stderr)
@@ -456,7 +456,7 @@ fn check_wasm_opt_version_compatibility(wasm_opt_path: &Path) -> Result<()> {
         .map_err(|err| {
             anyhow::anyhow!(
                 "Executing `{:?} --version` failed with {:?}",
-                wasm_opt_path,
+                wasm_opt_path.display(),
                 err
             )
         })?;
@@ -845,7 +845,7 @@ mod tests_ci_only {
             {
                 let mut file = std::fs::File::create(&path).unwrap();
                 file.write_all(
-                    b"#!/bin/sh\necho \"wasm-opt version 13 (version_13-79-gc12cc3f50)\"",
+                    b"#!/bin/sh\necho \"wasm-opt version 98 (version_13-79-gc12cc3f50)\"",
                 )
                 .expect("writing wasm-opt-mocked failed");
             }
@@ -859,7 +859,7 @@ mod tests_ci_only {
             assert!(res.is_err());
             assert_eq!(
                 format!("{:?}", res),
-                "Err(Your wasm-opt version is 13, but we require a version >= 99.)"
+                "Err(Your wasm-opt version is 98, but we require a version >= 99.)"
             );
 
             Ok(())

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -395,7 +395,7 @@ fn do_optimization(
     let which = which::which("wasm-opt");
     if which.is_err() {
         anyhow::bail!(
-            "wasm-opt not found!\n\
+            "wasm-opt not found! Make sure the binary is in your PATH environment.\n\
             We use this tool to optimize the size of your contract's Wasm binary.\n\n\
             wasm-opt is part of the binaryen package. You can find detailed\n\
             installation instructions on https://github.com/WebAssembly/binaryen#tools.\n\n\
@@ -413,6 +413,11 @@ fn do_optimization(
         .as_ref()
         .expect("we just checked if which returned an err; qed")
         .as_path();
+    log::info!(
+        "Path to wasm-opt executable: {}",
+        wasm_opt_path.display()
+    );
+
     let _ = check_wasm_opt_version_compatibility(wasm_opt_path)?;
 
     log::info!(

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -393,11 +393,18 @@ fn do_optimization(
     // check `wasm-opt` is installed
     if which::which("wasm-opt").is_err() {
         anyhow::bail!(
-            "{}",
-            "wasm-opt is not installed. Install this tool on your system in order to \n\
-             reduce the size of your contract's Wasm binary. \n\
-             See https://github.com/WebAssembly/binaryen#tools"
-                .bright_yellow()
+            "wasm-opt not found!\n\
+            We use this tool to optimize the size of your contract's Wasm binary.\n\n\
+            wasm-opt is part of the binaryen package. You can find detailed\n\
+            installation instructions on https://github.com/WebAssembly/binaryen#tools.\n\n\
+
+            There are also ready-to-install packages for many platforms:\n\
+            * Debian/Ubuntu: https://tracker.debian.org/pkg/binaryen\n\
+            * Homebrew: https://formulae.brew.sh/formula/binaryen\n\
+            * Arch Linux: https://archlinux.org/packages/community/x86_64/binaryen\n\
+            * Windows: binary releases are available at https://github.com/WebAssembly/binaryen/releases"
+            .to_string()
+            .bright_yellow()
         );
     }
 


### PR DESCRIPTION
The improved error message:
```
ERROR: wasm-opt not found!
We use this tool to optimize the size of your contract's Wasm binary.

wasm-opt is part of the binaryen package. You can find detailed
installation instructions on https://github.com/WebAssembly/binaryen#tools.

There are also ready-to-install packages for many platforms:
* Debian/Ubuntu: https://tracker.debian.org/pkg/binaryen
* Homebrew: https://formulae.brew.sh/formula/binaryen
* Arch Linux: https://archlinux.org/packages/community/x86_64/binaryen
* Windows: binary releases are available at https://github.com/WebAssembly/binaryen/releases
```
I'm aware that linking packages here can be seen as controversial, but due to the number of questions we get in public channels regarding this I think we should consider it.