### PR TITLE
Fix `clippy::needless_borrow`

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -314,7 +314,7 @@ fn optimize_wasm(
     ));
     let _ = do_optimization(
         crate_metadata.dest_wasm.as_os_str(),
-        &dest_optimized.as_os_str(),
+        dest_optimized.as_os_str(),
         optimization_passes,
     )?;
 
@@ -530,9 +530,9 @@ pub(crate) fn execute(
     unstable_flags: UnstableFlags,
     optimization_passes: OptimizationPasses,
 ) -> Result<BuildResult> {
-    let crate_metadata = CrateMetadata::collect(&manifest_path)?;
+    let crate_metadata = CrateMetadata::collect(manifest_path)?;
 
-    assert_compatible_ink_dependencies(&manifest_path, verbosity)?;
+    assert_compatible_ink_dependencies(manifest_path, verbosity)?;
 
     let build = || -> Result<OptimizationResult> {
         maybe_println!(

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -158,7 +158,7 @@ fn extended_metadata(
     let repository = contract_package
         .repository
         .as_ref()
-        .map(|repo| Url::parse(&repo))
+        .map(|repo| Url::parse(repo))
         .transpose()?;
     let homepage = crate_metadata.homepage.clone();
     let license = contract_package.license.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,7 @@ impl BuildResult {
         if let Some(dest_wasm) = self.dest_wasm.as_ref() {
             let wasm = format!(
                 "  - {} (the contract's code)\n",
-                util::base_name(&dest_wasm).bold()
+                util::base_name(dest_wasm).bold()
             );
             out.push_str(&wasm);
         }

--- a/src/validate_wasm.rs
+++ b/src/validate_wasm.rs
@@ -146,7 +146,7 @@ fn parse_linker_error(field: &str) -> String {
     let encoded = field
         .strip_prefix(INK_ENFORCE_ERR)
         .expect("error marker must exist as prefix");
-    let hex = serde_hex::from_hex(&encoded).expect("decoding hex failed");
+    let hex = serde_hex::from_hex(encoded).expect("decoding hex failed");
     let decoded = <EnforcedErrors as codec::Decode>::decode(&mut &hex[..]).expect(
         "The `EnforcedError` object could not be decoded. The probable\
         cause is a mismatch between the ink! definition of the type and the\


### PR DESCRIPTION
Fixes the broken `master` CI (see https://gitlab.parity.io/parity/cargo-contract/-/jobs/971882).