### PR TITLE
Fix `wasm-opt --version` parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ We optimize the resulting contract Wasm using `binaryen`. You have two options f
 ## Usage
 
 ```
-cargo-contract 0.8.0
-Utilities to develop Wasm smart contracts.
+cargo-contract 0.11.0-4d0206f-x86_64-linux-gnu
+Utilities to develop Wasm smart contracts
 
 USAGE:
     cargo contract <SUBCOMMAND>
@@ -42,8 +42,11 @@ OPTIONS:
 
 SUBCOMMANDS:
     new                  Setup and create a new smart contract project
-    build                Compiles the contract, generates metadata, bundles both together in a '.contract' file
-    check                Check that the code builds as Wasm; does not output any build artifact to the top level `target/` directory
+    build                Compiles the contract, generates metadata, bundles
+                         both together in a `<name>.contract` file
+    generate-metadata    Command has been deprecated, use `cargo contract build` instead
+    check                Check that the code builds as Wasm; does not output any
+                         `<name>.contract` artifact to the `target/` directory
     test                 Test the smart contract off-chain
     deploy               Upload the smart contract code to the chain
     instantiate          Instantiate a deployed smart contract

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We optimize the resulting contract Wasm using `binaryen`. You have two options f
 ## Usage
 
 ```
-cargo-contract 0.11.0-4d0206f-x86_64-linux-gnu
+cargo-contract 0.11.0
 Utilities to develop Wasm smart contracts
 
 USAGE:

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -496,7 +496,7 @@ fn check_wasm_opt_version_compatibility(wasm_opt_path: &Path) -> Result<()> {
     let re = Regex::new(r"wasm-opt version (\d+)").unwrap();
     let captures = re.captures(version_stdout).ok_or_else(|| {
         anyhow::anyhow!(
-            "Unable to extract version information from {}.\n\
+            "Unable to extract version information from \"{}\".\n\
             Your wasm-opt version is most probably too old. Make sure you use a version >= 99.",
             version_stdout
         )
@@ -504,13 +504,16 @@ fn check_wasm_opt_version_compatibility(wasm_opt_path: &Path) -> Result<()> {
     let version_number: u32 = captures
         .get(1) // first capture group is at index 1
         .ok_or_else(|| {
-            anyhow::anyhow!("Unable to extract version number from {:?}", version_stdout)
+            anyhow::anyhow!(
+                "Unable to extract version number from \"{:?}\"",
+                version_stdout
+            )
         })?
         .as_str()
         .parse()
         .map_err(|err| {
             anyhow::anyhow!(
-                "Parsing version number failed with {:?} for {:?}",
+                "Parsing version number failed with \"{:?}\" for \"{:?}\"",
                 err,
                 version_stdout
             )

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -493,10 +493,10 @@ fn check_wasm_opt_version_compatibility(wasm_opt_path: &Path) -> Result<()> {
     let version_stdout = str::from_utf8(&cmd.stdout)
         .expect("Cannot convert stdout output of wasm-opt to string")
         .trim();
-    let re = Regex::new(r"wasm-opt version (\d+)").unwrap();
+    let re = Regex::new(r"wasm-opt version (\d+)").expect("invalid regex");
     let captures = re.captures(version_stdout).ok_or_else(|| {
         anyhow::anyhow!(
-            "Unable to extract version information from \"{}\".\n\
+            "Unable to extract version information from '{}'.\n\
             Your wasm-opt version is most probably too old. Make sure you use a version >= 99.",
             version_stdout
         )
@@ -505,7 +505,7 @@ fn check_wasm_opt_version_compatibility(wasm_opt_path: &Path) -> Result<()> {
         .get(1) // first capture group is at index 1
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "Unable to extract version number from \"{:?}\"",
+                "Unable to extract version number from '{:?}'",
                 version_stdout
             )
         })?
@@ -513,14 +513,14 @@ fn check_wasm_opt_version_compatibility(wasm_opt_path: &Path) -> Result<()> {
         .parse()
         .map_err(|err| {
             anyhow::anyhow!(
-                "Parsing version number failed with \"{:?}\" for \"{:?}\"",
+                "Parsing version number failed with '{:?}' for '{:?}'",
                 err,
                 version_stdout
             )
         })?;
 
     log::info!(
-        "The wasm-opt version output is \"{}\", which was parsed to \"{}\"",
+        "The wasm-opt version output is '{}', which was parsed to '{}'",
         version_stdout,
         version_number
     );


### PR DESCRIPTION
Closes https://github.com/paritytech/cargo-contract/issues/247.

The issue was that binaryen includes more extensive version information in the `--version` output [only if built from source](https://github.com/WebAssembly/binaryen/blob/main/CMakeLists.txt#L20-L35). If installed via a package manager the version output can be more compact.

I've also escalated this into the ticket https://github.com/paritytech/ci_cd/issues/121, to install `binaryen` from a package manager in our CI.
