### PR TITLE
Offline flag

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -451,7 +451,6 @@ fn do_optimization(
             We use this tool to optimize the size of your contract's Wasm binary.\n\n\
             wasm-opt is part of the binaryen package. You can find detailed\n\
             installation instructions on https://github.com/WebAssembly/binaryen#tools.\n\n\
-
             There are ready-to-install packages for many platforms:\n\
             * Debian/Ubuntu: apt-get install binaryen\n\
             * Homebrew: brew install binaryen\n\

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -713,6 +713,7 @@ pub(crate) fn execute(args: ExecuteArgs) -> Result<BuildResult> {
             let metadata_result = super::metadata::execute(
                 &crate_metadata,
                 optimization_result.dest_wasm.as_path(),
+                network,
                 verbosity,
                 build_artifact.steps(),
                 &unstable_flags,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -70,6 +70,9 @@ pub struct BuildCommand {
     /// Then no debug functionality is compiled into the contract.
     #[structopt(long = "--release")]
     build_release: bool,
+    /// Build offline
+    #[structopt(long = "--offline")]
+    build_offline: bool,
     /// Which build artifacts to generate.
     ///
     /// - `all`: Generate the Wasm, the metadata and a bundled `<name>.contract` file.

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -18,8 +18,8 @@ use crate::{
     crate_metadata::CrateMetadata,
     maybe_println, util, validate_wasm,
     workspace::{Manifest, ManifestPath, Profile, Workspace},
-    BuildArtifacts, BuildMode, Network, BuildResult, OptimizationPasses, OptimizationResult, OutputType,
-    UnstableFlags, UnstableOptions, Verbosity, VerbosityFlags,
+    BuildArtifacts, BuildMode, BuildResult, Network, OptimizationPasses, OptimizationResult,
+    OutputType, UnstableFlags, UnstableOptions, Verbosity, VerbosityFlags,
 };
 use anyhow::{Context, Result};
 use colored::Colorize;

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -876,6 +876,7 @@ mod tests_ci_only {
                 manifest_path: Some(manifest_path.into()),
                 build_artifact: BuildArtifacts::All,
                 build_release: false,
+                build_offline: false,
                 verbosity: VerbosityFlags::default(),
                 unstable_options: UnstableOptions::default(),
 
@@ -916,6 +917,7 @@ mod tests_ci_only {
                 manifest_path: Some(manifest_path.into()),
                 build_artifact: BuildArtifacts::All,
                 build_release: false,
+                build_offline: false,
                 verbosity: VerbosityFlags::default(),
                 unstable_options: UnstableOptions::default(),
 
@@ -1083,6 +1085,7 @@ mod tests_ci_only {
                 manifest_path: Some(manifest_path.into()),
                 build_artifact: BuildArtifacts::All,
                 build_release: false,
+                build_offline: false,
                 verbosity: VerbosityFlags::default(),
                 unstable_options: UnstableOptions::default(),
                 optimization_passes: None,

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -18,7 +18,7 @@ use crate::{
     crate_metadata::CrateMetadata,
     maybe_println, util,
     workspace::{ManifestPath, Workspace},
-    UnstableFlags, Verbosity, Network
+    Network, UnstableFlags, Verbosity,
 };
 
 use anyhow::Result;
@@ -96,7 +96,7 @@ pub(crate) fn execute(
                 &manifest_path.cargo_arg(),
                 &target_dir_arg,
                 "--release",
-                &network.to_string()
+                &network.to_string(),
             ],
             crate_metadata.manifest_path.directory(),
             verbosity,

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -18,7 +18,7 @@ use crate::{
     crate_metadata::CrateMetadata,
     maybe_println, util,
     workspace::{ManifestPath, Workspace},
-    UnstableFlags, Verbosity,
+    UnstableFlags, Verbosity, Network
 };
 
 use anyhow::Result;
@@ -59,6 +59,7 @@ struct ExtendedMetadataResult {
 pub(crate) fn execute(
     crate_metadata: &CrateMetadata,
     final_contract_wasm: &Path,
+    network: Network,
     verbosity: Verbosity,
     total_steps: usize,
     unstable_options: &UnstableFlags,
@@ -95,6 +96,7 @@ pub(crate) fn execute(
                 &manifest_path.cargo_arg(),
                 &target_dir_arg,
                 "--release",
+                &network.to_string()
             ],
             crate_metadata.manifest_path.directory(),
             verbosity,

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,6 +306,30 @@ impl Display for BuildMode {
     }
 }
 
+/// USe network to build contracts or cached dependencies only.
+#[derive(Eq, PartialEq, Copy, Clone, Debug, serde::Serialize)]
+pub enum Network {
+    /// Use network
+    Online,
+    /// Use cached dependencies.
+    Offline,
+}
+
+impl Default for Network {
+    fn default() -> Network {
+        Network::Online
+    }
+}
+
+impl Display for Network {
+    fn fmt(&self, f: &mut Formatter<'_>) -> DisplayResult {
+        match self {
+            Self::Online => write!(f, ""),
+            Self::Offline => write!(f, "offline"),
+        }
+    }
+}
+
 /// The type of output to display at the end of a build.
 pub enum OutputType {
     /// Output build results in a human readable format.

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,7 +306,7 @@ impl Display for BuildMode {
     }
 }
 
-/// USe network to build contracts or cached dependencies only.
+/// Use network connection to build contracts and generate metadata or use cached dependencies only.
 #[derive(Eq, PartialEq, Copy, Clone, Debug, serde::Serialize)]
 pub enum Network {
     /// Use network
@@ -325,7 +325,7 @@ impl Display for Network {
     fn fmt(&self, f: &mut Formatter<'_>) -> DisplayResult {
         match self {
             Self::Online => write!(f, ""),
-            Self::Offline => write!(f, "offline"),
+            Self::Offline => write!(f, "--offline"),
         }
     }
 }


### PR DESCRIPTION
This PR adds a `--offline` flag which can be used to build contracts without network acces with `cargo contract build --offline`.

The motivation for providing this extra flag is to be able to compile Smart contracts in [ink! Playground](https://github.com/paritytech/ink-playground) within a safe docker environment without direct network access.

Ussing the `--offline` flag for `cargo contract build`, both, cargo build and also the generation of cargo contract metadata become possible without network connection, using cached dependencies only.