### PR TITLE
Use `-Clinker-plugin-lto` flag during Wasm build

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -249,7 +249,7 @@ fn exec_cargo_for_wasm_target(
     // Currently will override user defined RUSTFLAGS from .cargo/config. See https://github.com/paritytech/cargo-contract/issues/98.
     std::env::set_var(
         "RUSTFLAGS",
-        "-C link-arg=-zstack-size=65536 -C link-arg=--import-memory -Clto -Clinker-plugin-lto",
+        "-C link-arg=-zstack-size=65536 -C link-arg=--import-memory -Clinker-plugin-lto",
     );
 
     let cargo_build = |manifest_path: &ManifestPath| {

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -249,7 +249,7 @@ fn exec_cargo_for_wasm_target(
     // Currently will override user defined RUSTFLAGS from .cargo/config. See https://github.com/paritytech/cargo-contract/issues/98.
     std::env::set_var(
         "RUSTFLAGS",
-        "-C link-arg=-zstack-size=65536 -C link-arg=--import-memory",
+        "-C link-arg=-zstack-size=65536 -C link-arg=--import-memory -Clto -Clinker-plugin-lto",
     );
 
     let cargo_build = |manifest_path: &ManifestPath| {


### PR DESCRIPTION
`-Clinker-plugin-lto` reduced the size of my contract
From:
Original wasm size: 68.6K, Optimized: 31.9K

To:
Original wasm size: 67.2K, Optimized: 31.0K