### PR TITLE
Use `ArgEnum` for `BuildArtifacts`

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -85,8 +85,8 @@ pub struct BuildCommand {
     ///   `<name>.contract` file is skipped.
     #[clap(
         long = "generate",
+        arg_enum,
         default_value = "all",
-        value_name = "all | code-only",
         verbatim_doc_comment
     )]
     build_artifact: BuildArtifacts,
@@ -170,6 +170,8 @@ impl BuildCommand {
         if matches!(output_type, OutputType::Json) {
             verbosity = Verbosity::Quiet;
         }
+
+        println!("Build artifacts {:?}", self.build_artifact);
 
         let args = ExecuteArgs {
             manifest_path,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -169,8 +169,6 @@ impl BuildCommand {
             verbosity = Verbosity::Quiet;
         }
 
-        println!("Build artifacts {:?}", self.build_artifact);
-
         let args = ExecuteArgs {
             manifest_path,
             verbosity,

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -83,12 +83,10 @@ pub struct BuildCommand {
     ///
     /// - `code-only`: Only the Wasm is created, generation of metadata and a bundled
     ///   `<name>.contract` file is skipped.
-    #[clap(
-        long = "generate",
-        arg_enum,
-        default_value = "all",
-        verbatim_doc_comment
-    )]
+    ///
+    /// - `check-only`: No artifacts produced: runs the `cargo check` command for the Wasm target,
+    ///    only checks for compilation errors.
+    #[clap(long = "generate", arg_enum, default_value = "all")]
     build_artifact: BuildArtifacts,
     #[clap(flatten)]
     verbosity: VerbosityFlags,

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,15 +209,19 @@ impl TryFrom<&UnstableOptions> for UnstableFlags {
 }
 
 /// Describes which artifacts to generate
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Subcommand, serde::Serialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, clap::ArgEnum, serde::Serialize)]
 #[clap(name = "build-artifacts")]
 pub enum BuildArtifacts {
     /// Generate the Wasm, the metadata and a bundled `<name>.contract` file
     #[clap(name = "all")]
     All,
-    /// Only the Wasm is created, generation of metadata and a bundled `<name>.contract` file is skipped
+    /// Only the Wasm is created, generation of metadata and a bundled `<name>.contract` file is
+    /// skipped
     #[clap(name = "code-only")]
     CodeOnly,
+    /// Run the `cargo check` command for the Wasm target, only checks for compilation errors and
+    /// does not produce any artifacts.
+    #[clap(name = "check-only")]
     CheckOnly,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,8 +219,8 @@ pub enum BuildArtifacts {
     /// skipped
     #[clap(name = "code-only")]
     CodeOnly,
-    /// Run the `cargo check` command for the Wasm target, only checks for compilation errors and
-    /// does not produce any artifacts.
+    /// No artifacts produced: runs the `cargo check` command for the Wasm target, only checks for
+    /// compilation errors.
     #[clap(name = "check-only")]
     CheckOnly,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,17 +237,6 @@ impl BuildArtifacts {
     }
 }
 
-impl std::str::FromStr for BuildArtifacts {
-    type Err = String;
-    fn from_str(artifact: &str) -> Result<Self, Self::Err> {
-        match artifact {
-            "all" => Ok(BuildArtifacts::All),
-            "code-only" => Ok(BuildArtifacts::CodeOnly),
-            _ => Err("Could not parse build artifact".to_string()),
-        }
-    }
-}
-
 impl Default for BuildArtifacts {
     fn default() -> Self {
         BuildArtifacts::All


### PR DESCRIPTION
Fixes usage of `check-only` and removes need for `FromStr` impl.

![image](https://user-images.githubusercontent.com/75586/162187891-0394fb9c-95fe-4daa-a651-552d789db2d7.png)
