### PR TITLE
Replace `platforms` with `current_platform`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "clap",
  "colored",
  "contract-metadata",
+ "current_platform",
  "env_logger",
  "escape8259",
  "futures",
@@ -497,7 +498,6 @@ dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
  "parity-wasm",
- "platforms 2.0.0",
  "predicates",
  "pretty_assertions",
  "regex",
@@ -747,6 +747,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "current_platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74858bcfe44b22016cb49337d7b6f04618c58e5dbfdef61b06b8c434324a0bc"
 
 [[package]]
 name = "curve25519-dalek"
@@ -2312,12 +2318,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 
 [[package]]
-name = "platforms"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
-
-[[package]]
 name = "polling"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,7 +3364,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd540ba72520174c2c73ce96bf507eeba3cc8a481f58be92525b69110e1fa645"
 dependencies = [
- "platforms 1.1.0",
+ "platforms",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ anyhow = "1.0.57"
 zip = { version = "0.6.2", default-features = false }
 walkdir = "2.3.2"
 substrate-build-script-utils = "3.0.0"
-platforms = "2.0.0"
+current_platform = "0.2.0"
 which = "4.2.5"
 regex = "1.5.5"
 

--- a/build.rs
+++ b/build.rs
@@ -39,11 +39,6 @@ use zip::{
     ZipWriter,
 };
 
-use platforms::{
-    TARGET_ARCH,
-    TARGET_ENV,
-    TARGET_OS,
-};
 use substrate_build_script_utils::rerun_if_git_head_changed;
 
 const DEFAULT_UNIX_PERMISSIONS: u32 = 0o755;
@@ -407,19 +402,7 @@ fn get_version(impl_commit: &str) -> String {
         std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
         commit_dash,
         impl_commit,
-        get_platform(),
-    )
-}
-
-fn get_platform() -> String {
-    let env_dash = if TARGET_ENV.is_some() { "-" } else { "" };
-
-    format!(
-        "{}-{}{}{}",
-        TARGET_ARCH.as_str(),
-        TARGET_OS.as_str(),
-        env_dash,
-        TARGET_ENV.map(|x| x.as_str()).unwrap_or(""),
+        current_platform::CURRENT_PLATFORM,
     )
 }
 


### PR DESCRIPTION
Supersedes #531.

https://github.com/rustsec/rustsec/pull/516 mentions that `current_platform` supersedes this functionality in the move from 2.0 to 3.0.