### PR TITLE
Improve error reporting during installation + Release `1.0.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2022-03-18
+- Improved error reporting during installation - [#468](https://github.com/paritytech/cargo-contract/pull/468)
+
 ## [1.0.0] - 2022-03-17
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "metadata"]
 
 [package]
 name = "cargo-contract"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"

--- a/build.rs
+++ b/build.rs
@@ -96,10 +96,8 @@ fn zip_template_and_build_dylint_driver(manifest_dir: PathBuf, out_dir: PathBuf)
     let original_name = ink_dylint_driver_dir.join("_Cargo.toml");
     if !original_name.exists() {
         anyhow::bail!(
-            "'{:?}' does not exist, does the folder '{:?}'? {:?}",
+            "'{:?}' does not exist",
             original_name,
-            ink_dylint_driver_dir,
-            ink_dylint_driver_dir.exists()
         );
     }
 

--- a/build.rs
+++ b/build.rs
@@ -70,6 +70,14 @@ fn zip_template_and_build_dylint_driver(manifest_dir: PathBuf, out_dir: PathBuf)
     let dylint_driver_dst_file = out_dir.join("ink-dylint-driver.zip");
 
     let ink_dylint_driver_dir = manifest_dir.join("ink_linting");
+    let ink_dylint_driver_dir = ink_dylint_driver_dir.canonicalize().map_err(|err| {
+        anyhow::anyhow!(
+            "Unable to canonicalize '{:?}': {:?}\nDoes the folder exist? {}",
+            ink_dylint_driver_dir,
+            err,
+            ink_dylint_driver_dir.exists()
+        )
+    })?;
 
     // The `ink_linting/Cargo.toml` file is named `_Cargo.toml` in the repository.
     // This is because we need to have the `ink_linting` folder part of the release,
@@ -86,9 +94,6 @@ fn zip_template_and_build_dylint_driver(manifest_dir: PathBuf, out_dir: PathBuf)
     //
     // (from https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields)
     let original_name = ink_dylint_driver_dir.join("_Cargo.toml");
-    let original_name = original_name.canonicalize().map_err(|err| {
-        anyhow::anyhow!("Unable to canonicalize '{:?}': {:?}", original_name, err)
-    })?;
     if !original_name.exists() {
         anyhow::bail!(
             "'{:?}' does not exist, does the folder '{:?}'? {:?}",

--- a/build.rs
+++ b/build.rs
@@ -95,10 +95,7 @@ fn zip_template_and_build_dylint_driver(manifest_dir: PathBuf, out_dir: PathBuf)
     // (from https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields)
     let original_name = ink_dylint_driver_dir.join("_Cargo.toml");
     if !original_name.exists() {
-        anyhow::bail!(
-            "'{:?}' does not exist",
-            original_name,
-        );
+        anyhow::bail!("'{:?}' does not exist", original_name);
     }
 
     let tmp_name = ink_dylint_driver_dir.join("Cargo.toml");


### PR DESCRIPTION
Follow-up to https://github.com/paritytech/cargo-contract/issues/467, where we don't have an idea what causes it, but the next time someone runs into it we would have better error reporting.