### PR TITLE
Bump `cargo_metadata` to `v0.15.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1007653411165d371d51e7174a6f0e81ec815ecb425c0440c30d5f1ae64e0f"
+checksum = "3abb7553d5b9b8421c6de7cb02606ff15e0c6eea7d8eadd75ef013fd636bec36"
 dependencies = [
  "camino",
  "cargo-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4.17"
 heck = "0.4.0"
 zip = { version = "0.6.2", default-features = false }
 parity-wasm = "0.45.0"
-cargo_metadata = "0.14.3"
+cargo_metadata = "0.15.0"
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 which = "4.2.5"
 colored = "2.0.0"


### PR DESCRIPTION
Looks like `v0.14.3` was yanked, which is causing problems if you try
and install `cargo-contract` from Git.
