### PR TITLE
Release v1.5.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,7 +156,7 @@ test-new-project-template:
     - cargo check --verbose
     - cargo test --verbose --all
     - cargo fmt --verbose --all -- --check
-    - cargo clippy --verbose --manifest-path Cargo.toml -- -D warnings -A clippy::let-unit-value;
+    - cargo clippy --verbose --manifest-path Cargo.toml -- -D warnings;
     - rusty-cachier cache upload
 
 # With the introduction of `ink_linting` in `build.rs` the installation process

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,7 +156,7 @@ test-new-project-template:
     - cargo check --verbose
     - cargo test --verbose --all
     - cargo fmt --verbose --all -- --check
-    - cargo clippy --verbose --manifest-path Cargo.toml -- -D warnings;
+    - cargo clippy --verbose --manifest-path Cargo.toml -- -D warnings -A clippy::let-unit-value;
     - rusty-cachier cache upload
 
 # With the introduction of `ink_linting` in `build.rs` the installation process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync `metadata` version with `cargo-contract` [#611](https://github.com/paritytech/cargo-contract/pull/611)
 - Adapt to new subxt API [#678](https://github.com/paritytech/cargo-contract/pull/678)
 - Replace log/env_logger with tracing/tracing_subscriber [#689](https://github.com/paritytech/cargo-contract/pull/689)
-- contract upload: emitting a warning instead of an error when the contract already existed is more user friendly [#644](https://github.com/paritytech/cargo-contract/pull/644)
+- Contract upload: emitting a warning instead of an error when the contract already existed is more user friendly [#644](https://github.com/paritytech/cargo-contract/pull/644)
 
 ### Fixed
 - Fix windows dylint build [#690](https://github.com/paritytech/cargo-contract/pull/690)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2022-08-15
+
+- Fix windows dylint build (#690)
+
+### Added
+- Dry run gas limit estimation [#484](https://github.com/paritytech/cargo-contract/pull/484)
+
+### Changed
+- Bump `ink_*` crates to `v3.3.1` [#686](https://github.com/paritytech/cargo-contract/pull/686)
+- Refactor out transcode as a separate library [#597](https://github.com/paritytech/cargo-contract/pull/597)
+- Sync `metadata` version with `cargo-contract` [#611](https://github.com/paritytech/cargo-contract/pull/611)
+- Adapt to new subxt API [#678](https://github.com/paritytech/cargo-contract/pull/678)
+- Replace log/env_logger with tracing/tracing_subscriber [#689](https://github.com/paritytech/cargo-contract/pull/689)
+- contract upload: emitting a warning instead of an error when the contract already existed is more user friendly [#644](https://github.com/paritytech/cargo-contract/pull/644)
+
+### Fixed
+- Fix windows dylint build [#690](https://github.com/paritytech/cargo-contract/pull/690)
+- Fix `instantiate_with_code` with already uploaded code [#594](https://github.com/paritytech/cargo-contract/pull/594)
+
+
 ## [1.4.0] - 2022-05-18
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -628,7 +628,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contract-metadata"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "impl-serde",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "metadata", "transcode"]
 
 [package]
 name = "cargo-contract"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
Notable PRs:

## [1.5.0] - 2022-08-15

- Fix windows dylint build (#690)

### Added
- Dry run gas limit estimation [#484](https://github.com/paritytech/cargo-contract/pull/484)

### Changed
- Bump `ink_*` crates to `v3.3.1` [#686](https://github.com/paritytech/cargo-contract/pull/686)
- Refactor out transcode as a separate library [#597](https://github.com/paritytech/cargo-contract/pull/597)
- Sync `metadata` version with `cargo-contract` [#611](https://github.com/paritytech/cargo-contract/pull/611)
- Adapt to new subxt API [#678](https://github.com/paritytech/cargo-contract/pull/678)
- Replace log/env_logger with tracing/tracing_subscriber [#689](https://github.com/paritytech/cargo-contract/pull/689)
- contract upload: emitting a warning instead of an error when the contract already existed is more user friendly [#644](https://github.com/paritytech/cargo-contract/pull/644)

### Fixed
- Fix windows dylint build [#690](https://github.com/paritytech/cargo-contract/pull/690)
- Fix `instantiate_with_code` with already uploaded code [#594](https://github.com/paritytech/cargo-contract/pull/594)