### PR TITLE
Revert me: Don't require `clippy` CI stage to succeed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,6 +78,7 @@ clippy:
   <<:                              *docker-env
   script:
     - cargo clippy --verbose --all-targets --all-features -- -D warnings;
+  allow_failure:                   true
 
 #### stage:                        test (all features)
 


### PR DESCRIPTION
I've added some `dylint` stuff to our CI docker image in https://github.com/paritytech/scripts/pull/382. The docker image can't be build currently though: https://gitlab.parity.io/parity/cargo-contract/-/jobs/1376793.

This is due to an ICE in the nightly version of the Rust compiler (https://github.com/rust-lang/rust/issues/93788). Since I need those `dylint` tools now-ish, I would like to temporarily allow the `clippy` stage to fail. We can revert this PR once the ICE is fixed.

Let's not go into a discussion of setting a fixed toolchain for our CI here.