### PR TITLE
Allow multiple args values for call and instantiate commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Allow multiple args values for call and instantiate commands - [#480](https://github.com/paritytech/cargo-contract/pull/480)
+- Fix event decoding - [c721b1](https://github.com/paritytech/cargo-contract/commit/c721b19519e579de41217aa347625920925d8040)
+
 ## [1.1.0] - 2022-03-18
 
 ### Added

--- a/src/cmd/extrinsics/call.rs
+++ b/src/cmd/extrinsics/call.rs
@@ -39,7 +39,7 @@ pub struct CallCommand {
     #[clap(long, short)]
     message: String,
     /// The arguments of the contract message to call.
-    #[clap(long)]
+    #[clap(long, multiple_values = true)]
     args: Vec<String>,
     #[clap(flatten)]
     extrinsic_opts: ExtrinsicOpts,

--- a/src/cmd/extrinsics/instantiate.rs
+++ b/src/cmd/extrinsics/instantiate.rs
@@ -50,7 +50,7 @@ pub struct InstantiateCommand {
     #[clap(name = "constructor", long, default_value = "new")]
     constructor: String,
     /// The constructor arguments, encoded as strings
-    #[clap(long)]
+    #[clap(long, multiple_values = true)]
     args: Vec<String>,
     #[clap(flatten)]
     extrinsic_opts: ExtrinsicOpts,


### PR DESCRIPTION
After the migration from structopt to clap derive #457, the default for `Vec` opts is for `multiple_occurrences`, e.g. `--args arg1 --args arg2` whereas with structopt it was `multiple_values` e.g. `--args arg1 arg2`. This resulted in an error like `Found argument '2' which wasn't expected, or isn't valid in this context` when providing multiple values. 

As noted in [docs](https://docs.rs/clap/latest/clap/struct.Arg.html#method.multiple_values) for `multiple_values`, there are issues with its use so we should consider changing how contract arguments are specified.

However in the meantime this reverts to the original behaviour with `structopt` of accepting multiple values.