### PR TITLE
Release `contract-metadata` v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contract-metadata"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "pretty_assertions",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ colored = "2.0.0"
 toml = "0.5.8"
 rustc_version = "0.4.0"
 blake2 = "0.9.1"
-contract-metadata = { version = "0.2.0", path = "./metadata" }
+contract-metadata = { version = "0.3.0", path = "./metadata" }
 semver = { version = "1.0.3", features = ["serde"] }
 serde = { version = "1.0.126", default-features = false, features = ["derive"] }
 serde_json = "1.0.64"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -3,5 +3,5 @@
 Defines types for the extended metadata of smart contracts targeting [substrate](https://github.com/paritytech/substrate). 
 
 Currently part of [`cargo-contract`](https://github.com/paritytech/cargo-contract), the build tool for smart
- contracts written in ('ink!)[https://github.com/paritytech/ink].
+ contracts written in [ink!](https://github.com/paritytech/ink).
 


### PR DESCRIPTION
There were only dependency updates for that crate, some in minor version though, hence I would bump from the minor version here as well.