### PR TITLE
extrinsics: fix `Vec<AccountId>` args

### DIFF
--- a/src/cmd/extrinsics/instantiate.rs
+++ b/src/cmd/extrinsics/instantiate.rs
@@ -336,9 +336,10 @@ impl<'a> Exec<'a> {
             salt: self.args.salt.clone(),
         };
         let params = rpc_params![call_request];
-        let result: ContractInstantiateResult =
-            cli.request("contracts_instantiate", params).await
-                .context("contracts_instantiate RPC error")?;
+        let result: ContractInstantiateResult = cli
+            .request("contracts_instantiate", params)
+            .await
+            .context("contracts_instantiate RPC error")?;
         Ok(result)
     }
 }

--- a/src/cmd/extrinsics/instantiate.rs
+++ b/src/cmd/extrinsics/instantiate.rs
@@ -202,6 +202,7 @@ impl<'a> Exec<'a> {
     }
 
     async fn exec(&self, code: Code, dry_run: bool) -> Result<()> {
+        log::debug!("instantiate data {:?}", self.args.data);
         if dry_run {
             let result = self.instantiate_dry_run(code).await?;
             match result.result {
@@ -336,7 +337,8 @@ impl<'a> Exec<'a> {
         };
         let params = rpc_params![call_request];
         let result: ContractInstantiateResult =
-            cli.request("contracts_instantiate", params).await?;
+            cli.request("contracts_instantiate", params).await
+                .context("contracts_instantiate RPC error")?;
         Ok(result)
     }
 }

--- a/src/cmd/extrinsics/transcode/env_types.rs
+++ b/src/cmd/extrinsics/transcode/env_types.rs
@@ -15,7 +15,10 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::scon::Value;
-use anyhow::Result;
+use anyhow::{
+    Context,
+    Result
+};
 use scale::{
     Decode,
     Encode,
@@ -68,7 +71,8 @@ impl EnvTypesTranscoder {
         match self.transcoders.get(&type_id) {
             Some(transcoder) => {
                 log::debug!("Encoding type {:?} with custom encoder", type_id);
-                let encoded_env_type = transcoder.encode_value(value)?;
+                let encoded_env_type = transcoder.encode_value(value)
+                    .context("Error encoding custom type")?;
                 output.write(&encoded_env_type);
                 Ok(true)
             }

--- a/src/cmd/extrinsics/transcode/env_types.rs
+++ b/src/cmd/extrinsics/transcode/env_types.rs
@@ -17,7 +17,7 @@
 use super::scon::Value;
 use anyhow::{
     Context,
-    Result
+    Result,
 };
 use scale::{
     Decode,
@@ -71,7 +71,8 @@ impl EnvTypesTranscoder {
         match self.transcoders.get(&type_id) {
             Some(transcoder) => {
                 log::debug!("Encoding type {:?} with custom encoder", type_id);
-                let encoded_env_type = transcoder.encode_value(value)
+                let encoded_env_type = transcoder
+                    .encode_value(value)
                     .context("Error encoding custom type")?;
                 output.write(&encoded_env_type);
                 Ok(true)

--- a/src/cmd/extrinsics/transcode/mod.rs
+++ b/src/cmd/extrinsics/transcode/mod.rs
@@ -349,9 +349,9 @@ mod tests {
     use ink_lang as ink;
 
     #[ink::contract]
-    pub mod flipper {
+    pub mod transcode {
         #[ink(storage)]
-        pub struct Flipper {
+        pub struct Transcode {
             value: bool,
         }
 
@@ -363,35 +363,40 @@ mod tests {
             from: AccountId,
         }
 
-        impl Flipper {
-            /// Creates a new flipper smart contract initialized with the given value.
+        impl Transcode {
             #[ink(constructor)]
             pub fn new(init_value: bool) -> Self {
                 Self { value: init_value }
             }
 
-            /// Creates a new flipper smart contract initialized to `false`.
             #[ink(constructor)]
             pub fn default() -> Self {
                 Self::new(Default::default())
             }
 
-            /// Flips the current value of the Flipper's bool.
             #[ink(message)]
             pub fn flip(&mut self) {
                 self.value = !self.value;
             }
 
-            /// Returns the current value of the Flipper's bool.
             #[ink(message)]
             pub fn get(&self) -> bool {
                 self.value
             }
 
-            /// Dummy setter which receives the env type AccountId.
             #[ink(message)]
             pub fn set_account_id(&self, account_id: AccountId) {
                 let _ = account_id;
+            }
+
+            #[ink(message)]
+            pub fn set_account_ids_vec(&self, account_ids: Vec<AccountId>) {
+                let _ = account_ids;
+            }
+
+            #[ink(message)]
+            pub fn primitive_vec_args(&self, args: Vec<u32>) {
+                let _ = args;
             }
         }
     }
@@ -438,6 +443,48 @@ mod tests {
             "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
         )
         .unwrap();
+        assert_eq!(expected.encode(), encoded_args);
+        Ok(())
+    }
+
+    #[test]
+    fn encode_account_ids_vec_args() -> Result<()> {
+        let metadata = generate_metadata();
+        let transcoder = ContractMessageTranscoder::new(&metadata);
+
+        let encoded = transcoder.encode(
+            "set_account_ids_vec",
+            &["[5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY, 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY]"],
+        )?;
+
+        // encoded args follow the 4 byte selector
+        let encoded_args = &encoded[4..];
+
+        let expected = vec![
+            sp_core::crypto::AccountId32::from_str(
+                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+            )
+            .unwrap(),
+            sp_core::crypto::AccountId32::from_str(
+                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+            )
+            .unwrap(),
+        ];
+        assert_eq!(expected.encode(), encoded_args);
+        Ok(())
+    }
+
+    #[test]
+    fn encode_primitive_vec_args() -> Result<()> {
+        let metadata = generate_metadata();
+        let transcoder = ContractMessageTranscoder::new(&metadata);
+
+        let encoded = transcoder.encode("primitive_vec_args", &["[1, 2]"])?;
+
+        // encoded args follow the 4 byte selector
+        let encoded_args = &encoded[4..];
+
+        let expected = vec![1, 2];
         assert_eq!(expected.encode(), encoded_args);
         Ok(())
     }

--- a/src/cmd/extrinsics/transcode/mod.rs
+++ b/src/cmd/extrinsics/transcode/mod.rs
@@ -454,7 +454,7 @@ mod tests {
 
         let encoded = transcoder.encode(
             "set_account_ids_vec",
-            &["[5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY, 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY]"],
+            &["[5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY, 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty]"],
         )?;
 
         // encoded args follow the 4 byte selector
@@ -466,7 +466,7 @@ mod tests {
             )
             .unwrap(),
             sp_core::crypto::AccountId32::from_str(
-                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+                "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
             )
             .unwrap(),
         ];

--- a/src/cmd/extrinsics/transcode/transcoder.rs
+++ b/src/cmd/extrinsics/transcode/transcoder.rs
@@ -134,12 +134,16 @@ mod tests {
         super::scon::{
             self,
             Map,
+            Seq,
             Tuple,
             Value,
         },
         *,
     };
-    use crate::cmd::extrinsics::transcode;
+    use crate::cmd::extrinsics::{
+        transcode,
+        transcode::scon::Bytes,
+    };
     use scale::Encode;
     use scale_info::{
         MetaType,
@@ -601,6 +605,34 @@ mod tests {
                 ]
                 .into_iter()
                 .collect(),
+            )),
+        )
+    }
+
+    #[test]
+    fn transcode_account_id_custom_ss58_encoding_seq() -> Result<()> {
+        transcode_roundtrip::<Vec<sp_runtime::AccountId32>>(
+            r#"[
+                5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,
+                5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,
+             ]"#,
+            Value::Seq(Seq::new(
+                vec![
+                    Value::Tuple(
+                        Tuple::new(
+                            Some("AccountId32"),
+                            vec![Value::Bytes(Bytes::from_hex_string("0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d").unwrap())]
+                        )
+                    ),
+                    Value::Tuple(
+                        Tuple::new(
+                            Some("AccountId32"),
+                            vec![Value::Bytes(Bytes::from_hex_string("0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48").unwrap())]
+                        )
+                    )
+                ]
+                    .into_iter()
+                    .collect(),
             )),
         )
     }


### PR DESCRIPTION
Where a message or a constructor accepts a `Vec<AccountId>` as an argument e.g [`multisig`](https://github.com/paritytech/ink/blob/0897dea3a8995207fd3ce7ac623a36f0f3eb0672/examples/multisig/lib.rs#L283), the custom decoder should be used so that SS58 format. e.g.

```bash
 contract instantiate \
      --args 2 [5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty] \
      --suri //Alice \
      --dry-run
```