### PR TITLE
Add CI for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name:                 continuous-intergration/windows
+name: continuous-intergration/windows
 
 on:
   pull_request:
@@ -12,25 +12,25 @@ on:
 
 jobs:
   check:
-    name:              build-contract-template
+    name: build-contract-template
     strategy:
       matrix:
         platform:
           - windows-latest
         toolchain:
           - nightly
-    runs-on:           ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform }}
     env:
-      RUST_BACKTRACE:  full
+      RUST_BACKTRACE: full
     steps:
-      - name:          Install sudo for windows #https://github.com/actions/virtual-environments/issues/572
+      - name: Install sudo for windows #https://github.com/actions/virtual-environments/issues/572
         run: choco install sudo
 
-      - name:          Set cache_hash ENV and prepare cache dir
-        run:           |
+      - name: Set cache_hash ENV and prepare cache dir
+        run: |
           echo "cache_hash=${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.compiler }}-${{ hashFiles('**/Cargo.toml') }}" >> "$GITHUB_ENV"
           sudo chmod -R a+w $HOME/.cargo
-        shell:         bash
+        shell: bash
 
       - name: Cache cargo registry
         uses: actions/cache@master
@@ -56,22 +56,22 @@ jobs:
           url: "https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-windows.tar.gz"
           pathInArchive: "binaryen-version_101/bin/wasm-opt.exe"
 
-      - name:          Checkout sources & submodules
-        uses:          actions/checkout@master
+      - name: Checkout sources & submodules
+        uses: actions/checkout@master
         with:
           fetch-depth: 1
-          submodules:  recursive
+          submodules: recursive
 
-      - name:          Install toolchain
-        id:            toolchain
-        uses:          actions-rs/toolchain@master
+      - name: Install toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@master
         with:
-          profile:     minimal
-          toolchain:   ${{ matrix.toolchain }}
-          components:  rust-src
-          override:    true
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          components: rust-src
+          override: true
 
-      - name:          Build contract template on ${{ matrix.platform }}-${{ matrix.toolchain }}
+      - name: Build contract template on ${{ matrix.platform }}-${{ matrix.toolchain }}
         run: |
           wasm-opt --version
           cargo -vV

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,81 @@
+name:                 continuous-intergration/windows
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  check:
+    name:              build-contract-template
+    strategy:
+      matrix:
+        platform:
+          - windows-latest
+        toolchain:
+          - nightly
+    runs-on:           ${{ matrix.platform }}
+    env:
+      RUST_BACKTRACE:  full
+    steps:
+      - name:          Install sudo for windows #https://github.com/actions/virtual-environments/issues/572
+        run: choco install sudo
+
+      - name:          Set cache_hash ENV and prepare cache dir
+        run:           |
+          echo "cache_hash=${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.compiler }}-${{ hashFiles('**/Cargo.toml') }}" >> "$GITHUB_ENV"
+          sudo chmod -R a+w $HOME/.cargo
+        shell:         bash
+
+      - name: Cache cargo registry
+        uses: actions/cache@master
+        with:
+          path: $HOME/.cargo/registry
+          key: cargo-registry-${{ env['cache_hash'] }}
+
+      - name: Cache cargo index
+        uses: actions/cache@master
+        with:
+          path: $HOME/.cargo/git
+          key: cargo-git-${{ env['cache_hash'] }}
+
+      - name: Cache cargo build
+        uses: actions/cache@master
+        with:
+          path: target
+          key: cargo-target-${{ env['cache_hash'] }}
+
+      - uses: engineerd/configurator@v0.0.6
+        with:
+          name: "wasm-opt.exe"
+          url: "https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-windows.tar.gz"
+          pathInArchive: "binaryen-version_101/bin/wasm-opt.exe"
+
+      - name:          Checkout sources & submodules
+        uses:          actions/checkout@master
+        with:
+          fetch-depth: 1
+          submodules:  recursive
+
+      - name:          Install toolchain
+        id:            toolchain
+        uses:          actions-rs/toolchain@master
+        with:
+          profile:     minimal
+          toolchain:   ${{ matrix.toolchain }}
+          components:  rust-src
+          override:    true
+
+      - name:          Build contract template on ${{ matrix.platform }}-${{ matrix.toolchain }}
+        run: |
+          wasm-opt --version
+          cargo -vV
+          cargo run -- contract --version
+          cargo run -- contract new foobar
+          echo "[workspace]" >> foobar/Cargo.toml
+          cargo run -- contract build --manifest-path=foobar/Cargo.toml

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,32 +23,6 @@ jobs:
     env:
       RUST_BACKTRACE: full
     steps:
-      - name: Install sudo for windows #https://github.com/actions/virtual-environments/issues/572
-        run: choco install sudo
-
-      - name: Set cache_hash ENV and prepare cache dir
-        run: |
-          echo "cache_hash=${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ matrix.compiler }}-${{ hashFiles('**/Cargo.toml') }}" >> "$GITHUB_ENV"
-          sudo chmod -R a+w $HOME/.cargo
-        shell: bash
-
-      - name: Cache cargo registry
-        uses: actions/cache@master
-        with:
-          path: $HOME/.cargo/registry
-          key: cargo-registry-${{ env['cache_hash'] }}
-
-      - name: Cache cargo index
-        uses: actions/cache@master
-        with:
-          path: $HOME/.cargo/git
-          key: cargo-git-${{ env['cache_hash'] }}
-
-      - name: Cache cargo build
-        uses: actions/cache@master
-        with:
-          path: target
-          key: cargo-target-${{ env['cache_hash'] }}
 
       - uses: engineerd/configurator@v0.0.6
         with:
