### PR TITLE
Deserialize metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Use of `-Clinker-plugin-lto` flag(reduces the size of the contract) if `lto` is enabled - [#358](https://github.com/paritytech/cargo-contract/pull/358)
+- Deserialize metadata - [#368](https://github.com/paritytech/cargo-contract/pull/368)
 
 ## [0.15.0] - 2021-10-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 name = "contract-metadata"
 version = "0.4.0"
 dependencies = [
+ "impl-serde",
  "pretty_assertions",
  "semver",
  "serde",

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -17,6 +17,7 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 path = "lib.rs"
 
 [dependencies]
+impl-serde = "0.3.2"
 semver = { version = "1.0.4", features = ["serde"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = "1.0.71"

--- a/metadata/byte_str.rs
+++ b/metadata/byte_str.rs
@@ -70,12 +70,12 @@ where
         }
 
         fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
-            let mut result = from_hex(v).map_err(E::custom)?;
+            let result = from_hex(v).map_err(E::custom)?;
             if result.len() != 32 {
                 Err(E::custom("Expected exactly 32 bytes"))
             } else {
                 let mut arr = [0u8; 32];
-                arr.copy_from_slice(&mut result[..]);
+                arr.copy_from_slice(&result[..]);
                 Ok(arr)
             }
         }

--- a/metadata/byte_str.rs
+++ b/metadata/byte_str.rs
@@ -1,0 +1,97 @@
+// Copyright 2018-2021 Parity Technologies (UK) Ltd.
+// This file is part of cargo-contract.
+//
+// cargo-contract is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// cargo-contract is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
+
+use impl_serde::serialize as serde_hex;
+
+/// Serializes the given bytes as byte string.
+pub fn serialize_as_byte_str<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if bytes.is_empty() {
+        // Return empty string without prepended `0x`.
+        return serializer.serialize_str("");
+    }
+    serde_hex::serialize(bytes, serializer)
+}
+
+/// Deserializes the given hex string with optional `0x` prefix.
+pub fn deserialize_from_byte_str<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'b> serde::de::Visitor<'b> for Visitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "hex string with optional 0x prefix")
+        }
+
+        fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            let result = from_hex(v);
+            result.map_err(E::custom)
+        }
+
+        fn visit_string<E: serde::de::Error>(self, v: String) -> Result<Self::Value, E> {
+            self.visit_str(&v)
+        }
+    }
+
+    deserializer.deserialize_str(Visitor)
+}
+
+/// Deserializes the given hex string with optional `0x` prefix.
+pub fn deserialize_from_byte_str_array<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'b> serde::de::Visitor<'b> for Visitor {
+        type Value = [u8; 32];
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "hex string with optional 0x prefix")
+        }
+
+        fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+            let mut result = from_hex(v).map_err(E::custom)?;
+            if result.len() != 32 {
+                Err(E::custom("Expected exactly 32 bytes"))
+            } else {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&mut result[..]);
+                Ok(arr)
+            }
+        }
+
+        fn visit_string<E: serde::de::Error>(self, v: String) -> Result<Self::Value, E> {
+            self.visit_str(&v)
+        }
+    }
+
+    deserializer.deserialize_str(Visitor)
+}
+
+fn from_hex(v: &str) -> Result<Vec<u8>, serde_hex::FromHexError> {
+    if v.starts_with("0x") {
+        serde_hex::from_hex(v)
+    } else {
+        serde_hex::from_hex(&format!("0x{}", v))
+    }
+}

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -793,9 +793,9 @@ mod tests {
                 "types": []
             }
         }
-            .as_object()
-            .unwrap()
-            .clone();
+        .as_object()
+        .unwrap()
+        .clone();
 
         let metadata = ContractMetadata::new(source, contract, Some(user), abi_json);
         let json = serde_json::to_value(&metadata).unwrap();

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -66,11 +66,14 @@ use url::Url;
 /// Smart contract metadata.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ContractMetadata {
+    /// Information about the contract's Wasm code.
     pub source: Source,
+    /// Metadata about the contract.
     pub contract: Contract,
+    /// Additional user-defined metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<User>,
-    /// Raw JSON of the contract abi metadata, generated during contract compilation.
+    /// Raw JSON of the contract's abi metadata, generated during contract compilation.
     #[serde(flatten)]
     pub abi: Map<String, Value>,
 }
@@ -103,14 +106,21 @@ pub struct CodeHash(
         serialize_with = "byte_str::serialize_as_byte_str",
         deserialize_with = "byte_str::deserialize_from_byte_str_array"
     )]
+    /// The raw bytes of the hash.
     pub [u8; 32],
 );
 
+/// Information about the contract's Wasm code.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Source {
+    /// The hash of the contract's Wasm code.
     pub hash: CodeHash,
+    /// The language used to write the contract.
     pub language: SourceLanguage,
+    /// The compiler used to compile the contract.
     pub compiler: SourceCompiler,
+    /// The actual Wasm code of the contract, for optionally bundling the code
+    /// with the metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wasm: Option<SourceWasm>,
 }
@@ -139,6 +149,7 @@ pub struct SourceWasm(
         serialize_with = "byte_str::serialize_as_byte_str",
         deserialize_with = "byte_str::deserialize_from_byte_str"
     )]
+    /// The raw bytes of the Wasm code.
     pub Vec<u8>,
 );
 
