### PR TITLE
Bump scale codec version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a2f58b0bb10c380af2b26e57212856b8c9a59e0925b4c20f4a174a49734eaf7"
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,7 +512,7 @@ dependencies = [
  "hex",
  "impl-serde",
  "log",
- "parity-scale-codec 2.0.1",
+ "parity-scale-codec 2.1.0",
  "parity-wasm 0.42.2",
  "platforms",
  "pretty_assertions",
@@ -2034,11 +2040,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd3dab59b5cf4bc81069ade0fc470341a1ef3ad5fa73e5a8943bed2ec12b2e8"
+checksum = "731f4d179ed52b1c7eeb29baf29c604ea9301b889b23ce93660220a5465d5c6f"
 dependencies = [
- "arrayvec 0.5.2",
+ "arrayvec 0.7.0",
  "bitvec 0.20.1",
  "byte-slice-cast 1.0.0",
  "parity-scale-codec-derive 2.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ zip = { version = "0.5.11", default-features = false }
 pwasm-utils = "0.17.0"
 parity-wasm = "0.42.2"
 cargo_metadata = "0.13.1"
-codec = { package = "parity-scale-codec", version = "2.0.1", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.1", features = ["derive"] }
 which = "4.1.0"
 colored = "2.0.0"
 toml = "0.5.8"


### PR DESCRIPTION
for https://github.com/paritytech/ink/pull/754

There are a bunch of outdated references that already existed (parity-scale-codec 1.3.6 for example), is there a reason for this?