@@ -70,6 +44,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: rust-src
           override: true
+
+      - name:                      Rust Cache
+        uses:                      Swatinem/rust-cache@v1.2.0
 
       - name: Build contract template on ${{ matrix.platform }}-${{ matrix.toolchain }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed `ERROR: The workspace root package should be a workspace member` when building a contract
+  under Windows - [#261](https://github.com/paritytech/cargo-contract/pull/261)
+
 ### Removed
 - Remove support for `--binaryen-as-dependency` - [#251](https://github.com/paritytech/cargo-contract/pull/251)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,27 +308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
-name = "binaryen"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9b407f52d0b918c6ea41d7a328321496b315f61da99a309b375dfbbd04bc9a"
-dependencies = [
- "binaryen-sys",
-]
-
-[[package]]
-name = "binaryen-sys"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e9636d01b92f2df45dce29c35a9e3724687c1055bb4472fb4b829cc4a5a561"
-dependencies = [
- "cc",
- "cmake",
- "heck",
- "regex",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,7 +479,6 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-std",
- "binaryen",
  "blake2",
  "cargo_metadata",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 serde_json = "1.0.64"
 tempfile = "3.2.0"
 url = { version = "2.2.1", features = ["serde"] }
-binaryen = { version = "0.12.0", optional = true }
 impl-serde = "0.3.1"
 regex = "1.4"
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -596,9 +596,10 @@ mod tests_ci_only {
         BuildArtifacts, ManifestPath, OptimizationPasses, UnstableFlags, UnstableOptions,
         Verbosity, VerbosityFlags,
     };
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::{
         io::Write,
-        os::unix::fs::PermissionsExt,
         path::{Path, PathBuf},
     };
 
@@ -623,6 +624,9 @@ mod tests_ci_only {
     /// "wasm-opt version `version`".
     ///
     /// Returns the path to this file.
+    ///
+    /// Currently works only on `unix`.
+    #[cfg(unix)]
     fn mock_wasm_opt_version(tmp_dir: &Path, version: &str) -> PathBuf {
         let path = tmp_dir.join("wasm-opt-mocked");
         {
@@ -829,6 +833,7 @@ mod tests_ci_only {
         })
     }
 
+    #[cfg(unix)]
     #[test]
     fn incompatible_wasm_opt_version_must_be_detected_if_built_from_repo() {
         with_tmp_dir(|path| {
@@ -849,6 +854,7 @@ mod tests_ci_only {
         })
     }
 
+    #[cfg(unix)]
     #[test]
     fn compatible_wasm_opt_version_must_be_detected_if_built_from_repo() {
         with_tmp_dir(|path| {
@@ -865,6 +871,7 @@ mod tests_ci_only {
         })
     }
 
+    #[cfg(unix)]
     #[test]
     fn incompatible_wasm_opt_version_must_be_detected_if_installed_as_package() {
         with_tmp_dir(|path| {
@@ -885,6 +892,7 @@ mod tests_ci_only {
         })
     }
 
+    #[cfg(unix)]
     #[test]
     fn compatible_wasm_opt_version_must_be_detected_if_installed_as_package() {
         with_tmp_dir(|path| {

--- a/src/workspace/manifest.rs
+++ b/src/workspace/manifest.rs
@@ -177,6 +177,7 @@ impl Manifest {
     }
 
     /// Set `optimization-passes` in `[package.metadata.contract]`
+    #[cfg(feature = "test-ci-only")]
     #[cfg(test)]
     pub fn set_profile_optimization_passes(
         &mut self,
@@ -205,6 +206,7 @@ impl Manifest {
     }
 
     /// Set the dependency version of `package` to `version`.
+    #[cfg(feature = "test-ci-only")]
     #[cfg(test)]
     pub fn set_dependency_version(
         &mut self,


### PR DESCRIPTION
Closes https://github.com/paritytech/cargo-contract/issues/36.

Took inspiration [from here](https://github.com/paritytech/libsecp256k1/blob/master/.github/workflows/rust.yml).

The Windows run currently takes ~9 minutes.

While implementing this, I found the bug which caused some people asking in our channels why they got this error when building a contract under Windows:
```
[3/5] Optimizing wasm file
ERROR: The workspace root package should be a workspace member
```
It was due to a comparison of a non-canonicalized path with a canonicalized one.
```
workspace_root (non-canonicalized): "D:\\a\\cargo-contract\\cargo-contract\\foobar"
package_path (canonicalized):       "\\\\?\\D:\\a\\cargo-contract\\cargo-contract\\foobar"
comparison: Some("D:\\a\\cargo-contract\\cargo-contract\\foobar") == Some("\\\\?\\D:\\a\\cargo-contract\\cargo-contract\\foobar")
```
The `\\\\?` prefix appears only under Windows ‒ there a path with this prefix is the correct canonical path, this allows Windows-specific "long" paths ([more info](https://stackoverflow.com/a/41233992)).

I'm not sure if there might be more places in our code which could cause issues with this path discrepancy, FWIW tests are green.

I can do a new release once we have merged this.