### PR TITLE
Fix extrinsic params for contract chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+-  Fix extrinsic params for contract chains - [#523](https://github.com/paritytech/cargo-contract/pull/523)
+
 ## [1.2.0] - 2022-04-13
 
 ### Added

--- a/src/cmd/extrinsics/mod.rs
+++ b/src/cmd/extrinsics/mod.rs
@@ -66,7 +66,7 @@ type Balance = u128;
 type CodeHash = <DefaultConfig as Config>::Hash;
 type ContractAccount = <DefaultConfig as Config>::AccountId;
 type PairSigner = subxt::PairSigner<DefaultConfig, sp_core::sr25519::Pair>;
-type SignedExtra = subxt::SubstrateExtrinsicParams<DefaultConfig>;
+type SignedExtra = subxt::PolkadotExtrinsicParams<DefaultConfig>;
 type RuntimeApi = runtime_api::api::RuntimeApi<DefaultConfig, SignedExtra>;
 
 /// Arguments required for creating and sending an extrinsic to a substrate node.


### PR DESCRIPTION
Fixes the `SignedExtra` type to align with [`substrate-contracts-node`](https://github.com/paritytech/substrate-contracts-node/blob/main/runtime/src/lib.rs#L352) and the [parachain runtime](https://github.com/paritytech/cumulus/blob/master/polkadot-parachains/canvas-kusama/src/lib.rs#L79).

This PR changes it to `PolkadotExtrinsicParams` which is just an [alias](https://github.com/paritytech/subxt/blob/3d669f97c6d3adbb8297f458a1bb35e7ec5cc7ba/subxt/src/extrinsic/params.rs#L72) to `BaseExtrinsicParams<T, PlainTip>` which maps to the runtime `SignedExtra1 definition with `pallet_transaction_payment::ChargeTransactionPayment<Runtime>`

Fixes #515 