### PR TITLE
Change default optimizations pass to focus on code size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Change default optimizations pass to focus on code size - [#305](https://github.com/paritytech/cargo-contract/pull/305)
+
 ## [0.12.1] - 2021-04-25
 
 ### Added

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -81,7 +81,7 @@ pub struct BuildCommand {
     ///
     /// - `z`, execute default optimization passes, super-focusing on code size
     ///
-    /// - The default value is `3`
+    /// - The default value is `s`
     ///
     /// - It is possible to define the number of optimization passes in the
     ///   `[package.metadata.contract]` of your `Cargo.toml` as e.g. `optimization-passes = "3"`.

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -81,7 +81,7 @@ pub struct BuildCommand {
     ///
     /// - `z`, execute default optimization passes, super-focusing on code size
     ///
-    /// - The default value is `s`
+    /// - The default value is `z`
     ///
     /// - It is possible to define the number of optimization passes in the
     ///   `[package.metadata.contract]` of your `Cargo.toml` as e.g. `optimization-passes = "3"`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ impl Display for OptimizationPasses {
 
 impl Default for OptimizationPasses {
     fn default() -> OptimizationPasses {
-        OptimizationPasses::Three
+        OptimizationPasses::S
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ impl Display for OptimizationPasses {
 
 impl Default for OptimizationPasses {
     fn default() -> OptimizationPasses {
-        OptimizationPasses::S
+        OptimizationPasses::Z
     }
 }
 


### PR DESCRIPTION
This PR changes the default optimization option passed to `wasm-opt` from `-O3` to ~~`-Os`~~`-Oz`.
This saves us around 0.2-0.3K according to [these rough benchmarks](https://github.com/paritytech/cargo-contract/issues/110#issuecomment-882844120).

~~The default wasn't set to `-Oz` as I saw no noticeable size improvements, and it just
takes more time to run. However, you could also argue that since contracts are in general
quite small the extra time for `-Oz` is negligible so we should enable it anyways.~~

~~While I could be convinced of this, I'm not sure what hardware other people build on, and
the negative impact the change to `-Oz` could have for them.~~


