### PR TITLE
Upgrade `nom-supreme` to `0.7.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "nom-supreme"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadc66631948f6b65da03be4c4cd8bd104d481697ecbb9bbd65719b1ec60bc9f"
+checksum = "2f909b25a8371ad5c054abc2c48205d677231e6a2dcbf83704ed57bb147f30e0"
 dependencies = [
  "brownstone",
  "indent_write",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ futures = "0.3.19"
 hex = "0.4.3"
 jsonrpsee = { version = "0.9.0", features = ["ws-client"] }
 nom = "7.1.0"
-nom-supreme = "0.6.0"
+nom-supreme = { version = "0.7.0", features = ["error"] }
 indexmap = "1.8.0"
 thiserror = "1.0.30"
 escape8259 = "0.5.1"


### PR DESCRIPTION
dependabot failed doing it in https://github.com/paritytech/cargo-contract/pull/453.