### PR TITLE
Default `rusty-cachier` to a `nightly` toolchain

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,8 @@ variables:
   CI_IMAGE:                        "paritytech/contracts-ci-linux:production"
   RUSTY_CACHIER_SINGLE_BRANCH:     master
   RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"
+  # paritytech/contracts-ci-linux:production defaults to nightly toolchain, default rusty-cachier to it too
+  RUSTY_CACHIER_TOOLCHAIN:         nightly
 
 workflow:
   rules:


### PR DESCRIPTION
The `paritytech/contracts-ci-linux:production` image defaults to a `nightly` toolchain, default `rusty-cachier` to it too.