### PR TITLE
Remove support for `binaryen-as-dependency`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- Remove support for `--binaryen-as-dependency` - [#251](https://github.com/paritytech/cargo-contract/pull/251)
+
 ## [0.11.1] - 2021-04-06
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ wabt = "0.10.0"
 
 [features]
 default = []
-binaryen-as-dependency = ["binaryen"]
 
 # Enable this for (experimental) commands to deploy, instantiate and call contracts.
 #

--- a/README.md
+++ b/README.md
@@ -10,22 +10,17 @@ A CLI tool for helping setting up and managing WebAssembly smart contracts writt
 
 `rust-src` is a prerequisite: `rustup component add rust-src`.
 
-We optimize the resulting contract Wasm using `binaryen`. You have two options for installing it:
+`binaryen` is a prerequisite as well, we use it for optimizing the contract Wasm. 
 
-  - _The preferred way:_  
-    Install [`binaryen`](https://github.com/WebAssembly/binaryen#tools) with a version >= 99.
-    Many package managers have it available nowadays:
-    
-    * [Debian/Ubuntu](https://tracker.debian.org/pkg/binaryen): `apt-get install binaryen`
-    * [Homebrew](https://formulae.brew.sh/formula/binaryen): `brew install binaryen`
-    * [Arch Linux](https://archlinux.org/packages/community/x86_64/binaryen/): `pacman -S binaryen`
-    * Windows: [binary releases are available](https://github.com/WebAssembly/binaryen/releases)
-      
-    After you've installed the package execute `cargo install --force cargo-contract`.
+Install [`binaryen`](https://github.com/WebAssembly/binaryen#tools) with a version >= 99.
+Many package managers have it available nowadays:
 
-  - _Build `binaryen` as a dependency when installing `cargo-contract`:_  
-    A C++14 compiler and python >= 3.5 is required.
-    Execute `cargo install --force --features binaryen-as-dependency cargo-contract`.
+* [Debian/Ubuntu](https://tracker.debian.org/pkg/binaryen): `apt-get install binaryen`
+* [Homebrew](https://formulae.brew.sh/formula/binaryen): `brew install binaryen`
+* [Arch Linux](https://archlinux.org/packages/community/x86_64/binaryen/): `pacman -S binaryen`
+* Windows: [binary releases are available](https://github.com/WebAssembly/binaryen/releases)
+  
+After you've installed the package execute `cargo install --force cargo-contract`.
 
 ## Usage
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,32 +159,6 @@ impl From<std::string::String> for OptimizationPasses {
     }
 }
 
-impl OptimizationPasses {
-    /// Returns the number of optimization passes to do
-    #[cfg(feature = "binaryen-as-dependency")]
-    pub(crate) fn to_passes(&self) -> u32 {
-        match self {
-            OptimizationPasses::Zero => 0,
-            OptimizationPasses::One => 1,
-            OptimizationPasses::Two => 2,
-            OptimizationPasses::Three => 3,
-            OptimizationPasses::Four => 4,
-            _ => 3, // Default to three for shrink settings
-        }
-    }
-
-    /// Returns amount of shrinkage to do
-    #[cfg(feature = "binaryen-as-dependency")]
-    pub(crate) fn to_shrink(&self) -> u32 {
-        match self {
-            OptimizationPasses::Zero => 0,
-            OptimizationPasses::S => 1,
-            OptimizationPasses::Z => 2,
-            _ => 1,
-        }
-    }
-}
-
 #[derive(Default, Clone, Debug, StructOpt)]
 pub struct VerbosityFlags {
     /// No output printed to stdout


### PR DESCRIPTION
It caused only problems and complicated things.

I removed it from our CI as well: https://github.com/paritytech/scripts/pull/285. We now install `binaryen` as a system package in our docker image (this was not possible a couple weeks ago).