### PR TITLE
Release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2021-04-25
+
 ### Added
-- Suggest `binaryen` installation from  GitHub release on outdated version - [#274](https://github.com/paritytech/cargo-contract/pull/274)
+- Suggest `binaryen` installation from GitHub release on outdated version - [#274](https://github.com/paritytech/cargo-contract/pull/274)
+
+### Fixed
+- Always use library targets name for contract artifacts - [#277](https://github.com/paritytech/cargo-contract/pull/277)
 
 ## [0.12.0] - 2021-04-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "metadata"]
 
 [package]
 name = "cargo-contract"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"


### PR DESCRIPTION
### Added
- Suggest `binaryen` installation from GitHub release on outdated version - [#274](https://github.com/paritytech/cargo-contract/pull/274)
 
### Fixed
- Always use library targets name for contract artifacts - [#277](https://github.com/paritytech/cargo-contract/pull/277)<br class="Apple-interchange-newline">