### PR TITLE
Don't spin up `rusty-cachier` caches on the main branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,7 @@ variables:
   # read more https://github.com/paritytech/cargo-contract/pull/115
   CI_IMAGE:                        "paritytech/contracts-ci-linux:production"
   RUSTY_CACHIER_SINGLE_BRANCH:     master
+  RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"
 
 workflow:
   rules:


### PR DESCRIPTION
Enabling this `rusty-cachier` option will lead to creating "fresh" caches on each `master` pipeline run. Fresh caches don't include any leftovers from previous cache overlays. 