### PR TITLE
Fix linting support on Apple Silicon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ walkdir = "2.3.2"
 substrate-build-script-utils = "3.0.0"
 platforms = "2.0.0"
 which = "4.2.5"
+regex = "1.5.5"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,6 @@ use std::{
 };
 
 use anyhow::Result;
-use regex::Regex;
 use walkdir::WalkDir;
 use zip::{write::FileOptions, CompressionMethod, ZipWriter};
 
@@ -315,7 +314,8 @@ fn zip_dylint_driver(src_dir: &Path, dst_file: &Path, method: CompressionMethod)
 
     let walkdir = WalkDir::new(src_dir);
     let it = walkdir.into_iter().filter_map(|e| e.ok());
-    let regex = Regex::new(r#"libink_linting@.+\.(dll|so|dylib)"#).expect("Regex is correct; qed");
+    let regex =
+        regex::Regex::new(r#"libink_linting@.+\.(dll|so|dylib)"#).expect("Regex is correct; qed");
     let mut lib_found = false;
 
     for entry in it {
@@ -338,7 +338,10 @@ fn zip_dylint_driver(src_dir: &Path, dst_file: &Path, method: CompressionMethod)
     }
 
     if !lib_found {
-        anyhow::bail!("Couldn't find compiled lint. Is your architecture defined in ./ink_linting/.cargo/config.toml?");
+        anyhow::bail!(
+            "Couldn't find compiled lint. Is your architecture ({}) defined in ./ink_linting/.cargo/config.toml?",
+            std::env::var("TARGET").unwrap(),
+        );
     }
 
     Ok(())

--- a/build.rs
+++ b/build.rs
@@ -314,8 +314,8 @@ fn zip_dylint_driver(src_dir: &Path, dst_file: &Path, method: CompressionMethod)
 
     let walkdir = WalkDir::new(src_dir);
     let it = walkdir.into_iter().filter_map(|e| e.ok());
-    let regex =
-        regex::Regex::new(r#"libink_linting@.+\.(dll|so|dylib)"#).expect("Regex is correct; qed");
+    let regex = regex::Regex::new(r#"(lib)?ink_linting@.+\.(dll|so|dylib)"#)
+        .expect("Regex is correct; qed");
     let mut lib_found = false;
 
     for entry in it {

--- a/ink_linting/.cargo/config.toml
+++ b/ink_linting/.cargo/config.toml
@@ -1,11 +1,38 @@
 # This file corresponds to the `.cargo/config.toml` file used for the `dylint` examples here:
 # https://github.com/trailofbits/dylint/tree/master/examples.
 
+[target.aarch64-apple-darwin]
+linker = "dylint-link"
+
 [target.x86_64-apple-darwin]
+linker = "dylint-link"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "dylint-link"
+
+[target.aarch64-unknown-linux-musl]
 linker = "dylint-link"
 
 [target.x86_64-unknown-linux-gnu]
 linker = "dylint-link"
 
+[target.x86_64-unknown-linux-musl]
+linker = "dylint-link"
+
+[target.x86_64-unknown-linux-gnux32]
+linker = "dylint-link"
+
+[target.aarch64-pc-windows-msvc]
+linker = "dylint-link"
+
+[target.i586-pc-windows-msvc]
+linker = "dylint-link"
+
+[target.i586-pc-windows-gnu]
+linker = "dylint-link"
+
 [target.x86_64-pc-windows-msvc]
+linker = "dylint-link"
+
+[target.x86_64-pc-windows-gnu]
 linker = "dylint-link"


### PR DESCRIPTION
Fixes #478

Apple Silicon wasn't defined in the `config.toml` of our linting project. And hence `dylint-link` wasn't used to produce the binary. I also added a hand full of other common architectures.

This won't fix the windows CI, though. I am not sure what is up with that.