### PR TITLE
Remove deprecated `generate-metadata` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Remove support for `--binaryen-as-dependency` - [#251](https://github.com/paritytech/cargo-contract/pull/251)
-- Remove support for the deprecated `cargo contract check` command - [#265](https://github.com/paritytech/cargo-contract/pull/265)
+- Remove support for the deprecated `cargo contract generate-metadata` command - [#265](https://github.com/paritytech/cargo-contract/pull/265)
 
 ## [0.11.1] - 2021-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Remove support for `--binaryen-as-dependency` - [#251](https://github.com/paritytech/cargo-contract/pull/251)
+- Remove support for the deprecated `cargo contract check` command - [#265](https://github.com/paritytech/cargo-contract/pull/265)
 
 ## [0.11.1] - 2021-04-06
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ SUBCOMMANDS:
     new                  Setup and create a new smart contract project
     build                Compiles the contract, generates metadata, bundles
                          both together in a `<name>.contract` file
-    generate-metadata    Command has been deprecated, use `cargo contract build` instead
     check                Check that the code builds as Wasm; does not output any
                          `<name>.contract` artifact to the `target/` directory
     test                 Test the smart contract off-chain

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,9 +378,6 @@ enum Command {
     /// Compiles the contract, generates metadata, bundles both together in a `<name>.contract` file
     #[structopt(name = "build")]
     Build(BuildCommand),
-    /// Command has been deprecated, use `cargo contract build` instead
-    #[structopt(name = "generate-metadata")]
-    GenerateMetadata {},
     /// Check that the code builds as Wasm; does not output any `<name>.contract` artifact to the `target/` directory
     #[structopt(name = "check")]
     Check(CheckCommand),
@@ -475,9 +472,6 @@ fn exec(cmd: Command) -> Result<Option<String>> {
                 Ok(None)
             }
         }
-        Command::GenerateMetadata {} => Err(anyhow::anyhow!(
-            "Command deprecated, use `cargo contract build` instead"
-        )),
         Command::Test {} => Err(anyhow::anyhow!("Command unimplemented")),
         #[cfg(feature = "extrinsics")]
         Command::Deploy {


### PR DESCRIPTION
Is has been marked as deprecated since https://github.com/paritytech/cargo-contract/pull/97.