### PR TITLE
Fix bug when `cargo-contract` installation had been interrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated `cargo contract new` template dependencies to ink! `3` - [#569](https://github.com/paritytech/cargo-contract/pull/569)
 
+### Fixed
+- Fix dirty directory issue when crate installation had been interrupted - [#571](https://github.com/paritytech/cargo-contract/pull/571)
+
 ## [1.3.0] - 2022-05-09
 
 ### Added

--- a/build.rs
+++ b/build.rs
@@ -111,9 +111,9 @@ fn zip_template_and_build_dylint_driver(
     }
 
     let tmp_name = ink_dylint_driver_dir.join("Cargo.toml");
-    std::fs::rename(&original_name, &tmp_name).map_err(|err| {
+    std::fs::copy(&original_name, &tmp_name).map_err(|err| {
         anyhow::anyhow!(
-            "Failed renaming '{:?}' to '{:?}': {:?}",
+            "Failed copying '{:?}' to '{:?}': {:?}",
             original_name,
             tmp_name,
             err
@@ -126,14 +126,13 @@ fn zip_template_and_build_dylint_driver(
         dylint_driver_dst_file,
     );
 
-    // After the build process of `ink_linting` happened we need to name back to the original
-    // `_Cargo.toml` name, otherwise the directory would be "dirty" and  `cargo publish` would
-    // fail with `Source directory was modified by build.rs during cargo publish`.
-    std::fs::rename(&tmp_name, &original_name).map_err(|err| {
+    // After the build process of `ink_linting` happened we need to remove the `Cargo.toml` file.
+    // Otherwise the directory would be "dirty" and `cargo publish` would fail with `Source
+    // directory was modified by build.rs during cargo publish`.
+    std::fs::remove_file(&tmp_name).map_err(|err| {
         anyhow::anyhow!(
-            "Failed renaming '{:?}' to '{:?}': {:?}",
+            "Failed removing '{:?}': {:?}",
             tmp_name,
-            original_name,
             err
         )
     })?;


### PR DESCRIPTION
Fixes https://github.com/paritytech/cargo-contract/issues/513.

If the crate installation had been interrupted the file `_Cargo.toml` had already been renamed to `Cargo.toml`. If the installation was resumed the `_Cargo.toml` was no longer found. This resulted in the panic `Failed renaming _Cargo.toml to Cargo.toml: File not found.`.

I fixed it by copy (with overwrite) the file `_Cargo.toml` to `Cargo.toml` instead.