### PR TITLE
Check wasm optimized output file exists

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -283,7 +283,9 @@ fn optimize_wasm(
     )?;
 
     if !dest_optimized.exists() {
-        return Err(anyhow::anyhow!("Optimization failed, optimized wasm output file not found."))
+        return Err(anyhow::anyhow!(
+            "Optimization failed, optimized wasm output file not found."
+        ));
     }
 
     let original_size = metadata(&crate_metadata.dest_wasm)?.len() as f64 / 1000.0;

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -284,7 +284,8 @@ fn optimize_wasm(
 
     if !dest_optimized.exists() {
         return Err(anyhow::anyhow!(
-            "Optimization failed, optimized wasm output file not found."
+            "Optimization failed, optimized wasm output file `{}` not found.",
+            dest_optimized
         ));
     }
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -282,6 +282,10 @@ fn optimize_wasm(
         optimization_passes,
     )?;
 
+    if !dest_optimized.exists() {
+        return Err(anyhow::anyhow!("Optimization failed, optimized wasm output file not found."))
+    }
+
     let original_size = metadata(&crate_metadata.dest_wasm)?.len() as f64 / 1000.0;
     let optimized_size = metadata(&dest_optimized)?.len() as f64 / 1000.0;
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -285,7 +285,7 @@ fn optimize_wasm(
     if !dest_optimized.exists() {
         return Err(anyhow::anyhow!(
             "Optimization failed, optimized wasm output file `{}` not found.",
-            dest_optimized
+            dest_optimized.display()
         ));
     }
 


### PR DESCRIPTION
Possible improvement for the source of this error message here:

![image](https://user-images.githubusercontent.com/75586/112973618-76667b80-9149-11eb-9ef8-599940fdf86e.png)

Suspect that the installed version of `wasm-opt` runs but doesn't produce the output file as expected.

I haven't reproduced it because my installation of `wasm-opt` is valid and produces a optimized file, however this is a useful check to make anyway, since we have no guarantees that `do_optimization` will write the optimized wasm fle.
