### PR TITLE
Add `--keep-symbols` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,6 @@ dependencies = [
  "parity-wasm 0.42.2",
  "platforms",
  "pretty_assertions",
- "pwasm-utils",
  "regex",
  "rustc_version",
  "semver",
@@ -2330,17 +2329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "pwasm-utils"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c1a2f10b47d446372a4f397c58b329aaea72b2daf9395a623a411cb8ccb54f"
-dependencies = [
- "byteorder",
- "log",
- "parity-wasm 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ structopt = "0.3.22"
 log = "0.4.14"
 heck = "0.3.3"
 zip = { version = "0.5.13", default-features = false }
-pwasm-utils = "0.18.1"
 parity-wasm = "0.42.2"
 cargo_metadata = "0.14.0"
 codec = { package = "parity-scale-codec", version = "2.1", features = ["derive"] }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -774,11 +774,13 @@ mod tests_ci_only {
                 keep_debug_symbols: false,
             };
 
+            // when
             let res = cmd.exec().expect("build failed");
             let optimization = res
                 .optimization_result
                 .expect("no optimization result available");
 
+            // then
             // The size does not exactly match the original size even without optimization
             // passed because there is still some post processing happening.
             let size_diff = optimization.original_size - optimization.optimized_size;
@@ -810,11 +812,13 @@ mod tests_ci_only {
                 keep_debug_symbols: false,
             };
 
+            // when
             let res = cmd.exec().expect("build failed");
             let optimization = res
                 .optimization_result
                 .expect("no optimization result available");
 
+            // then
             // The size does not exactly match the original size even without optimization
             // passed because there is still some post processing happening.
             let size_diff = optimization.original_size - optimization.optimized_size;

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -278,7 +278,7 @@ fn strip_custom_sections(module: &mut Module) {
 
 /// A contract should export nothing but the "call" and "deploy" functions.
 ///
-/// Any elements referenced by these exports become orphaned and are removed by `wasm-opt`.
+/// Any elements not referenced by these exports become orphaned and are removed by `wasm-opt`.
 fn strip_exports(module: &mut Module) {
     if let Some(section) = module.export_section_mut() {
         section.entries_mut().retain(|entry| {
@@ -820,7 +820,7 @@ mod tests_ci_only {
             let size_diff = optimization.original_size - optimization.optimized_size;
             assert!(
                 size_diff > (optimization.original_size / 2.0),
-                "The optimized size savings are to small: {}",
+                "The optimized size savings are too small: {}",
                 size_diff,
             );
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -681,6 +681,7 @@ mod tests_ci_only {
                 BuildArtifacts::CodeOnly,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
+                false,
             )
             .expect("build failed");
 
@@ -720,6 +721,7 @@ mod tests_ci_only {
                 BuildArtifacts::CheckOnly,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
+                false,
             )
             .expect("build failed");
 
@@ -752,6 +754,7 @@ mod tests_ci_only {
 
                 // we choose zero optimization passes as the "cli" parameter
                 optimization_passes: Some(OptimizationPasses::Zero),
+                keep_symbols: false,
             };
 
             // when
@@ -792,6 +795,7 @@ mod tests_ci_only {
 
                 // we choose no optimization passes as the "cli" parameter
                 optimization_passes: None,
+                keep_symbols: false,
             };
 
             // when
@@ -951,6 +955,7 @@ mod tests_ci_only {
                 verbosity: VerbosityFlags::default(),
                 unstable_options: UnstableOptions::default(),
                 optimization_passes: None,
+                keep_symbols: false,
             };
             let res = cmd.exec().expect("build failed");
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -88,9 +88,9 @@ pub struct BuildCommand {
     ///   The CLI argument always takes precedence over the profile value.
     #[structopt(long)]
     optimization_passes: Option<OptimizationPasses>,
-    /// Do not remove symbols (wasm name section) when optimizing.
+    /// Do not remove symbols (Wasm name section) when optimizing.
     ///
-    /// This is useful if one want to analyze or debug the optimized binary.
+    /// This is useful if one wants to analyze or debug the optimized binary.
     #[structopt(long)]
     keep_symbols: bool,
 }
@@ -267,7 +267,7 @@ fn ensure_maximum_memory_pages(module: &mut Module, maximum_allowed_pages: u32) 
 /// Strips all custom sections.
 ///
 /// Presently all custom sections are not required so they can be stripped safely.
-/// The name section is already stripped by wasm-opt.
+/// The name section is already stripped by `wasm-opt`.
 fn strip_custom_sections(module: &mut Module) {
     module.sections_mut().retain(|section| match section {
         Section::Reloc(_) => false,
@@ -278,7 +278,7 @@ fn strip_custom_sections(module: &mut Module) {
 
 /// A contract should export nothing but the "call" and "deploy" functions.
 ///
-/// Any elements referenced by these exports become orphaned and are removed by wasm-opt.
+/// Any elements referenced by these exports become orphaned and are removed by `wasm-opt`.
 fn strip_exports(module: &mut Module) {
     if let Some(section) = module.export_section_mut() {
         section.entries_mut().retain(|entry| {

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -280,12 +280,12 @@ fn strip_custom_sections(module: &mut Module) {
 ///
 /// Any elements referenced by these exports become orphaned and are removed by wasm-opt.
 fn strip_exports(module: &mut Module) {
-    module.export_section_mut().map(|section| {
+    if let Some(section) = module.export_section_mut() {
         section.entries_mut().retain(|entry| {
             matches!(entry.internal(), Internal::Function(_))
                 && (entry.field() == "call" || entry.field() == "deploy")
         })
-    });
+    }
 }
 
 /// Performs required post-processing steps on the wasm artifact.

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -757,24 +757,19 @@ mod tests_ci_only {
                 keep_symbols: false,
             };
 
-            // when
             let res = cmd.exec().expect("build failed");
             let optimization = res
                 .optimization_result
                 .expect("no optimization result available");
 
-            // then
-            // we have to truncate here to account for a possible small delta
-            // in the floating point numbers
-            let optimized_size = optimization.optimized_size.trunc();
-            let original_size = optimization.original_size.trunc();
+            // The size does not exactly match the original size even without optimization
+            // passed because there is still some post processing happening.
+            let size_diff = optimization.original_size - optimization.optimized_size;
             assert!(
-                optimized_size == original_size,
-                "The optimized size {:?} differs from the original size {:?}",
-                optimized_size,
-                original_size
+                0.0 < size_diff && size_diff < 10.0,
+                "The optimized size savings are larger than allowed or negative: {}",
+                size_diff,
             );
-
             Ok(())
         })
     }
@@ -798,22 +793,18 @@ mod tests_ci_only {
                 keep_symbols: false,
             };
 
-            // when
             let res = cmd.exec().expect("build failed");
             let optimization = res
                 .optimization_result
                 .expect("no optimization result available");
 
-            // then
-            // we have to truncate here to account for a possible small delta
-            // in the floating point numbers
-            let optimized_size = optimization.optimized_size.trunc();
-            let original_size = optimization.original_size.trunc();
+            // The size does not exactly match the original size even without optimization
+            // passed because there is still some post processing happening.
+            let size_diff = optimization.original_size - optimization.optimized_size;
             assert!(
-                optimized_size < original_size,
-                "The optimized size DOES NOT {:?} differ from the original size {:?}",
-                optimized_size,
-                original_size
+                size_diff > (optimization.original_size / 2.0),
+                "The optimized size savings are to small: {}",
+                size_diff,
             );
 
             Ok(())

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -328,6 +328,7 @@ mod tests {
                 BuildArtifacts::All,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
+                false,
             )?;
             let dest_bundle = build_result
                 .metadata_result


### PR DESCRIPTION
In order to properly analyze a contract binary we need to keep the wasm name section alive so that we can see what is going on. Using the non post processed wasm file is of no use because we are interested in the fully optimized binary when doing an analysis. To that end I added a new `--keep-symbols` flag to the `build` command which prevents `wasm-opt` from removing the debug section.

I needed to make some other changes to make this work, too. Most notable I removed the call to `pwasm_utils::optimize` which unconditionally removes all custom sections. We don't need this anyways because `wasm-opt` does the same optimizations and more. It sufficed to remove all exports from the module (but `call` and `deploy`) to have the same result without `pwasm_utils::optimize`. I argue that having one less pass involved is a good thing.