### PR TITLE
Add `verify` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add Rust specific build info to metadata - [#680](https://github.com/paritytech/cargo-contract/pull/680)
+- Add `verify` command - [#696](https://github.com/paritytech/cargo-contract/pull/696)
 
 ### Changed
 - Removed requirement to install binaryen. The `wasm-opt` tool is now compiled into `cargo-contract`.

--- a/crates/cargo-contract/src/cmd/build/mod.rs
+++ b/crates/cargo-contract/src/cmd/build/mod.rs
@@ -68,7 +68,7 @@ use std::{
 const MAX_MEMORY_PAGES: u32 = 16;
 
 /// Version of the currently executing `cargo-contract` binary.
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Arguments to use when executing `build` or `check` commands.
 #[derive(Default)]

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -50,7 +50,7 @@ pub struct VerifyCommand {
     manifest_path: Option<PathBuf>,
     /// The reference Wasm contract (`*.contract`) that the workspace will be checked against.
     contract: PathBuf,
-    ///
+    /// Denotes if output should be printed to stdout.
     #[clap(flatten)]
     verbosity: VerbosityFlags,
 }

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -65,7 +65,8 @@ impl VerifyCommand {
 
         // 2. Call `cargo contract build` with the `BuildInfo` from the metadata.
         let expected_rustc_version = build_info.rustc_version;
-        let rustc_version = crate::util::rustc_toolchain()?;
+        let rustc_version = rustc_version::version()
+            .expect("`rustc` always has a version associated with it.");
 
         anyhow::ensure!(
             rustc_version == expected_rustc_version,

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -64,13 +64,7 @@ impl VerifyCommand {
 
         // 2. Call `cmd::Build` with the given `BuildInfo`
         let expected_rustc_version = build_info.rustc_version;
-        let rustc_version = rustc_version::version_meta()?;
-        let rustc_version = format!(
-            "{:?}-{}",
-            rustc_version.channel,
-            rustc_version.commit_date.expect("TODO")
-        )
-        .to_lowercase();
+        let rustc_version = crate::util::rustc_toolchain()?;
 
         anyhow::ensure!(
             rustc_version == expected_rustc_version,

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -63,6 +63,23 @@ impl VerifyCommand {
             serde_json::from_value(build_info.clone().into()).unwrap();
 
         // 2. Call `cmd::Build` with the given `BuildInfo`
+        let expected_rustc_version = build_info.rustc_version;
+        let rustc_version = rustc_version::version_meta()?;
+        let rustc_version = format!(
+            "{:?}-{}",
+            rustc_version.channel,
+            rustc_version.commit_date.expect("TODO")
+        )
+        .to_lowercase();
+
+        anyhow::ensure!(
+            rustc_version == expected_rustc_version,
+            "You are trying to `verify` a contract using the `{rustc_version}` toolchain.\n\
+             However, the original contract was built using `{expected_rustc_version}`. Please\n\
+             install the correct toolchain (`rustup install {expected_rustc_version}`) and\n\
+             re-run the `verify` command.",
+        );
+
         let args = ExecuteArgs {
             manifest_path: manifest_path.clone(),
             verbosity: Default::default(),

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -81,8 +81,8 @@ impl VerifyCommand {
             )
         };
 
-        let build_info: BuildInfo = serde_json::from_value(build_info.clone().into())
-            .context(format!(
+        let build_info: BuildInfo =
+            serde_json::from_value(build_info.into()).context(format!(
                 "Failed to deserialize the build info from {}",
                 path.display()
             ))?;

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -103,7 +103,7 @@ impl VerifyCommand {
         let built_wasm = SourceWasm::new(fs_wasm);
 
         if reference_wasm != built_wasm {
-            log::debug!(
+            tracing::debug!(
                 "Expected Wasm Binary '{}'\n\nGot Wasm Binary `{}`",
                 &reference_wasm,
                 &built_wasm
@@ -116,7 +116,7 @@ impl VerifyCommand {
             );
         }
 
-        log::info!("Succesfully verified `{}`!", &metadata.contract.name);
+        tracing::info!("Succesfully verified `{}`!", &metadata.contract.name);
 
         Ok(())
     }

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -75,6 +75,22 @@ impl VerifyCommand {
              re-run the `verify` command.",
         );
 
+        let expected_wasm_opt_version = build_info.wasm_opt_settings.version;
+        // TODO: Will either want to add this to BuildInfo or assume release (so no)
+        let keep_debug_symbols = false;
+        let handler = crate::wasm_opt::WasmOptHandler::new(
+            build_info.wasm_opt_settings.optimization_passes,
+            keep_debug_symbols,
+        )?;
+        let wasm_opt_version = handler.version();
+
+        anyhow::ensure!(
+            wasm_opt_version == expected_wasm_opt_version,
+            "You are trying to `verify` a contract using `wasm-opt` version {wasm_opt_version}`.\n\
+             However, the original contract was built using `wasm-opt` version {expected_wasm_opt_version}`.\n\
+             Please install the matching version and re-run the `verify` command.",
+        );
+
         let args = ExecuteArgs {
             manifest_path: manifest_path.clone(),
             verbosity: Default::default(),
@@ -83,7 +99,7 @@ impl VerifyCommand {
             build_artifact: BuildArtifacts::CodeOnly,
             unstable_flags: Default::default(),
             optimization_passes: build_info.wasm_opt_settings.optimization_passes,
-            keep_debug_symbols: false, /* TODO: Will either want to add this to BuildInfo or assume release (so no) */
+            keep_debug_symbols,
             skip_linting: true,
             output_type: Default::default(),
         };

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -48,7 +48,7 @@ use std::{
 #[clap(name = "verify")]
 pub struct VerifyCommand {
     /// Path to the `Cargo.toml` of the contract to verify.
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
     /// The reference Wasm contract (`*.contract`) that the workspace will be checked against.
     contract: PathBuf,

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -93,15 +93,15 @@ impl VerifyCommand {
         );
 
         // 2. Call `cargo contract build` with the `BuildInfo` from the metadata.
-        let expected_rustc_version = build_info.rustc_version;
-        let rustc_version = rustc_version::version()
+        let expected_rust_toolchain = build_info.rust_toolchain;
+        let rust_toolchain = crate::util::rust_toolchain()
             .expect("`rustc` always has a version associated with it.");
 
-        let rustc_matches = rustc_version == expected_rustc_version;
+        let rustc_matches = rust_toolchain == expected_rust_toolchain;
         let mismatched_rustc = format!(
-            "\nYou are trying to `verify` a contract using the `{rustc_version}` toolchain.\n\
-             However, the original contract was built using `{expected_rustc_version}`. Please\n\
-             install the correct toolchain (`rustup install {expected_rustc_version}`) and\n\
+            "\nYou are trying to `verify` a contract using the `{rust_toolchain}` toolchain.\n\
+             However, the original contract was built using `{expected_rust_toolchain}`. Please\n\
+             install the correct toolchain (`rustup install {expected_rust_toolchain}`) and\n\
              re-run the `verify` command.",);
         anyhow::ensure!(rustc_matches, mismatched_rustc.bright_yellow());
 

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -14,27 +14,25 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod build;
-pub mod decode;
-pub mod metadata;
-pub mod new;
-pub mod test;
-pub mod verify;
+use crate::workspace::ManifestPath;
 
-pub(crate) use self::{
-    build::{
-        BuildCommand,
-        CheckCommand,
-    },
-    decode::DecodeCommand,
-    test::TestCommand,
-    verify::VerifyCommand,
-};
-mod extrinsics;
+use anyhow::Result;
 
-pub(crate) use self::extrinsics::{
-    CallCommand,
-    ErrorVariant,
-    InstantiateCommand,
-    UploadCommand,
-};
+use std::path::PathBuf;
+
+#[derive(Debug, clap::Args)]
+#[clap(name = "verify")]
+pub struct VerifyCommand {
+    /// Path to the `Cargo.toml` of the contract to verify.
+    #[clap(long, parse(from_os_str))]
+    manifest_path: Option<PathBuf>,
+    /// The reference Wasm contract (`*.contract`) that the workspace will be checked against.
+    contract_wasm: String,
+}
+
+impl VerifyCommand {
+    pub fn run(&self) -> Result<()> {
+        let manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
+        todo!()
+    }
+}

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -38,6 +38,7 @@ use std::{
     path::PathBuf,
 };
 
+/// Checks if a contract in the given workspace matches that of a reference contract.
 #[derive(Debug, clap::Args)]
 #[clap(name = "verify")]
 pub struct VerifyCommand {
@@ -62,7 +63,7 @@ impl VerifyCommand {
         let build_info: BuildInfo =
             serde_json::from_value(build_info.clone().into()).unwrap();
 
-        // 2. Call `cmd::Build` with the given `BuildInfo`
+        // 2. Call `cargo contract build` with the `BuildInfo` from the metadata.
         let expected_rustc_version = build_info.rustc_version;
         let rustc_version = crate::util::rustc_toolchain()?;
 
@@ -89,7 +90,7 @@ impl VerifyCommand {
 
         let build_result = execute(args)?;
 
-        // 3. Read output file, compare with given contract_wasm
+        // 3. Grab the built Wasm contract and compare it with the Wasm from the metadata.
         let reference_wasm = metadata.source.wasm.unwrap();
 
         let built_wasm_path = build_result.dest_wasm.unwrap();

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -15,8 +15,15 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-    cmd::metadata::BuildInfo,
+    cmd::{
+        build::{
+            execute,
+            ExecuteArgs,
+        },
+        metadata::BuildInfo,
+    },
     workspace::ManifestPath,
+    BuildArtifacts,
 };
 
 use anyhow::Result;
@@ -40,7 +47,7 @@ pub struct VerifyCommand {
 
 impl VerifyCommand {
     pub fn run(&self) -> Result<()> {
-        let _manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
+        let manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
 
         // 1. Read the given metadata, and pull out the `BuildInfo`
         let mut file = File::open(&self.contract)?;
@@ -54,7 +61,21 @@ impl VerifyCommand {
         dbg!(&build_info);
 
         // 2. Call `cmd::Build` with the given `BuildInfo`
-        //
+        let args = ExecuteArgs {
+            manifest_path,
+            verbosity: Default::default(),
+            build_mode: build_info.build_mode,
+            network: Default::default(),
+            build_artifact: BuildArtifacts::CodeOnly,
+            unstable_flags: Default::default(),
+            optimization_passes: build_info.wasm_opt_settings.optimization_passes,
+            keep_debug_symbols: false, /* TODO: Will either want to add this to BuildInfo or assume release (so no) */
+            skip_linting: true,
+            output_type: Default::default(),
+        };
+
+        let _build_result = execute(args)?;
+
         // 3. Read output file, compare with given contract_wasm
         todo!()
     }

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -77,8 +77,7 @@ impl VerifyCommand {
         );
 
         let expected_wasm_opt_version = build_info.wasm_opt_settings.version;
-        // TODO: Will either want to add this to BuildInfo or assume release (so no)
-        let keep_debug_symbols = false;
+        let keep_debug_symbols = build_info.wasm_opt_settings.keep_debug_symbols;
         let handler = crate::wasm_opt::WasmOptHandler::new(
             build_info.wasm_opt_settings.optimization_passes,
             keep_debug_symbols,

--- a/crates/cargo-contract/src/main.rs
+++ b/crates/cargo-contract/src/main.rs
@@ -34,6 +34,7 @@ use self::{
         InstantiateCommand,
         TestCommand,
         UploadCommand,
+        VerifyCommand,
     },
     util::DEFAULT_KEY_COL_WIDTH,
     workspace::ManifestPath,
@@ -504,6 +505,9 @@ enum Command {
     /// Decodes a contracts input or output data (supplied in hex-encoding)
     #[clap(name = "decode")]
     Decode(DecodeCommand),
+    /// Verifies that a given contract binary matches the build result of the specified workspace.
+    #[clap(name = "verify")]
+    Verify(VerifyCommand),
 }
 
 fn main() {
@@ -570,6 +574,7 @@ fn exec(cmd: Command) -> Result<()> {
                 .map_err(|err| map_extrinsic_err(err, call.is_json()))
         }
         Command::Decode(decode) => decode.run().map_err(format_err),
+        Command::Verify(verify) => verify.run(),
     }
 }
 

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -166,7 +166,7 @@ impl Source {
 }
 
 /// The bytes of the compiled Wasm smart contract.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SourceWasm(
     #[serde(
         serialize_with = "byte_str::serialize_as_byte_str",


### PR DESCRIPTION
Will close the `verify` subcommand part of #525.

Note that this command does not necessarily work across different operating systems
or CPU architectures (see the discussion in #525 for more details). As such it should
only be used in the context of a well known Docker container à la `srtool`. 

Current built on top of #680 since I want to make sure that we have all the correct info
in the metadata.
