### PR TITLE
Implement `BuildMode`

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,3 @@
 license_template_path = "FILE_HEADER" # changed
+report_todo = "Always"
+report_fixme = "Always"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Convenient off-chain testing through `cargo contract test` - [#283](https://github.com/paritytech/cargo-contract/pull/283)
+- Build contracts in debug mode by default, add `--release` flag - [#298](https://github.com/paritytech/cargo-contract/pull/298)
+
 ## [0.12.1] - 2021-04-25
 
 ### Added

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -416,7 +416,6 @@ fn do_optimization(
                 err
             )
         })?;
-    // TODO
 
     if !output.status.success() {
         let err = str::from_utf8(&output.stderr)

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -546,7 +546,8 @@ fn assert_compatible_ink_dependencies(
 /// This feature was introduced in `3.0.0-rc4` with `ink_env/ink-debug`.
 pub fn assert_debug_mode_supported(ink_version: &Version) -> anyhow::Result<()> {
     log::info!("Contract version: {:?}", ink_version);
-    if ink_version <= &Version::parse("3.0.0-rc2").expect("parsing minimum ink! version failed") {
+    let minimum_version = Version::parse("3.0.0-rc4").expect("parsing version failed");
+    if ink_version < &minimum_version {
         anyhow::bail!(
             "Building the contract in debug mode requires an ink! version newer than `3.0.0-rc3`!"
         );

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -18,7 +18,7 @@ use crate::{
     crate_metadata::CrateMetadata,
     maybe_println, util, validate_wasm,
     workspace::{Manifest, ManifestPath, Profile, Workspace},
-    BuildArtifacts, BuildMode, BuildResult, OptimizationPasses, OptimizationResult, UnstableFlags,
+    BuildArtifacts, BuildResult, OptimizationPasses, OptimizationResult, UnstableFlags,
     UnstableOptions, Verbosity, VerbosityFlags,
 };
 use anyhow::{Context, Result};
@@ -48,24 +48,14 @@ pub struct BuildCommand {
     /// Path to the Cargo.toml of the contract to build
     #[structopt(long, parse(from_os_str))]
     manifest_path: Option<PathBuf>,
-    /// Which mode to build the contract in.
+    /// By default the contract is compiled with debug functionality
+    /// included. This enables the contract to output debug messages,
+    /// but increases the contract size and the amount of gas used.
     ///
-    /// - `debug`: The contract will be compiled with debug functionality
-    ///   included. This enables the contract to output debug messages.
-    ///
-    ///   This increases the contract size and the used gas. A production
-    ///   contract should never be build in debug mode!
-    ///
-    /// - `release`: No debug functionality is compiled into the contract.
-    ///
-    /// - The default value is `debug`.
-    #[structopt(
-        long = "mode",
-        default_value = "debug",
-        value_name = "debug | release",
-        verbatim_doc_comment
-    )]
-    build_mode: BuildMode,
+    /// A production contract should always be build in `release` mode!
+    /// Then no debug functionality is compiled into the contract.
+    #[structopt(long = "--release")]
+    build_release: bool,
     /// Which build artifacts to generate.
     ///
     /// - `all`: Generate the Wasm, the metadata and a bundled `<name>.contract` file.
@@ -134,7 +124,7 @@ impl BuildCommand {
         execute(
             &manifest_path,
             verbosity,
-            self.build_mode,
+            self.build_release,
             self.build_artifact,
             unstable_flags,
             optimization_passes,
@@ -163,7 +153,7 @@ impl CheckCommand {
         execute(
             &manifest_path,
             verbosity,
-            BuildMode::Debug,
+            false,
             BuildArtifacts::CheckOnly,
             unstable_flags,
             OptimizationPasses::Zero,
@@ -190,7 +180,7 @@ impl CheckCommand {
 fn exec_cargo_for_wasm_target(
     crate_metadata: &CrateMetadata,
     command: &str,
-    build_mode: BuildMode,
+    build_release: bool,
     verbosity: Verbosity,
     unstable_flags: &UnstableFlags,
 ) -> Result<()> {
@@ -214,7 +204,7 @@ fn exec_cargo_for_wasm_target(
             "--release",
             &target_dir,
         ];
-        if build_mode == BuildMode::Debug {
+        if !build_release {
             args.push("--features=ink_env/ink-debug");
         }
         util::invoke_cargo(command, &args, manifest_path.directory(), verbosity)?;
@@ -551,7 +541,7 @@ fn assert_compatible_ink_dependencies(
 /// This feature was introduced in `3.0.0-rc4` with `ink_env/ink-debug`.
 pub fn assert_debug_mode_supported(ink_version: &Version) -> anyhow::Result<()> {
     log::info!("Contract version: {:?}", ink_version);
-    if ink_version <= &Version::parse("3.0.0-rc3").expect("parsing minimum ink! version failed") {
+    if ink_version <= &Version::parse("3.0.0-rc2").expect("parsing minimum ink! version failed") {
         anyhow::bail!(
             "Building the contract in debug mode requires an ink! version newer than `3.0.0-rc3`!"
         );
@@ -565,7 +555,7 @@ pub fn assert_debug_mode_supported(ink_version: &Version) -> anyhow::Result<()> 
 pub(crate) fn execute(
     manifest_path: &ManifestPath,
     verbosity: Verbosity,
-    build_mode: BuildMode,
+    build_release: bool,
     build_artifact: BuildArtifacts,
     unstable_flags: UnstableFlags,
     optimization_passes: OptimizationPasses,
@@ -585,7 +575,7 @@ pub(crate) fn execute(
         exec_cargo_for_wasm_target(
             &crate_metadata,
             "build",
-            build_mode,
+            build_release,
             verbosity,
             &unstable_flags,
         )?;
@@ -611,13 +601,7 @@ pub(crate) fn execute(
 
     let (opt_result, metadata_result) = match build_artifact {
         BuildArtifacts::CheckOnly => {
-            exec_cargo_for_wasm_target(
-                &crate_metadata,
-                "check",
-                BuildMode::Release,
-                verbosity,
-                &unstable_flags,
-            )?;
+            exec_cargo_for_wasm_target(&crate_metadata, "check", true, verbosity, &unstable_flags)?;
             (None, None)
         }
         BuildArtifacts::CodeOnly => {
@@ -643,7 +627,7 @@ pub(crate) fn execute(
         metadata_result,
         target_directory: crate_metadata.target_directory,
         optimization_result: opt_result,
-        build_mode,
+        build_release,
         build_artifact,
         verbosity,
     })
@@ -660,8 +644,8 @@ mod tests_ci_only {
         cmd::BuildCommand,
         util::tests::{with_new_contract_project, with_tmp_dir},
         workspace::Manifest,
-        BuildArtifacts, BuildMode, ManifestPath, OptimizationPasses, UnstableFlags,
-        UnstableOptions, Verbosity, VerbosityFlags,
+        BuildArtifacts, ManifestPath, OptimizationPasses, UnstableFlags, UnstableOptions,
+        Verbosity, VerbosityFlags,
     };
     use semver::Version;
     #[cfg(unix)]
@@ -715,7 +699,7 @@ mod tests_ci_only {
             let res = super::execute(
                 &manifest_path,
                 Verbosity::Default,
-                BuildMode::default(),
+                false,
                 BuildArtifacts::CodeOnly,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
@@ -755,7 +739,7 @@ mod tests_ci_only {
             super::execute(
                 &manifest_path,
                 Verbosity::Default,
-                BuildMode::default(),
+                false,
                 BuildArtifacts::CheckOnly,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
@@ -786,7 +770,7 @@ mod tests_ci_only {
             let cmd = BuildCommand {
                 manifest_path: Some(manifest_path.into()),
                 build_artifact: BuildArtifacts::All,
-                build_mode: BuildMode::default(),
+                build_release: false,
                 verbosity: VerbosityFlags::default(),
                 unstable_options: UnstableOptions::default(),
 
@@ -827,7 +811,7 @@ mod tests_ci_only {
             let cmd = BuildCommand {
                 manifest_path: Some(manifest_path.into()),
                 build_artifact: BuildArtifacts::All,
-                build_mode: BuildMode::default(),
+                build_release: false,
                 verbosity: VerbosityFlags::default(),
                 unstable_options: UnstableOptions::default(),
 
@@ -989,7 +973,7 @@ mod tests_ci_only {
             let cmd = BuildCommand {
                 manifest_path: Some(manifest_path.into()),
                 build_artifact: BuildArtifacts::All,
-                build_mode: BuildMode::default(),
+                build_release: false,
                 verbosity: VerbosityFlags::default(),
                 unstable_options: UnstableOptions::default(),
                 optimization_passes: None,
@@ -1035,13 +1019,13 @@ mod tests_ci_only {
     fn building_template_in_debug_mode_must_work() {
         with_new_contract_project(|manifest_path| {
             // given
-            let build_mode = BuildMode::Debug;
+            let build_release = false;
 
             // when
             let res = super::execute(
                 &manifest_path,
                 Verbosity::Default,
-                build_mode,
+                build_release,
                 BuildArtifacts::All,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
@@ -1057,13 +1041,13 @@ mod tests_ci_only {
     fn building_template_in_release_mode_must_work() {
         with_new_contract_project(|manifest_path| {
             // given
-            let build_mode = BuildMode::Release;
+            let build_release = true;
 
             // when
             let res = super::execute(
                 &manifest_path,
                 Verbosity::Default,
-                build_mode,
+                build_release,
                 BuildArtifacts::All,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1077,6 +1077,7 @@ mod tests_ci_only {
                 BuildArtifacts::All,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
+                Default::default(),
             );
 
             // then
@@ -1099,6 +1100,7 @@ mod tests_ci_only {
                 BuildArtifacts::All,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
+                Default::default(),
             );
 
             // then
@@ -1107,11 +1109,34 @@ mod tests_ci_only {
         })
     }
 
-    fn keep_debug_symbols() {
+    #[test]
+    fn keep_debug_symbols_in_debug_mode() {
         with_new_contract_project(|manifest_path| {
             let res = super::execute(
                 &manifest_path,
                 Verbosity::Default,
+                BuildMode::Debug,
+                BuildArtifacts::CodeOnly,
+                UnstableFlags::default(),
+                OptimizationPasses::default(),
+                true,
+            )
+            .expect("build failed");
+
+            // we specified that debug symbols should be kept
+            assert!(has_debug_symbols(&res.dest_wasm.unwrap()));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn keep_debug_symbols_in_release_mode() {
+        with_new_contract_project(|manifest_path| {
+            let res = super::execute(
+                &manifest_path,
+                Verbosity::Default,
+                BuildMode::Release,
                 BuildArtifacts::CodeOnly,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1031,9 +1031,6 @@ mod tests_ci_only {
         );
     }
 
-    // We must ignore the test until ink! `3.0.0-rc4` is released, which will
-    // contain `ink_env/ink-debug`.
-    #[ignore]
     #[test]
     fn building_template_in_debug_mode_must_work() {
         with_new_contract_project(|manifest_path| {
@@ -1056,9 +1053,6 @@ mod tests_ci_only {
         })
     }
 
-    // We must ignore the test until ink! `3.0.0-rc4` is released, which will
-    // contain `ink_env/ink-debug`.
-    #[ignore]
     #[test]
     fn building_template_in_release_mode_must_work() {
         with_new_contract_project(|manifest_path| {

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -226,7 +226,7 @@ mod tests {
     use crate::cmd::metadata::blake2_hash;
     use crate::{
         cmd, crate_metadata::CrateMetadata, util::tests::with_new_contract_project, BuildArtifacts,
-        BuildMode, ManifestPath, OptimizationPasses, UnstableFlags, Verbosity,
+        ManifestPath, OptimizationPasses, UnstableFlags, Verbosity,
     };
     use contract_metadata::*;
     use serde_json::{Map, Value};
@@ -325,7 +325,7 @@ mod tests {
             let build_result = cmd::build::execute(
                 &test_manifest.manifest_path,
                 Verbosity::Default,
-                BuildMode::default(),
+                false,
                 BuildArtifacts::All,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -226,7 +226,7 @@ mod tests {
     use crate::cmd::metadata::blake2_hash;
     use crate::{
         cmd, crate_metadata::CrateMetadata, util::tests::with_new_contract_project, BuildArtifacts,
-        ManifestPath, OptimizationPasses, UnstableFlags, Verbosity,
+        BuildMode, ManifestPath, OptimizationPasses, UnstableFlags, Verbosity,
     };
     use contract_metadata::*;
     use serde_json::{Map, Value};
@@ -325,7 +325,7 @@ mod tests {
             let build_result = cmd::build::execute(
                 &test_manifest.manifest_path,
                 Verbosity::Default,
-                false,
+                BuildMode::default(),
                 BuildArtifacts::All,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -226,7 +226,7 @@ mod tests {
     use crate::cmd::metadata::blake2_hash;
     use crate::{
         cmd, crate_metadata::CrateMetadata, util::tests::with_new_contract_project, BuildArtifacts,
-        ManifestPath, OptimizationPasses, UnstableFlags, Verbosity,
+        BuildMode, ManifestPath, OptimizationPasses, UnstableFlags, Verbosity,
     };
     use contract_metadata::*;
     use serde_json::{Map, Value};
@@ -325,6 +325,7 @@ mod tests {
             let build_result = cmd::build::execute(
                 &test_manifest.manifest_path,
                 Verbosity::Default,
+                BuildMode::default(),
                 BuildArtifacts::All,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,6 +270,44 @@ impl std::str::FromStr for BuildArtifacts {
     }
 }
 
+/// The mode to build the contract in.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, StructOpt)]
+#[structopt(name = "build-mode")]
+pub enum BuildMode {
+    /// Functionality to output debug messages is build into the contract.
+    #[structopt(name = "debug")]
+    Debug,
+    /// The contract is build without any debugging functionality.
+    #[structopt(name = "release")]
+    Release,
+}
+
+impl Default for BuildMode {
+    fn default() -> BuildMode {
+        BuildMode::Debug
+    }
+}
+
+impl Display for BuildMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> DisplayResult {
+        match self {
+            Self::Debug => write!(f, "debug"),
+            Self::Release => write!(f, "release"),
+        }
+    }
+}
+
+impl std::str::FromStr for BuildMode {
+    type Err = String;
+    fn from_str(artifact: &str) -> Result<Self, Self::Err> {
+        match artifact {
+            "debug" => Ok(BuildMode::Debug),
+            "release" => Ok(BuildMode::Release),
+            _ => Err("Could not parse build mode".to_string()),
+        }
+    }
+}
+
 /// Result of the metadata generation process.
 pub struct BuildResult {
     /// Path to the resulting Wasm file.
@@ -280,8 +318,8 @@ pub struct BuildResult {
     pub target_directory: PathBuf,
     /// If existent the result of the optimization.
     pub optimization_result: Option<OptimizationResult>,
-    /// If the contract was built as a release.
-    pub build_release: bool,
+    /// The mode to build the contract in.
+    pub build_mode: BuildMode,
     /// Which build artifacts were generated.
     pub build_artifact: BuildArtifacts,
     /// The verbosity flags.
@@ -311,13 +349,9 @@ impl BuildResult {
             "optimized file size must be greater 0"
         );
 
-        let mode = match self.build_release {
-            true => "BUILD",
-            false => "DEBUG",
-        };
         let build_mode = format!(
             "The contract was built in {} mode.\n\n",
-            format!("{}", mode).bold(),
+            format!("{}", self.build_mode).to_uppercase().bold(),
         );
 
         if self.build_artifact == BuildArtifacts::CodeOnly {

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,6 +270,44 @@ impl std::str::FromStr for BuildArtifacts {
     }
 }
 
+/// The mode to build the contract in.
+#[derive(Copy, Clone, Eq, PartialEq, Debug, StructOpt)]
+#[structopt(name = "build-mode")]
+pub enum BuildMode {
+    /// Functionality to output debug messages is build into the contract.
+    #[structopt(name = "debug")]
+    Debug,
+    /// The contract is build without any debugging functionality.
+    #[structopt(name = "release")]
+    Release,
+}
+
+impl Default for BuildMode {
+    fn default() -> BuildMode {
+        BuildMode::Debug
+    }
+}
+
+impl Display for BuildMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> DisplayResult {
+        match self {
+            Self::Debug => write!(f, "debug"),
+            Self::Release => write!(f, "release"),
+        }
+    }
+}
+
+impl std::str::FromStr for BuildMode {
+    type Err = String;
+    fn from_str(artifact: &str) -> Result<Self, Self::Err> {
+        match artifact {
+            "debug" => Ok(BuildMode::Debug),
+            "release" => Ok(BuildMode::Release),
+            _ => Err("Could not parse build mode".to_string()),
+        }
+    }
+}
+
 /// Result of the metadata generation process.
 pub struct BuildResult {
     /// Path to the resulting Wasm file.
@@ -280,6 +318,8 @@ pub struct BuildResult {
     pub target_directory: PathBuf,
     /// If existent the result of the optimization.
     pub optimization_result: Option<OptimizationResult>,
+    /// The mode to build the contract in.
+    pub build_mode: BuildMode,
     /// Which build artifacts were generated.
     pub build_artifact: BuildArtifacts,
     /// The verbosity flags.
@@ -309,10 +349,16 @@ impl BuildResult {
             "optimized file size must be greater 0"
         );
 
+        let build_mode = format!(
+            "The contract was built in {} mode.\n\n",
+            format!("{}", self.build_mode).to_uppercase().bold(),
+        );
+
         if self.build_artifact == BuildArtifacts::CodeOnly {
             let out = format!(
-                "{}Your contract's code is ready. You can find it here:\n{}",
+                "{}{}Your contract's code is ready. You can find it here:\n{}",
                 size_diff,
+                build_mode,
                 self.dest_wasm
                     .as_ref()
                     .expect("wasm path must exist")
@@ -324,8 +370,9 @@ impl BuildResult {
         };
 
         let mut out = format!(
-            "{}Your contract artifacts are ready. You can find them in:\n{}\n\n",
+            "{}{}Your contract artifacts are ready. You can find them in:\n{}\n\n",
             size_diff,
+            build_mode,
             self.target_directory.display().to_string().bold(),
         );
         if let Some(metadata_result) = self.metadata_result.as_ref() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,44 +270,6 @@ impl std::str::FromStr for BuildArtifacts {
     }
 }
 
-/// The mode to build the contract in.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, StructOpt)]
-#[structopt(name = "build-mode")]
-pub enum BuildMode {
-    /// Functionality to output debug messages is build into the contract.
-    #[structopt(name = "debug")]
-    Debug,
-    /// The contract is build without any debugging functionality.
-    #[structopt(name = "release")]
-    Release,
-}
-
-impl Default for BuildMode {
-    fn default() -> BuildMode {
-        BuildMode::Debug
-    }
-}
-
-impl Display for BuildMode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> DisplayResult {
-        match self {
-            Self::Debug => write!(f, "debug"),
-            Self::Release => write!(f, "release"),
-        }
-    }
-}
-
-impl std::str::FromStr for BuildMode {
-    type Err = String;
-    fn from_str(artifact: &str) -> Result<Self, Self::Err> {
-        match artifact {
-            "debug" => Ok(BuildMode::Debug),
-            "release" => Ok(BuildMode::Release),
-            _ => Err("Could not parse build mode".to_string()),
-        }
-    }
-}
-
 /// Result of the metadata generation process.
 pub struct BuildResult {
     /// Path to the resulting Wasm file.
@@ -318,8 +280,8 @@ pub struct BuildResult {
     pub target_directory: PathBuf,
     /// If existent the result of the optimization.
     pub optimization_result: Option<OptimizationResult>,
-    /// The mode to build the contract in.
-    pub build_mode: BuildMode,
+    /// If the contract was built as a release.
+    pub build_release: bool,
     /// Which build artifacts were generated.
     pub build_artifact: BuildArtifacts,
     /// The verbosity flags.
@@ -349,9 +311,13 @@ impl BuildResult {
             "optimized file size must be greater 0"
         );
 
+        let mode = match self.build_release {
+            true => "BUILD",
+            false => "DEBUG",
+        };
         let build_mode = format!(
             "The contract was built in {} mode.\n\n",
-            format!("{}", self.build_mode).to_uppercase().bold(),
+            format!("{}", mode).bold(),
         );
 
         if self.build_artifact == BuildArtifacts::CodeOnly {

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,14 +271,11 @@ impl std::str::FromStr for BuildArtifacts {
 }
 
 /// The mode to build the contract in.
-#[derive(Copy, Clone, Eq, PartialEq, Debug, StructOpt)]
-#[structopt(name = "build-mode")]
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub enum BuildMode {
     /// Functionality to output debug messages is build into the contract.
-    #[structopt(name = "debug")]
     Debug,
     /// The contract is build without any debugging functionality.
-    #[structopt(name = "release")]
     Release,
 }
 
@@ -293,17 +290,6 @@ impl Display for BuildMode {
         match self {
             Self::Debug => write!(f, "debug"),
             Self::Release => write!(f, "release"),
-        }
-    }
-}
-
-impl std::str::FromStr for BuildMode {
-    type Err = String;
-    fn from_str(artifact: &str) -> Result<Self, Self::Err> {
-        match artifact {
-            "debug" => Ok(BuildMode::Debug),
-            "release" => Ok(BuildMode::Release),
-            _ => Err("Could not parse build mode".to_string()),
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/paritytech/cargo-contract/issues/284.

Kinda blocked until we have a release of ink! `3.0.0-rc4`, since the `ink_env/ink-debug` feature is newer than the currently released `3.0.0-rc3`. The tests are failing because they use the published ink! crates.

This PR adds a new CLI flag `--release`, which mirrors the behavior of `cargo` ‒ compiling the artifact in release mode is not done by default.