### PR TITLE
Add option for JSON formatted output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+-  Add option for JSON formatted output [#324](https://github.com/paritytech/cargo-contract/pull/324)
+
 ## [0.13.1] - 2021-08-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--  Add option for JSON formatted output [#324](https://github.com/paritytech/cargo-contract/pull/324)
+-  Add option for JSON formatted output - [#324](https://github.com/paritytech/cargo-contract/pull/324)
 
 ## [0.13.1] - 2021-08-03
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -104,7 +104,7 @@ pub struct BuildCommand {
     keep_debug_symbols: bool,
 
     /// Export the build output in JSON format.
-    #[structopt(long)]
+    #[structopt(long, conflicts_with = "verbose")]
     output_json: bool,
 }
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -42,7 +42,8 @@ const MAX_MEMORY_PAGES: u32 = 16;
 /// Arguments to use when executing `build` or `check` commands.
 #[derive(Default)]
 pub(crate) struct ExecuteArgs {
-    manifest_path: ManifestPath,
+    /// The location of the Cargo manifest (`Cargo.toml`) file to use.
+    pub(crate) manifest_path: ManifestPath,
     verbosity: Verbosity,
     build_mode: BuildMode,
     build_artifact: BuildArtifacts,
@@ -50,16 +51,6 @@ pub(crate) struct ExecuteArgs {
     optimization_passes: OptimizationPasses,
     keep_debug_symbols: bool,
     output_type: OutputType,
-}
-
-impl ExecuteArgs {
-    /// Construct a default set of `ExecuteArgs` with the given `ManifestPath`.
-    pub(crate) fn with_manifest(manifest_path: ManifestPath) -> Self {
-        Self {
-            manifest_path,
-            ..Default::default()
-        }
-    }
 }
 
 /// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1224,48 +1224,21 @@ mod tests_ci_only {
     }
 
     #[test]
-    fn outputs_json() {
+    fn build_result_seralization_sanity_check() {
         with_new_contract_project(|manifest_path| {
-            // given
-            let build_mode = BuildMode::Debug;
-            dbg!(&manifest_path);
-
-            let build_result = crate::BuildResult {
-                dest_wasm: Some(PathBuf::default()),
-                metadata_result: Some(crate::MetadataResult {
-                    dest_metadata: Default::default(),
-                    dest_bundle: Default::default(),
-                }),
-                target_directory: PathBuf::default(),
-                optimization_result: Some(crate::OptimizationResult {
-                    dest_wasm: Default::default(),
-                    original_size: Default::default(),
-                    optimized_size: Default::default(),
-                }),
-                build_mode: BuildMode::Debug,
-                build_artifact: BuildArtifacts::All,
-                verbosity: Verbosity::Quiet,
-                output_type: OutputType::Json,
-            };
-
-            let j = serde_json::to_string_pretty(&build_result).unwrap();
-            dbg!(&j);
-
-            // when
             let res = super::execute(
                 &manifest_path,
                 Verbosity::Default,
-                build_mode,
+                BuildMode::Release,
                 BuildArtifacts::All,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
                 Default::default(),
                 OutputType::Json,
-            );
+            )
+            .expect("build failed");
 
-            // then
-            assert_eq!(j, res.unwrap().serialize_json());
-            // assert!(res.is_ok(), "building template in debug mode failed!");
+            assert!(res.serialize_json().is_ok());
             Ok(())
         })
     }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -113,7 +113,7 @@ impl BuildCommand {
         let manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
         let unstable_flags: UnstableFlags =
             TryFrom::<&UnstableOptions>::try_from(&self.unstable_options)?;
-        let verbosity = TryFrom::<&VerbosityFlags>::try_from(&self.verbosity)?;
+        let mut verbosity = TryFrom::<&VerbosityFlags>::try_from(&self.verbosity)?;
 
         // The CLI flag `optimization-passes` overwrites optimization passes which are
         // potentially defined in the `Cargo.toml` profile.
@@ -139,6 +139,11 @@ impl BuildCommand {
             true => OutputType::Json,
             false => OutputType::HumanReadable,
         };
+
+        // We want to ensure that the only thing in `STDOUT` is our JSON formatted string.
+        if matches!(output_type, OutputType::Json) {
+            verbosity = Verbosity::Quiet;
+        }
 
         execute(
             &manifest_path,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1215,4 +1215,23 @@ mod tests_ci_only {
             Ok(())
         })
     }
+
+    #[test]
+    fn build_with_json_output_works() {
+        with_new_contract_project(|manifest_path| {
+            // given
+            let args = crate::cmd::build::ExecuteArgs {
+                manifest_path,
+                output_type: OutputType::Json,
+                ..Default::default()
+            };
+
+            // when
+            let res = super::execute(args).expect("build failed");
+
+            // then
+            assert!(res.serialize_json().is_ok());
+            Ok(())
+        })
+    }
 }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1228,6 +1228,7 @@ mod tests_ci_only {
         with_new_contract_project(|manifest_path| {
             // given
             let build_mode = BuildMode::Debug;
+            dbg!(&manifest_path);
 
             let build_result = crate::BuildResult {
                 dest_wasm: Some(PathBuf::default()),
@@ -1236,13 +1237,19 @@ mod tests_ci_only {
                     dest_bundle: Default::default(),
                 }),
                 target_directory: PathBuf::default(),
-                optimization_result: Some(crate::OptimizationResult::default()),
+                optimization_result: Some(crate::OptimizationResult {
+                    dest_wasm: Default::default(),
+                    original_size: Default::default(),
+                    optimized_size: Default::default(),
+                }),
                 build_mode: BuildMode::Debug,
                 build_artifact: BuildArtifacts::All,
-                verbosity: Verbosity::default(),
+                verbosity: Verbosity::Quiet,
                 output_type: OutputType::Json,
             };
+
             let j = serde_json::to_string_pretty(&build_result).unwrap();
+            dbg!(&j);
 
             // when
             let res = super::execute(
@@ -1257,7 +1264,7 @@ mod tests_ci_only {
             );
 
             // then
-            assert!(j, res.serialize_json());
+            assert_eq!(j, res.unwrap().serialize_json());
             // assert!(res.is_ok(), "building template in debug mode failed!");
             Ok(())
         })

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -618,7 +618,6 @@ pub fn assert_debug_mode_supported(ink_version: &Version) -> anyhow::Result<()> 
 /// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.
 ///
 /// It does so by invoking `cargo build` and then post processing the final binary.
-// Maybe turn these args into a struct
 pub(crate) fn execute(args: ExecuteArgs) -> Result<BuildResult> {
     let ExecuteArgs {
         manifest_path,
@@ -1220,14 +1219,17 @@ mod tests_ci_only {
     #[test]
     fn build_result_seralization_sanity_check() {
         with_new_contract_project(|manifest_path| {
+            // given
             let args = crate::cmd::build::ExecuteArgs {
                 manifest_path,
                 output_type: OutputType::Json,
                 ..Default::default()
             };
 
+            // when
             let res = super::execute(args).expect("build failed");
 
+            // then
             assert!(res.serialize_json().is_ok());
             Ok(())
         })

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -725,8 +725,8 @@ mod tests_ci_only {
         cmd::{build::load_module, BuildCommand},
         util::tests::{with_new_contract_project, with_tmp_dir},
         workspace::Manifest,
-        BuildArtifacts, BuildMode, ManifestPath, OptimizationPasses, OutputType, UnstableOptions,
-        Verbosity, VerbosityFlags,
+        BuildArtifacts, BuildMode, ManifestPath, OptimizationPasses, UnstableOptions, Verbosity,
+        VerbosityFlags,
     };
     use semver::Version;
     #[cfg(unix)]
@@ -1212,25 +1212,6 @@ mod tests_ci_only {
             // we specified that debug symbols should be kept
             assert!(has_debug_symbols(&res.dest_wasm.unwrap()));
 
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn build_result_seralization_sanity_check() {
-        with_new_contract_project(|manifest_path| {
-            // given
-            let args = crate::cmd::build::ExecuteArgs {
-                manifest_path,
-                output_type: OutputType::Json,
-                ..Default::default()
-            };
-
-            // when
-            let res = super::execute(args).expect("build failed");
-
-            // then
-            assert!(res.serialize_json().is_ok());
             Ok(())
         })
     }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -704,7 +704,7 @@ mod tests_ci_only {
         cmd::{build::load_module, BuildCommand},
         util::tests::{with_new_contract_project, with_tmp_dir},
         workspace::Manifest,
-        BuildArtifacts, BuildMode, ManifestPath, OptimizationPasses, UnstableFlags,
+        BuildArtifacts, BuildMode, ManifestPath, OptimizationPasses, OutputType, UnstableFlags,
         UnstableOptions, Verbosity, VerbosityFlags,
     };
     use semver::Version;
@@ -768,6 +768,7 @@ mod tests_ci_only {
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
                 false,
+                OutputType::default(),
             )
             .expect("build failed");
 
@@ -813,6 +814,7 @@ mod tests_ci_only {
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
                 false,
+                OutputType::default(),
             )
             .expect("build failed");
 
@@ -847,6 +849,7 @@ mod tests_ci_only {
                 // we choose zero optimization passes as the "cli" parameter
                 optimization_passes: Some(OptimizationPasses::Zero),
                 keep_debug_symbols: false,
+                output_json: false,
             };
 
             // when
@@ -886,6 +889,7 @@ mod tests_ci_only {
                 // we choose no optimization passes as the "cli" parameter
                 optimization_passes: None,
                 keep_debug_symbols: false,
+                output_json: false,
             };
 
             // when
@@ -1050,6 +1054,7 @@ mod tests_ci_only {
                 unstable_options: UnstableOptions::default(),
                 optimization_passes: None,
                 keep_debug_symbols: false,
+                output_json: false,
             };
             let res = cmd.exec().expect("build failed");
 
@@ -1103,6 +1108,7 @@ mod tests_ci_only {
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
                 Default::default(),
+                Default::default(),
             );
 
             // then
@@ -1125,6 +1131,7 @@ mod tests_ci_only {
                 BuildArtifacts::All,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
+                Default::default(),
                 Default::default(),
             );
 
@@ -1161,6 +1168,7 @@ mod tests_ci_only {
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
                 Default::default(),
+                Default::default(),
             );
 
             // then
@@ -1180,6 +1188,7 @@ mod tests_ci_only {
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
                 true,
+                OutputType::default(),
             )
             .expect("build failed");
 
@@ -1201,6 +1210,7 @@ mod tests_ci_only {
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
                 true,
+                OutputType::default(),
             )
             .expect("build failed");
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -599,7 +599,7 @@ pub fn assert_debug_mode_supported(ink_version: &Version) -> anyhow::Result<()> 
 /// Executes build of the smart-contract which produces a wasm binary that is ready for deploying.
 ///
 /// It does so by invoking `cargo build` and then post processing the final binary.
-// TODO: Maybe turn these args into a struct
+// Maybe turn these args into a struct
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn execute(
     manifest_path: &ManifestPath,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -726,8 +726,8 @@ mod tests_ci_only {
         cmd::{build::load_module, BuildCommand},
         util::tests::{with_new_contract_project, with_tmp_dir},
         workspace::Manifest,
-        BuildArtifacts, BuildMode, ManifestPath, OptimizationPasses, UnstableOptions, Verbosity,
-        VerbosityFlags,
+        BuildArtifacts, BuildMode, ManifestPath, OptimizationPasses, OutputType, UnstableOptions,
+        Verbosity, VerbosityFlags,
     };
     use semver::Version;
     #[cfg(unix)]

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -226,8 +226,7 @@ fn blake2_hash(code: &[u8]) -> CodeHash {
 mod tests {
     use crate::cmd::metadata::blake2_hash;
     use crate::{
-        cmd, crate_metadata::CrateMetadata, util::tests::with_new_contract_project, BuildArtifacts,
-        BuildMode, ManifestPath, OptimizationPasses, OutputType, UnstableFlags, Verbosity,
+        cmd, crate_metadata::CrateMetadata, util::tests::with_new_contract_project, ManifestPath,
     };
     use anyhow::Context;
     use contract_metadata::*;
@@ -320,16 +319,14 @@ mod tests {
             fs::create_dir_all(final_contract_wasm_path.parent().unwrap()).unwrap();
             fs::write(final_contract_wasm_path, "TEST FINAL WASM BLOB").unwrap();
 
-            let build_result = cmd::build::execute(
-                &test_manifest.manifest_path,
-                Verbosity::Default,
-                BuildMode::default(),
-                BuildArtifacts::All,
-                UnstableFlags::default(),
-                OptimizationPasses::default(),
-                false,
-                OutputType::default(),
-            )?;
+            let args = crate::cmd::build::ExecuteArgs::with_manifest(test_manifest.manifest_path);
+            // args.manifest_path = test_manifest.manifest_path;
+            // {
+            //     manifest_path: test_manifest.manifest_path,
+            //     ..Default::default()
+            // };
+
+            let build_result = cmd::build::execute(args)?;
             let dest_bundle = build_result
                 .metadata_result
                 .expect("Metadata should be generated")

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -227,7 +227,7 @@ mod tests {
     use crate::cmd::metadata::blake2_hash;
     use crate::{
         cmd, crate_metadata::CrateMetadata, util::tests::with_new_contract_project, BuildArtifacts,
-        BuildMode, ManifestPath, OptimizationPasses, UnstableFlags, Verbosity,
+        BuildMode, ManifestPath, OptimizationPasses, OutputType, UnstableFlags, Verbosity,
     };
     use anyhow::Context;
     use contract_metadata::*;
@@ -328,6 +328,7 @@ mod tests {
                 UnstableFlags::default(),
                 OptimizationPasses::default(),
                 false,
+                OutputType::default(),
             )?;
             let dest_bundle = build_result
                 .metadata_result

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -38,6 +38,7 @@ use url::Url;
 const METADATA_FILE: &str = "metadata.json";
 
 /// Metadata generation result.
+#[derive(serde::Serialize)]
 pub struct MetadataResult {
     /// Path to the resulting metadata file.
     pub dest_metadata: PathBuf,

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -319,12 +319,8 @@ mod tests {
             fs::create_dir_all(final_contract_wasm_path.parent().unwrap()).unwrap();
             fs::write(final_contract_wasm_path, "TEST FINAL WASM BLOB").unwrap();
 
-            let args = crate::cmd::build::ExecuteArgs::with_manifest(test_manifest.manifest_path);
-            // args.manifest_path = test_manifest.manifest_path;
-            // {
-            //     manifest_path: test_manifest.manifest_path,
-            //     ..Default::default()
-            // };
+            let mut args = crate::cmd::build::ExecuteArgs::default();
+            args.manifest_path = test_manifest.manifest_path;
 
             let build_result = cmd::build::execute(args)?;
             let dest_bundle = build_result

--- a/src/main.rs
+++ b/src/main.rs
@@ -416,9 +416,8 @@ impl BuildResult {
     }
 
     /// Display the build results in a pretty formatted JSON string.
-    pub fn serialize_json(&self) -> String {
-        serde_json::to_string_pretty(self)
-            .expect("Since the built execution finished our BuiltResult must be non-empty.")
+    pub fn serialize_json(&self) -> Result<String> {
+        Ok(serde_json::to_string_pretty(self)?)
     }
 }
 
@@ -512,7 +511,7 @@ fn exec(cmd: Command) -> Result<Option<String>> {
             let result = build.exec()?;
 
             if matches!(result.output_type, OutputType::Json) {
-                Ok(Some(result.serialize_json()))
+                Ok(Some(result.serialize_json()?))
             } else if result.verbosity.is_verbose() {
                 Ok(Some(result.display()))
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,6 +294,7 @@ impl Display for BuildMode {
     }
 }
 
+/// The type of output to display at the end of a build.
 pub enum OutputType {
     /// Output build results in a human readable format.
     HumanReadable,
@@ -510,12 +511,9 @@ fn exec(cmd: Command) -> Result<Option<String>> {
         Command::Build(build) => {
             let result = build.exec()?;
 
-            // How should this play with the verbosity argument?
             if matches!(result.output_type, OutputType::Json) {
-                return Ok(Some(result.serialize_json()));
-            }
-
-            if result.verbosity.is_verbose() {
+                Ok(Some(result.serialize_json()))
+            } else if result.verbosity.is_verbose() {
                 Ok(Some(result.display()))
             } else {
                 Ok(None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,7 +337,7 @@ pub struct BuildResult {
     pub build_artifact: BuildArtifacts,
     /// The verbosity flags.
     pub verbosity: Verbosity,
-    /// The type of formatting to use for the built output.
+    /// The type of formatting to use for the build output.
     #[serde(skip_serializing)]
     pub output_type: OutputType,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -579,3 +579,54 @@ fn exec(cmd: Command) -> Result<Option<String>> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_result_seralization_sanity_check() {
+        // given
+        let raw_result = r#"{
+  "dest_wasm": "/path/to/contract.wasm",
+  "metadata_result": {
+    "dest_metadata": "/path/to/metadata.json",
+    "dest_bundle": "/path/to/contract.contract"
+  },
+  "target_directory": "/path/to/target",
+  "optimization_result": {
+    "dest_wasm": "/path/to/contract.wasm",
+    "original_size": 64.0,
+    "optimized_size": 32.0
+  },
+  "build_mode": "Debug",
+  "build_artifact": "All",
+  "verbosity": "Quiet"
+}"#;
+
+        let build_result = crate::BuildResult {
+            dest_wasm: Some(PathBuf::from("/path/to/contract.wasm")),
+            metadata_result: Some(crate::cmd::metadata::MetadataResult {
+                dest_metadata: PathBuf::from("/path/to/metadata.json"),
+                dest_bundle: PathBuf::from("/path/to/contract.contract"),
+            }),
+            target_directory: PathBuf::from("/path/to/target"),
+            optimization_result: Some(crate::OptimizationResult {
+                dest_wasm: PathBuf::from("/path/to/contract.wasm"),
+                original_size: 64.0,
+                optimized_size: 32.0,
+            }),
+            build_mode: Default::default(),
+            build_artifact: Default::default(),
+            verbosity: Verbosity::Quiet,
+            output_type: OutputType::Json,
+        };
+
+        // when
+        let serialized_result = build_result.serialize_json();
+
+        // then
+        assert!(serialized_result.is_ok());
+        assert_eq!(serialized_result.unwrap(), raw_result);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,12 @@ pub enum Verbosity {
     Verbose,
 }
 
+impl Default for Verbosity {
+    fn default() -> Self {
+        Verbosity::Default
+    }
+}
+
 impl Verbosity {
     /// Returns `true` if output should be printed (i.e. verbose output is set).
     pub(crate) fn is_verbose(&self) -> bool {
@@ -267,6 +273,12 @@ impl std::str::FromStr for BuildArtifacts {
             "code-only" => Ok(BuildArtifacts::CodeOnly),
             _ => Err("Could not parse build artifact".to_string()),
         }
+    }
+}
+
+impl Default for BuildArtifacts {
+    fn default() -> Self {
+        BuildArtifacts::All
     }
 }
 


### PR DESCRIPTION
Adds a new `--output-json` flag which will output `build` results in JSON instead of the
normal human readable format. This is useful for using `cargo-contract` in part of data
pipelines.
