### PR TITLE
Bump all ink dependencies to 3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,18 +1398,18 @@ dependencies = [
 
 [[package]]
 name = "ink_allocator"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e131a5e2dc1ae56ba66a2b32fcac74134044e828cc46bfbeccead93b4d2a6cd3"
+checksum = "9ed249de74298ed051ebcf6d3082b8d3dbd19cbc448d9ed3235d8a7b92713049"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_engine"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a3accfd498e386e6a1dad78ca18ed8cbc699ec72f48931bd0d51cd7736e6fc"
+checksum = "acb9d32ec27d71fefb3f2b6a26bae82a2c6509d7ad61e8a5107b6291a1b03ecb"
 dependencies = [
  "blake2",
  "derive_more",
@@ -1422,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "ink_env"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68d27c8e99f67681862779f1238d13d2f6fae996a2140a0e52d1d25eeed8972"
+checksum = "1549f5966167387c89fb3dfcdc59973bfb396cc3a7110d7a31ad5fdea56db0cf"
 dependencies = [
  "arrayref",
  "blake2",
@@ -1449,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "ink_lang"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18fdbce6774f2c4a1f5890412d3a5337e82c61b9e57a50295d91b314e264103"
+checksum = "6e5282f2722ac6dca469e7f223a7b38b2a6d20fbca6b974497e630d5dc8934e9"
 dependencies = [
  "derive_more",
  "ink_env",
@@ -1465,9 +1465,9 @@ dependencies = [
 
 [[package]]
 name = "ink_lang_codegen"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c4cca39c31030b9ffdd6d0fecacec10158fde164868c4beb13399c95983b8d"
+checksum = "bb3a5de33b59450adc3f61c5eb05b768067c7ab8af9d00f33e284310598168dc"
 dependencies = [
  "blake2",
  "derive_more",
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "ink_lang_ir"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb68cdb4db44e7c088755857c93ec7a270e720bcd403c8caefa90100533759e5"
+checksum = "b9d4d614462280fa06e15b9ca5725d7c8440dde93c8dae1c6f15422f7756cacb"
 dependencies = [
  "blake2",
  "either",
@@ -1498,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "ink_lang_macro"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39fcbdaffd4126eb985fcb571ac302e966f8d14c5c2d3d64c330ef111a9d789"
+checksum = "72f85f64141957c5db7cbabbb97a9c16c489e5e9d363e9f147d132a43c71cd29"
 dependencies = [
  "ink_lang_codegen",
  "ink_lang_ir",
@@ -1512,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "ink_metadata"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00b1ea893ae80972db897ae2c9ce2d5292961a9c7b83714d3ee6b17461413e1"
+checksum = "dca6c159a2774f07437c6fd9ea710eb73a6b5e9a031a932bddf08742bf2c081a"
 dependencies = [
  "derive_more",
  "impl-serde",
@@ -1526,18 +1526,18 @@ dependencies = [
 
 [[package]]
 name = "ink_prelude"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17443d7d15df552eca048ba3b7ba8551fff3b0d529779bd3a64afc1be19ba65a"
+checksum = "b1f7f4dec15e573496c9d2af353e78bde84add391251608f25b5adcf175dc777"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_primitives"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538ad6c2050f950099e6d0202c296d174854f956d2d815e608c24d9db214ae4f"
+checksum = "b3296dd1c4f4fe12ede7c92d60e6fcb94d46a959ec19c701e4ac588b09e0b4a6"
 dependencies = [
  "cfg-if",
  "ink_prelude",
@@ -1547,9 +1547,9 @@ dependencies = [
 
 [[package]]
 name = "ink_storage"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1b226ba92ffa9dca87150bb0e472050db540d3af4ce1323311154971652d69"
+checksum = "4ff9b503995a7b41fe201a7a2643ce22f5a11e0b67db7b685424b6d5fe0ecf0b"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -1565,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "ink_storage_derive"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbe35878a5db2fb9405bae6a0943bf9ace1198b1279ea6926e01d6ac0502599"
+checksum = "afb68e24e93e8327dda1924868d7ee4dbe01e1ed2b392f28583caa96809b585c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ regex = "1.5.6"
 
 # dependencies for extrinsics (deploying and calling a contract)
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
-ink_metadata = { version = "3", features = ["derive"] }
+ink_metadata = { version = "3.3", features = ["derive"] }
 sp-core = "6.0.0"
 pallet-contracts-primitives = "6.0.0"
 subxt = "0.22.0"

--- a/templates/new/_Cargo.toml
+++ b/templates/new/_Cargo.toml
@@ -5,11 +5,11 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "3", default-features = false }
-ink_metadata = { version = "3", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3", default-features = false }
-ink_storage = { version = "3", default-features = false }
-ink_lang = { version = "3", default-features = false }
+ink_primitives = { version = "3.3", default-features = false }
+ink_metadata = { version = "3.3", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.3", default-features = false }
+ink_storage = { version = "3.3", default-features = false }
+ink_lang = { version = "3.3", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/transcode/Cargo.toml
+++ b/transcode/Cargo.toml
@@ -23,8 +23,8 @@ env_logger = "0.9.0"
 escape8259 = "0.5.1"
 hex = "0.4.3"
 indexmap = "1.9.1"
-ink_env = "3.0"
-ink_metadata = { version = "3.0", features = ["derive"] }
+ink_env = "3.3"
+ink_metadata = { version = "3.3", features = ["derive"] }
 itertools = "0.10.3"
 log = "0.4.17"
 nom = "7.1.1"
@@ -38,9 +38,9 @@ sp-runtime = "6.0.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-ink_lang = "3"
-ink_primitives = "3"
-ink_storage = "3"
+ink_lang = "3.3"
+ink_primitives = "3.3"
+ink_storage = "3.3"
 
 [features]
 # This `std` feature is required for testing using an inline contract's metadata, because `ink!` annotates the metadata


### PR DESCRIPTION
Increases minimum required version to 3.3 to ensure skipping semver incompatible version 3.2.