### PR TITLE
Do not run CI tests under MacOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,10 +56,3 @@ jobs:
           cargo run -- contract build --manifest-path=foobar/Cargo.toml
           cargo run -- contract check --manifest-path=foobar/Cargo.toml
           cargo run -- contract test --manifest-path=foobar/Cargo.toml
-
-      - name: Run tests on {{ matrix.platform }}-${{ matrix.toolchain }}
-        # The tests take a long time in the GitHub Actions runner (~30 mins),
-        # hence we run them only on `master`.
-        if: github.ref == 'refs/heads/master'
-        run: |
-          cargo test --verbose --workspace --all-features

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <div align="center">
     <img src="./.images/cargo-contract.svg" alt="cargo-contract" height="170" />
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <div align="center">
     <img src="./.images/cargo-contract.svg" alt="cargo-contract" height="170" />
 


### PR DESCRIPTION
I've removed running the CI tests on MacOS, since those tests are not needed to be run under MacOS as well. We already test if the ink! examples can be built and tested with `cargo-contract`'s `master` in https://github.com/paritytech/ink/blob/master/.github/workflows/examples.yml.