### PR TITLE
Use new dependency resolver for template contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Use new dependency resolver for template contract [#325](https://github.com/paritytech/cargo-contract/pull/325)
+- Use new dependency resolver for template contract - [#325](https://github.com/paritytech/cargo-contract/pull/325)
 
 ## [0.13.1] - 2021-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Use new dependency resolver for template contract [#325](https://github.com/paritytech/cargo-contract/pull/325)
+
 ## [0.13.1] - 2021-08-03
 
 ### Fixed

--- a/templates/new/_Cargo.toml
+++ b/templates/new/_Cargo.toml
@@ -3,6 +3,7 @@ name = "{{name}}"
 version = "0.1.0"
 authors = ["[your_name] <[your_email]>"]
 edition = "2018"
+resolver = "2"
 
 [dependencies]
 ink_primitives = { version = "3.0.0-rc3", default-features = false }


### PR DESCRIPTION
By default, Cargo's dependency resolver leaks `std` features from `dev-dependencies` into
`no_std` builds. This results in confusing errors messages such as the one in
https://github.com/paritytech/ink/issues/889. 

To avoid issues like this we can use the new(ish) dependency resolver, which doesn't leak
features from `dev-dependencies` into the regular build. You can read more about it [here](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2).
