### PR TITLE
Temporarily disable `clippy::let-unit-value` lint for new project template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,7 +150,7 @@ test-new-project-template:
     - cargo check --verbose
     - cargo test --verbose --all
     - cargo fmt --verbose --all -- --check
-    - cargo clippy --verbose --manifest-path Cargo.toml -- -D warnings;
+    - cargo clippy --verbose --manifest-path Cargo.toml -- -D warnings -A clippy::let-unit-value;
     - rusty-cachier cache upload
 
 # With the introduction of `ink_linting` in `build.rs` the installation process


### PR DESCRIPTION
This lint is fixed in https://github.com/paritytech/ink/pull/1311, but it won't be pulled in until a new release of `ink!` since the new project template uses `ink!` from crates.io.

This is a temporary fix to make CI green and should be removed once there is a new `ink!` release.