### PR TITLE
CI: force cache pre-population

### DIFF
--- a/scripts/pre_cache.sh
+++ b/scripts/pre_cache.sh
@@ -12,10 +12,11 @@ function prepopulate {
   if [[ ! -d $1 ]]; then
     mkdir -p "$1";
     FRESH_CACHE=$(find "/ci-cache/$CI_PROJECT_NAME/$2" -mindepth 2 -maxdepth 2 \
-      -type d -name "$CI_JOB_NAME" -not -path "$1" -exec stat --printf="%Y\t%n\n" {} \; |sort -n -r |head -1 |cut -f2);
+      -type d -name "$CI_JOB_NAME" -not -path "$1" -exec stat --printf="%Y\t%n\n" {} \; \
+      |sort -n -r |head -1 |cut -f2);
     if [[ -d "$FRESH_CACHE" ]]; then
       echo "____Using" "$FRESH_CACHE" "to prepopulate the cache____";
-      time cp -r "$FRESH_CACHE" "$1";
+      time cp -rf "$FRESH_CACHE" "$1";
     else
       echo "_____No such $2 dir, proceeding from scratch_____";
     fi


### PR DESCRIPTION
Closes: https://github.com/paritytech/ci_cd/issues/166

Let's try your suggestion @cmichi , but I'm pretty sure that the logic there is that it happens only if there's no such a cache dir on the host.

Last time I was revisiting a similar issue I came to the conclusion that this happens because cargo automatically removes some old caches.