### PR TITLE
Add `macos` CI stage

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,9 +27,9 @@ jobs:
 
       - uses: engineerd/configurator@v0.0.6
         with:
-          name: "wasm-opt.exe"
+          name: "wasm-opt"
           url: "https://github.com/WebAssembly/binaryen/releases/download/version_103/binaryen-version_103-x86_64-macos.tar.gz"
-          pathInArchive: "binaryen-/bin/wasm-opt.exe"
+          pathInArchive: "binaryen-/bin/wasm-opt"
 
       - name: Checkout sources & submodules
         uses: actions/checkout@master

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: engineerd/configurator@v0.0.6
         with:
-          name: "libbinaryen.dylib"
+          name: "lib/libbinaryen.dylib"
           url: "https://github.com/WebAssembly/binaryen/releases/download/version_103/binaryen-version_103-x86_64-macos.tar.gz"
           pathInArchive: "binaryen-/lib/libbinaryen.dylib"
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,17 +25,11 @@ jobs:
       RUST_BACKTRACE: full
     steps:
 
-      - uses: engineerd/configurator@v0.0.6
+      - uses: actions/setup-node@v2
         with:
-          name: "wasm-opt"
-          url: "https://github.com/WebAssembly/binaryen/releases/download/version_103/binaryen-version_103-x86_64-macos.tar.gz"
-          pathInArchive: "binaryen-/bin/wasm-opt"
+          cache: 'npm'
 
-      - uses: engineerd/configurator@v0.0.6
-        with:
-          name: "lib/libbinaryen.dylib"
-          url: "https://github.com/WebAssembly/binaryen/releases/download/version_103/binaryen-version_103-x86_64-macos.tar.gz"
-          pathInArchive: "binaryen-/lib/libbinaryen.dylib"
+      - run: npm install wasm-opt -g
 
       - name: Checkout sources & submodules
         uses: actions/checkout@master

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,67 @@
+name: continuous-intergration/macos
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+    paths-ignore:
+      - 'README.md'
+
+jobs:
+  check:
+    name: build-contract-template
+    strategy:
+      matrix:
+        platform:
+          - macos-latest
+        toolchain:
+          - nightly
+    runs-on: ${{ matrix.platform }}
+    env:
+      RUST_BACKTRACE: full
+    steps:
+
+      - uses: engineerd/configurator@v0.0.6
+        with:
+          name: "wasm-opt.exe"
+          url: "https://github.com/WebAssembly/binaryen/releases/download/version_103/binaryen-version_103-x86_64-macos.tar.gz"
+          pathInArchive: "binaryen-/bin/wasm-opt.exe"
+
+      - name: Checkout sources & submodules
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Install toolchain
+        id: toolchain
+        uses: actions-rs/toolchain@master
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          components: rust-src
+          override: true
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.2.0
+
+      - name: Build contract template on ${{ matrix.platform }}-${{ matrix.toolchain }}
+        run: |
+          wasm-opt --version
+          cargo -vV
+          cargo run -- contract --version
+          cargo run -- contract new foobar
+          echo "[workspace]" >> foobar/Cargo.toml
+          cargo run -- contract build --manifest-path=foobar/Cargo.toml
+          cargo run -- contract check --manifest-path=foobar/Cargo.toml
+          cargo run -- contract test --manifest-path=foobar/Cargo.toml
+
+      - name: Run tests on {{ matrix.platform }}-${{ matrix.toolchain }}
+        # The tests take a long time in the GitHub Actions runner (~30 mins),
+        # hence we run them only on `master`.
+        if: github.ref == 'refs/heads/master'
+        run: |
+          cargo test --verbose --workspace --all-features

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,17 +25,14 @@ jobs:
       RUST_BACKTRACE: full
     steps:
 
-      - uses: actions/setup-node@v2
-        with:
-          cache: 'npm'
-
-      - run: npm install wasm-opt -g
-
       - name: Checkout sources & submodules
         uses: actions/checkout@master
         with:
           fetch-depth: 1
           submodules: recursive
+
+      - uses: actions/setup-node@v2
+      - run: npm install wasm-opt -g
 
       - name: Install toolchain
         id: toolchain

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,6 +31,12 @@ jobs:
           url: "https://github.com/WebAssembly/binaryen/releases/download/version_103/binaryen-version_103-x86_64-macos.tar.gz"
           pathInArchive: "binaryen-/bin/wasm-opt"
 
+      - uses: engineerd/configurator@v0.0.6
+        with:
+          name: "libbinaryen.dylib"
+          url: "https://github.com/WebAssembly/binaryen/releases/download/version_103/binaryen-version_103-x86_64-macos.tar.gz"
+          pathInArchive: "binaryen-/lib/libbinaryen.dylib"
+
       - name: Checkout sources & submodules
         uses: actions/checkout@master
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,7 @@ on:
       - v*
     paths-ignore:
       - 'README.md'
+      - '.gitlab-ci.yml'
 
 jobs:
   check:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,8 +45,8 @@ jobs:
           components: rust-src
           override: true
 
-      - name:                      Rust Cache
-        uses:                      Swatinem/rust-cache@v1.2.0
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v1.2.0
 
       - name: Build contract template on ${{ matrix.platform }}-${{ matrix.toolchain }}
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,8 +27,8 @@ jobs:
       - uses: engineerd/configurator@v0.0.6
         with:
           name: "wasm-opt.exe"
-          url: "https://github.com/WebAssembly/binaryen/releases/download/version_101/binaryen-version_101-x86_64-windows.tar.gz"
-          pathInArchive: "binaryen-version_101/bin/wasm-opt.exe"
+          url: "https://github.com/WebAssembly/binaryen/releases/download/version_103/binaryen-version_103-x86_64-windows.tar.gz"
+          pathInArchive: "binaryen-/bin/wasm-opt.exe"
 
       - name: Checkout sources & submodules
         uses: actions/checkout@master

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,7 @@ on:
       - v*
     paths-ignore:
       - 'README.md'
+      - '.gitlab-ci.yml'
 
 jobs:
   check:


### PR DESCRIPTION
Adds a `macos` CI stage analogue to the Windows CI stage which we already have.

This is a follow-up to https://github.com/paritytech/ink/pull/1066.