### PR TITLE
Do not strip out panic messages in debug builds

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -210,13 +210,14 @@ fn exec_cargo_for_wasm_target(
         let mut args = vec![
             "--target=wasm32-unknown-unknown",
             "-Zbuild-std",
-            "-Zbuild-std-features=panic_immediate_abort",
             "--no-default-features",
             "--release",
             &target_dir,
         ];
         if build_mode == BuildMode::Debug {
             args.push("--features=ink_env/ink-debug");
+        } else {
+            args.push("-Zbuild-std-features=panic_immediate_abort");
         }
         util::invoke_cargo(command, &args, manifest_path.directory(), verbosity)?;
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -744,7 +744,7 @@ mod tests_ci_only {
             let res = super::execute(
                 &manifest_path,
                 Verbosity::Default,
-                BuildMode::default(),
+                BuildMode::Release,
                 BuildArtifacts::CodeOnly,
                 UnstableFlags::default(),
                 OptimizationPasses::default(),


### PR DESCRIPTION
We should keep the panic messages for debug builds because they convey valuable information. Until `Result` based error handling is implemented that is even the only way of reacting to runtime errors (as opposed to programming errors for which panics are usually used).