@@ -162,7 +173,9 @@ impl Display for SourceWasm {
 /// The language and version in which a smart contract is written.
 #[derive(Clone, Debug)]
 pub struct SourceLanguage {
+    /// The language used to write the contract.
     pub language: Language,
+    /// The version of the language used to write the contract.
     pub version: Version,
 }
 
@@ -265,7 +278,9 @@ impl FromStr for Language {
 /// A compiler used to compile a smart contract.
 #[derive(Clone, Debug)]
 pub struct SourceCompiler {
+    /// The compiler used to compile the smart contract.
     pub compiler: Compiler,
+    /// The version of the compiler used to compile the smart contract.
     pub version: Version,
 }
 
@@ -336,7 +351,9 @@ impl SourceCompiler {
 /// Compilers used to compile a smart contract.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Compiler {
+    /// The rust compiler.
     RustC,
+    /// The solang compiler.
     Solang,
 }
 
@@ -364,17 +381,25 @@ impl FromStr for Compiler {
 /// Metadata about a smart contract.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Contract {
+    /// The name of the smart contract.
     pub name: String,
+    /// The version of the smart contract.
     pub version: Version,
+    /// The authors of the smart contract.
     pub authors: Vec<String>,
+    /// The description of the smart contract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Link to the documentation of the smart contract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub documentation: Option<Url>,
+    /// Link to the code repository of the smart contract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repository: Option<Url>,
+    /// Link to the homepage of the smart contract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub homepage: Option<Url>,
+    /// The license of the smart contract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub license: Option<String>,
 }
@@ -388,8 +413,9 @@ impl Contract {
 /// Additional user defined metadata, can be any valid json.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    /// Raw json of user defined metadata.
     #[serde(flatten)]
-    json: Map<String, Value>,
+    pub json: Map<String, Value>,
 }
 
 impl User {

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -134,25 +134,25 @@ impl Source {
 
 /// The bytes of the compiled Wasm smart contract.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct SourceWasm {
+pub struct SourceWasm(
     #[serde(
         serialize_with = "byte_str::serialize_as_byte_str",
         deserialize_with = "byte_str::deserialize_from_byte_str"
     )]
-    wasm: Vec<u8>,
-}
+    pub Vec<u8>,
+);
 
 impl SourceWasm {
     /// Constructs a new `SourceWasm`.
     pub fn new(wasm: Vec<u8>) -> Self {
-        SourceWasm { wasm }
+        SourceWasm(wasm)
     }
 }
 
 impl Display for SourceWasm {
     fn fmt(&self, f: &mut Formatter<'_>) -> DisplayResult {
         write!(f, "0x").expect("failed writing to string");
-        for byte in &self.wasm {
+        for byte in &self.0 {
             write!(f, "{:02x}", byte).expect("failed writing to string");
         }
         write!(f, "")

--- a/metadata/lib.rs
+++ b/metadata/lib.rs
@@ -61,13 +61,13 @@ use url::Url;
 /// Smart contract metadata.
 #[derive(Clone, Debug, Serialize)]
 pub struct ContractMetadata {
-    source: Source,
-    contract: Contract,
+    pub source: Source,
+    pub contract: Contract,
     #[serde(skip_serializing_if = "Option::is_none")]
-    user: Option<User>,
+    pub user: Option<User>,
     /// Raw JSON of the contract abi metadata, generated during contract compilation.
     #[serde(flatten)]
-    abi: Map<String, Value>,
+    pub abi: Map<String, Value>,
 }
 
 impl ContractMetadata {
@@ -106,11 +106,11 @@ impl Serialize for CodeHash {
 
 #[derive(Clone, Debug, Serialize)]
 pub struct Source {
-    hash: CodeHash,
-    language: SourceLanguage,
-    compiler: SourceCompiler,
+    pub hash: CodeHash,
+    pub language: SourceLanguage,
+    pub compiler: SourceCompiler,
     #[serde(skip_serializing_if = "Option::is_none")]
-    wasm: Option<SourceWasm>,
+    pub wasm: Option<SourceWasm>,
 }
 
 impl Source {
@@ -165,8 +165,8 @@ impl Display for SourceWasm {
 /// The language and version in which a smart contract is written.
 #[derive(Clone, Debug)]
 pub struct SourceLanguage {
-    language: Language,
-    version: Version,
+    pub language: Language,
+    pub version: Version,
 }
 
 impl SourceLanguage {
@@ -212,8 +212,8 @@ impl Display for Language {
 /// A compiler used to compile a smart contract.
 #[derive(Clone, Debug)]
 pub struct SourceCompiler {
-    compiler: Compiler,
-    version: Version,
+    pub compiler: Compiler,
+    pub version: Version,
 }
 
 impl Display for SourceCompiler {
@@ -256,19 +256,19 @@ impl Display for Compiler {
 /// Metadata about a smart contract.
 #[derive(Clone, Debug, Serialize)]
 pub struct Contract {
-    name: String,
-    version: Version,
-    authors: Vec<String>,
+    pub name: String,
+    pub version: Version,
+    pub authors: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
+    pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    documentation: Option<Url>,
+    pub documentation: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    repository: Option<Url>,
+    pub repository: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    homepage: Option<Url>,
+    pub homepage: Option<Url>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    license: Option<String>,
+    pub license: Option<String>,
 }
 
 impl Contract {


### PR DESCRIPTION
Extracted from #79. Would be required for any consumer to deserialize contract metadata into Rust types.

- Implement deserializing `cargo-contract` metadata
- Expose all fields as `pub` for decoded metadata.