### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2021-07-22
+
 ### Added
 - Convenient off-chain testing through `cargo contract test` - [#283](https://github.com/paritytech/cargo-contract/pull/283)
 - Build contracts in debug mode by default, add `--release` flag - [#298](https://github.com/paritytech/cargo-contract/pull/298)
+- Add `--keep-symbols` flag for better Wasm analysis capabilities  - [#302](https://github.com/paritytech/cargo-contract/pull/302)
 
 ### Changed
 - Change default optimizations pass to focus on code size - [#305](https://github.com/paritytech/cargo-contract/pull/305)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Change default optimizations pass to focus on code size - [#305](https://github.com/paritytech/cargo-contract/pull/305)
 
-## [0.12.1] - 2021-04-25
+## [0.12.1] - 2021-05-25
 
 ### Added
 - Suggest `binaryen` installation from GitHub release on outdated version - [#274](https://github.com/paritytech/cargo-contract/pull/274)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "metadata"]
 
 [package]
 name = "cargo-contract"
-version = "0.12.1"
+version = "0.13.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"


### PR DESCRIPTION
ink! rc4 has just been published, I would also release `cargo-contract` now, so that's in sync (especially for the `ink_debug!` stuff).