### PR TITLE
Sync `metadata` version with `cargo-contract`

### DIFF
--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "0.6.0"
+version = "1.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
I want to sync the version and publish it.