### PR TITLE
Fix tests on macOS

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -120,7 +120,7 @@ pub mod tests {
             .expect("temporary directory creation failed");
 
         // catch test panics in order to clean up temp dir which will be very large
-        f(tmp_dir.path()).expect("Error executing test with tmp dir")
+        f(&tmp_dir.path().canonicalize().unwrap()).expect("Error executing test with tmp dir")
     }
 
     /// Global counter to generate unique contract names in `with_new_contract_project`.


### PR DESCRIPTION
One of the tests fails to pass on macOS. The reason is that the temporary pass used is a symlink and one side of the equality used path canonicalization while the other does not.

This PR fixes that by adding canonicalization to the test only `with_tmp_dir` function.