### PR TITLE
Added `workspace` section to override parent `workspace`

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -234,6 +234,8 @@ impl CheckCommand {
 /// Preferred default `[profile.release]` settings will be added if they are missing, existing
 /// user-defined settings will be preserved.
 ///
+/// The `[workspace]` will be added if it is missing to ignore `workspace` from parent `Cargo.toml`.
+///
 /// To disable this and use the original `Cargo.toml` as is then pass the `-Z original_manifest` flag.
 fn exec_cargo_for_wasm_target(
     crate_metadata: &CrateMetadata,
@@ -289,7 +291,8 @@ fn exec_cargo_for_wasm_target(
             .with_root_package_manifest(|manifest| {
                 manifest
                     .with_removed_crate_type("rlib")?
-                    .with_profile_release_defaults(Profile::default_contract_release())?;
+                    .with_profile_release_defaults(Profile::default_contract_release())?
+                    .with_workspace()?;
                 Ok(())
             })?
             .using_temp(cargo_build)?;

--- a/src/workspace/manifest.rs
+++ b/src/workspace/manifest.rs
@@ -283,6 +283,17 @@ impl Manifest {
         Ok(self)
     }
 
+    /// Set empty `[workspace]` section if it is not exist
+    ///
+    /// It allows ignore `workspace` from parent `Cargo.toml`.
+    /// It can reduce the size of the contract in some cases.
+    pub fn with_workspace(&mut self) -> Result<&mut Self> {
+        if let toml::map::Entry::Vacant(value) = self.toml.entry("workspace") {
+            value.insert(value::Value::Table(Default::default()));
+        }
+        Ok(self)
+    }
+
     /// Get mutable reference to `[profile.release]` section
     fn get_profile_release_table_mut(&mut self) -> Result<&mut value::Table> {
         let profile = self

--- a/src/workspace/manifest.rs
+++ b/src/workspace/manifest.rs
@@ -283,10 +283,10 @@ impl Manifest {
         Ok(self)
     }
 
-    /// Set empty `[workspace]` section if it is not exist
+    /// Set empty `[workspace]` section if it does not exist.
     ///
-    /// It allows ignore `workspace` from parent `Cargo.toml`.
-    /// It can reduce the size of the contract in some cases.
+    /// Ignores the `workspace` from the parent `Cargo.toml`.
+    /// This can reduce the size of the contract in some cases.
     pub fn with_workspace(&mut self) -> Result<&mut Self> {
         if let toml::map::Entry::Vacant(value) = self.toml.entry("workspace") {
             value.insert(value::Value::Table(Default::default()));


### PR DESCRIPTION
It should close https://github.com/paritytech/cargo-contract/issues/377.
I tested it with sub contracts from the `delegator` example in ink!.