### PR TITLE
Fix flaky CI test

### DIFF
--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -225,7 +225,7 @@ fn blake2_hash(code: &[u8]) -> CodeHash {
 mod tests {
     use crate::cmd::metadata::blake2_hash;
     use crate::{
-        cmd, crate_metadata::CrateMetadata, util::tests::with_tmp_dir, BuildArtifacts,
+        cmd, crate_metadata::CrateMetadata, util::tests::with_new_contract_project, BuildArtifacts,
         ManifestPath, OptimizationPasses, UnstableFlags, Verbosity,
     };
     use contract_metadata::*;
@@ -299,11 +299,7 @@ mod tests {
     #[test]
     fn generate_metadata() {
         env_logger::try_init().ok();
-        with_tmp_dir(|path| {
-            cmd::new::execute("new_project", Some(path)).expect("new project creation failed");
-            let working_dir = path.join("new_project");
-            let manifest_path = ManifestPath::new(working_dir.join("Cargo.toml"))?;
-
+        with_new_contract_project(|manifest_path| {
             // add optional metadata fields
             let mut test_manifest = TestContractManifest::new(manifest_path)?;
             test_manifest.add_package_value("description", "contract description".into())?;

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -151,10 +151,10 @@ mod tests {
 
     #[test]
     fn contract_cargo_project_already_exists() {
-        with_new_contract_project(|manifest_path| {
+        with_tmp_dir(|path| {
             let name = "test_contract_cargo_project_already_exists";
-            let _ = execute(name, Some(manifest_path.clone()));
-            let result = execute(name, Some(manifest_path));
+            let _ = execute(name, Some(path));
+            let result = execute(name, Some(path));
 
             assert!(result.is_err(), "Should fail");
             assert_eq!(

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -108,12 +108,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::tests::with_tmp_dir;
+    use crate::util::tests::{with_new_contract_project, with_tmp_dir};
 
     #[test]
     fn rejects_hyphenated_name() {
-        with_tmp_dir(|path| {
-            let result = execute("rejects-hyphenated-name", Some(path));
+        with_new_contract_project(|manifest_path| {
+            let result = execute("rejects-hyphenated-name", Some(manifest_path));
             assert!(result.is_err(), "Should fail");
             assert_eq!(
                 result.err().unwrap().to_string(),
@@ -125,8 +125,8 @@ mod tests {
 
     #[test]
     fn rejects_name_with_period() {
-        with_tmp_dir(|path| {
-            let result = execute("../xxx", Some(path));
+        with_new_contract_project(|manifest_path| {
+            let result = execute("../xxx", Some(manifest_path));
             assert!(result.is_err(), "Should fail");
             assert_eq!(
                 result.err().unwrap().to_string(),
@@ -138,8 +138,8 @@ mod tests {
 
     #[test]
     fn rejects_name_beginning_with_number() {
-        with_tmp_dir(|path| {
-            let result = execute("1xxx", Some(path));
+        with_new_contract_project(|manifest_path| {
+            let result = execute("1xxx", Some(manifest_path));
             assert!(result.is_err(), "Should fail");
             assert_eq!(
                 result.err().unwrap().to_string(),
@@ -151,10 +151,10 @@ mod tests {
 
     #[test]
     fn contract_cargo_project_already_exists() {
-        with_tmp_dir(|path| {
+        with_new_contract_project(|manifest_path| {
             let name = "test_contract_cargo_project_already_exists";
-            let _ = execute(name, Some(path));
-            let result = execute(name, Some(path));
+            let _ = execute(name, Some(manifest_path.clone()));
+            let result = execute(name, Some(manifest_path));
 
             assert!(result.is_err(), "Should fail");
             assert_eq!(

--- a/src/crate_metadata.rs
+++ b/src/crate_metadata.rs
@@ -43,26 +43,7 @@ impl CrateMetadata {
     /// Parses the contract manifest and returns relevant metadata.
     pub fn collect(manifest_path: &ManifestPath) -> Result<Self> {
         let (metadata, root_package) = get_cargo_metadata(manifest_path)?;
-        let mut target_directory = metadata.target_directory.to_path_buf();
-
-        #[cfg(test)]
-        {
-            // Our CI uses `CARGO_TARGET_DIR` to overwrite the `target_directory` returned
-            // here (for caching purposes). We still want to ensure that each test builds
-            // to its own, unique folder, without interfering with other tests.
-            // Hence we append a hash of the `manifest_path`, which for tests typically
-            // contains a `tmp_dir`.
-            use impl_serde::serialize as serde_hex;
-            let hex = serde_hex::to_hex(
-                &codec::Encode::encode(&manifest_path.as_ref().display().to_string()),
-                false,
-            );
-            target_directory = target_directory.join(hex);
-        }
-
-        // We have some tests which check that the target director path always ends with `ink`,
-        // hence we can only append it after (possibly) having appended the hash.
-        target_directory = target_directory.join("ink");
+        let mut target_directory = metadata.target_directory.as_path().join("ink");
 
         // Normalize the package name.
         let package_name = root_package.name.replace("-", "_");

--- a/src/util.rs
+++ b/src/util.rs
@@ -127,7 +127,8 @@ pub mod tests {
     ///
     /// We typically use `with_tmp_dir` to generate temporary folders to build contracts
     /// in. But for caching purposes our CI uses `CARGO_TARGET_DIR` to overwrite the
-    /// target directory of any contract build.
+    /// target directory of any contract build -- it is set to a fixed cache directory
+    /// instead.
     /// This poses a problem since we still want to ensure that each test builds to its
     /// own, unique target directory -- without interfering with the target directory of
     /// other tests. In the past this has been a problem when a test tried to create a
@@ -137,6 +138,9 @@ pub mod tests {
     /// The fix we decided on is to append a unique number to each contract name which
     /// is created. This `COUNTER` provides a global counter which is accessed by each test
     /// (in each thread) to get the current `COUNTER` number and increase it afterwards.
+    ///
+    /// We decided to go for this counter instead of hashing (with e.g. the temp dir) to
+    /// prevent an infinite number of contract artifacts being created in the cache directory.
     static COUNTER: AtomicU32 = AtomicU32::new(0);
 
     /// Creates a new contract into a temporary directory. The contract's

--- a/src/util.rs
+++ b/src/util.rs
@@ -123,7 +123,20 @@ pub mod tests {
         f(tmp_dir.path()).expect("Error executing test with tmp dir")
     }
 
-    /// Counter to generate unique project names in `with_new_contract_project`.
+    /// Global counter to generate unique contract names in `with_new_contract_project`.
+    ///
+    /// We typically use `with_tmp_dir` to generate temporary folders to build contracts
+    /// in. But for caching purposes our CI uses `CARGO_TARGET_DIR` to overwrite the
+    /// target directory of any contract build.
+    /// This poses a problem since we still want to ensure that each test builds to its
+    /// own, unique target directory -- without interfering with the target directory of
+    /// other tests. In the past this has been a problem when a test tried to create a
+    /// contract with the same contract name as another test -- both were then build
+    /// into the same target directory, sometimes causing test failures for strange reasons.
+    ///
+    /// The fix we decided on is to append a unique number to each contract name which
+    /// is created. This `COUNTER` provides a global counter which is accessed by each test
+    /// (in each thread) to get the current `COUNTER` number and increase it afterwards.
     static COUNTER: AtomicU32 = AtomicU32::new(0);
 
     /// Creates a new contract into a temporary directory. The contract's
@@ -133,8 +146,7 @@ pub mod tests {
         F: FnOnce(ManifestPath) -> anyhow::Result<()>,
     {
         with_tmp_dir(|tmp_dir| {
-            let unique_name = format!("new_project_{}", COUNTER.load(Ordering::SeqCst));
-            COUNTER.fetch_add(1, Ordering::SeqCst);
+            let unique_name = format!("new_project_{}", COUNTER.fetch_add(1, Ordering::SeqCst));
 
             crate::cmd::new::execute(&unique_name, Some(tmp_dir))
                 .expect("new project creation failed");


### PR DESCRIPTION
It's hunting season for https://github.com/paritytech/cargo-contract/issues/234 🏹!

I found it!

The issue was that we use
```
CARGO_TARGET_DIR: "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
```
in our CI configuration. This made all tests build to the same `target` directory. Since we have a number of tests which build a contract called `new_project` this made our `tmp_dir`'s obsolete and resulted in overlapping contracts build to e.g. `/ci-cache/cargo-contract/targets/263/test/ink/new_project.contract`.

The way I fixed it now is by appending a hash of a contract's `manifest_path` to the `target_directory` (for tests this path contains the `tmp_dir` path). This results in the paths now being e.g. `/ci-cache/cargo-contract/targets/263/test/0xd82f746d702f636172676f2d636f6e74726163742e746573742e5479444c634b2f6e65775f70726f6a6563742f436172676f2e746f6d6c/ink/new_project.contract`.

I'm not super-happy with that solution, since it makes caching obsolete for the contract build in those particular tests (since the hash is unique each time a test is run, due to `tmp_dir` being included in it).

I have a better idea, but it's a bit more involved: 
* We could use the full test path (e.g. `cmd::metadata::tests::generate_metadata`) for the hash instead.
* This would be achieved by writing a proc. macro (could also be called `#[test]`), which wraps around the Rust `#[test]` macro.
* The macro would then extract the `module_path!` and `function_name!` and put those into a thread-local variable.
* This thread-local variable would be used for hashing.

The disadvantage is that we would require something like `use crate::test;` for the macro to become available for tests. But we would then again have proper caching.

But: The CI hasn't really slowed down with the current fix in this PR ‒ a run of the `test` stage still takes 4-5 minutes. So maybe the current fix is already good enough. Though it fills up the cache and I'm not sure when it is cleared.

Wdyt?