### PR TITLE
Release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2021-04-06
+
+### Fixed
+- Fix `wasm-opt --version` parsing - [#248](https://github.com/paritytech/cargo-contract/pull/248)
+
 ## [0.11.0] - 2021-03-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "metadata"]
 
 [package]
 name = "cargo-contract"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"


### PR DESCRIPTION
### Fixed

- Fix `wasm-opt --version` parsing - [#248](https://github.com/paritytech/cargo-contract/pull/248)