### PR TITLE
Release `cargo-contract` v0.16.0 and `metadata` v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2021-11-25
+
 ### Changed
-- Use of `-Clinker-plugin-lto` flag(reduces the size of the contract) if `lto` is enabled - [#358](https://github.com/paritytech/cargo-contract/pull/358)
+- Updated `cargo contract new` template dependencies to ink! `3.0.0-rc7` - [#374](https://github.com/paritytech/cargo-contract/pull/374)
+- Disabled overflow checks in the `cargo contract new` template - [#372](https://github.com/paritytech/cargo-contract/pull/372)
+- Use `-Clinker-plugin-lto` if `lto` is enabled (reduces the size of a contract) - [#358](https://github.com/paritytech/cargo-contract/pull/358)
 
 ### Added
-- Disabled overflow checks in the `cargo contract new` template - [#372](https://github.com/paritytech/cargo-contract/pull/372)
+- Added a `--offline` flag to build contracts without network access - [#356](https://github.com/paritytech/cargo-contract/pull/356)
 
 ## [0.15.0] - 2021-10-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contract-metadata"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "impl-serde",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "metadata"]
 
 [package]
 name = "cargo-contract"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ colored = "2.0.0"
 toml = "0.5.8"
 rustc_version = "0.4.0"
 blake2 = "0.9.2"
-contract-metadata = { version = "0.4.0", path = "./metadata" }
+contract-metadata = { version = "0.5.0", path = "./metadata" }
 semver = { version = "1.0.4", features = ["serde"] }
 serde = { version = "1.0.130", default-features = false, features = ["derive"] }
 serde_json = "1.0.71"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 

--- a/templates/new/_Cargo.toml
+++ b/templates/new/_Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc6", default-features = false }
-ink_metadata = { version = "3.0.0-rc6", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc6", default-features = false }
-ink_storage = { version = "3.0.0-rc6", default-features = false }
-ink_lang = { version = "3.0.0-rc6", default-features = false }
+ink_primitives = { version = "3.0.0-rc7", default-features = false }
+ink_metadata = { version = "3.0.0-rc7", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc7", default-features = false }
+ink_storage = { version = "3.0.0-rc7", default-features = false }
+ink_lang = { version = "3.0.0-rc7", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"], optional = true }


### PR DESCRIPTION
Follow-up to https://github.com/paritytech/ink/pull/1043.

[Preview here](https://github.com/paritytech/cargo-contract/blob/cmichi-release-0.16.0/CHANGELOG.md#0160---2021-11-25).

CI fails because we haven't published the new ink! rc yet.