### PR TITLE
Build contracts and dylint driver with stable

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,7 @@ jobs:
         platform:
           - macos-latest
         toolchain:
-          - nightly
+          - stable
     runs-on: ${{ matrix.platform }}
     env:
       RUST_BACKTRACE: full

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,8 +40,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          components: rust-src
-          override: true
+          components: rust-src, rustc-dev, llvm-tools-preview
 
       - name: Install cargo-dylint
         uses: baptiste0928/cargo-install@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
-          components: rust-src
+          components: rust-src, rustc-dev, llvm-tools-preview
 
       - name: Install cargo-dylint
         uses: baptiste0928/cargo-install@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
         platform:
           - windows-latest
         toolchain:
-          - nightly
+          - stable
     runs-on: ${{ matrix.platform }}
     env:
       RUST_BACKTRACE: full

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,8 @@ workflow:
   image:
     name:                          "${CI_IMAGE}"
   before_script:
+    - rustup default stable
+    - rustup component add rustfmt clippy rust-src rustc-dev llvm-tools-preview
     - cargo -vV
     - rustc -vV
     - rustup show

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,7 @@ test-new-project-template:
     - cargo check --verbose
     - cargo test --verbose --all
     - cargo +nightly fmt --verbose --all -- --check
-    - cargo clippy --verbose --manifest-path Cargo.toml -- -D warnings -A clippy::let-unit-value;
+    - cargo clippy --verbose --manifest-path Cargo.toml -- -D warnings -A clippy::let-unit-value -A clippy::extra-unused-lifetimes
     - rusty-cachier cache upload
 
 # With the introduction of `ink_linting` in `build.rs` the installation process

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,15 +161,13 @@ test-new-project-template:
 test-registry-publish-install:
   stage:                           test
   <<:                              *docker-env
-  before_script:
-    - !reference [.rusty-cachier, before_script]
+  script:
     # Set up a local registry.
     - mkdir -p ./estuary/crates/ ./estuary/indices/
     - estuary --base-url=http://0.0.0.0:7878 --crate-dir ./estuary/crates/ --index-dir ./estuary/indices &
     - mkdir .cargo
     - echo -e '[registries]\nestuary = { index = "http://0.0.0.0:7878/git/index" }' > .cargo/config.toml
     - echo 0000 | cargo login --registry estuary
-  script:
     - rusty-cachier snapshot create
     - cargo publish --registry estuary
     - cargo install cargo-contract --index http://0.0.0.0:7878/git/index

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,11 +109,15 @@ test-dylint:
   stage:                           test
   <<:                              *docker-env
   script:
+    # We need to fix this test to a toolchain because of the UI tests
+    # We can't use stable here because the UI tests freak out if there are dots in the drivers file name
+    - rustup default nightly-2022-06-30
+    - rustup component add rustfmt clippy rust-src rustc-dev llvm-tools-preview
+
     - rusty-cachier snapshot create
     - cd ink_linting/
     - mv _Cargo.toml Cargo.toml
 
-    - export RUSTC_BOOTSTRAP=1
     - cargo check --verbose
     - cargo +nightly fmt --verbose --all -- --check
     - cargo clippy --verbose -- -D warnings;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,7 @@ variables:
   RUSTY_CACHIER_SINGLE_BRANCH:     master
   RUSTY_CACHIER_DONT_OPERATE_ON_MAIN_BRANCH: "true"
   # paritytech/contracts-ci-linux:production defaults to nightly toolchain, default rusty-cachier to it too
-  RUSTY_CACHIER_TOOLCHAIN:         nightly
+  RUSTY_CACHIER_TOOLCHAIN:         stable
 
 workflow:
   rules:
@@ -111,14 +111,7 @@ test-dylint:
     - cd ink_linting/
     - mv _Cargo.toml Cargo.toml
 
-    # Installing these components here is necessary because
-    # `ink_linting/` has a fixed `rust-toolchain` file.
-    # We can't move this line to the Docker container, since
-    # that would then make it impossible to upgrade the
-    # `ink_linting/rust-toolchain` file while still having
-    # this CI job succeed.
-    - rustup component add rustfmt clippy rust-src
-
+    - export RUSTC_BOOTSTRAP=1
     - cargo check --verbose
     - cargo fmt --verbose --all -- --check
     - cargo clippy --verbose -- -D warnings;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,7 +93,7 @@ fmt:
   stage:                           check
   <<:                              *docker-env
   script:
-    - cargo fmt --verbose --all -- --check
+    - cargo +nightly fmt --verbose --all -- --check
 
 clippy:
   stage:                           check
@@ -115,7 +115,7 @@ test-dylint:
 
     - export RUSTC_BOOTSTRAP=1
     - cargo check --verbose
-    - cargo fmt --verbose --all -- --check
+    - cargo +nightly fmt --verbose --all -- --check
     - cargo clippy --verbose -- -D warnings;
 
     # Needed until https://github.com/mozilla/sccache/issues/1000 is fixed.
@@ -150,7 +150,7 @@ test-new-project-template:
 
     - cargo check --verbose
     - cargo test --verbose --all
-    - cargo fmt --verbose --all -- --check
+    - cargo +nightly fmt --verbose --all -- --check
     - cargo clippy --verbose --manifest-path Cargo.toml -- -D warnings -A clippy::let-unit-value;
     - rusty-cachier cache upload
 

--- a/build.rs
+++ b/build.rs
@@ -211,6 +211,9 @@ fn build_and_zip_dylint_driver(
     cmd.env_remove("RUSTUP_TOOLCHAIN");
     cmd.env_remove("CARGO_TARGET_DIR");
 
+    // Dylint drivers need unstable features. Allow them on a stable toolchain.
+    cmd.env("RUSTC_BOOTSTRAP", "1");
+
     println!(
         "Setting cargo working dir to '{}'",
         ink_dylint_driver_dir.display()

--- a/ink_linting/README.md
+++ b/ink_linting/README.md
@@ -13,5 +13,8 @@ cargo build --release
 
 # Run the linting on a contract.
 DYLINT_LIBRARY_PATH=$PWD/target/release cargo dylint contract_instantiated
-    --manifest-path ../ink/examples/erc20/Cargo.toml 
+    --manifest-path ../ink/examples/erc20/Cargo.toml
+
+# The UI tests are written against a specific toolchain version. If you wish to run them locally:
+cargo +nightly-2022-06-30 test
 ```

--- a/ink_linting/rust-toolchain.toml
+++ b/ink_linting/rust-toolchain.toml
@@ -1,6 +1,0 @@
-# This file corresponds to the `rust-toolchain` file used for the `dylint` examples here:
-# https://github.com/trailofbits/dylint/tree/master/examples.
-
-[toolchain]
-channel = "nightly-2022-06-30"
-components = ["llvm-tools-preview", "rustc-dev"]

--- a/src/util.rs
+++ b/src/util.rs
@@ -55,7 +55,7 @@ pub fn assert_channel() -> Result<()> {
         _ => {
             anyhow::bail!(
                 "Using the {:?} channel is not supported. \
-                Contracts should be built using a "stable" toolchain.",
+                Contracts should be built using a \"stable\" toolchain.",
                 format!("{:?}", meta.channel).to_lowercase(),
             )
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -55,7 +55,7 @@ pub fn assert_channel() -> Result<()> {
         _ => {
             anyhow::bail!(
                 "cargo-contract cannot build using the {:?} channel. \
-                Contracts should be build using a stable toolchain.",
+                Contracts should be build using a "stable" toolchain.",
                 format!("{:?}", meta.channel).to_lowercase(),
             )
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -39,7 +39,7 @@ use std::{
     process::Command,
 };
 
-/// Check whether the current rust channel is valid: `nightly` is recommended.
+/// This makes sure we are building with a minimum `stable` toolchain version.
 pub fn assert_channel() -> Result<()> {
     let meta = rustc_version::version_meta()?;
     let min_version = Version::new(1, 63, 0);
@@ -47,15 +47,15 @@ pub fn assert_channel() -> Result<()> {
         Channel::Stable if meta.semver >= min_version => Ok(()),
         Channel::Stable => {
             anyhow::bail!(
-                "Minimum Rust version is {}. You are using {}.",
+                "The minimum Rust version is {}. You are using {}.",
                 min_version,
                 meta.semver
             )
         }
         _ => {
             anyhow::bail!(
-                "cargo-contract cannot build using the {:?} channel. \
-                Contracts should be build using a "stable" toolchain.",
+                "Using the {:?} channel is not supported. \
+                Contracts should be built using a "stable" toolchain.",
                 format!("{:?}", meta.channel).to_lowercase(),
             )
         }


### PR DESCRIPTION
Instead of using a `nightly` toolchain we want to build contracts with a `stable` compiler. Since we use nightly features we need to pass the `RUSTC_BOOTSTRAP=1` env variable.

This PR does the following:

- Pass `RUSTC_BOOTSTRAP=1` when building contracts and the dylint driver
- Check that the user uses a stable compiler with a minimum version
- Remove the toolchain file from ink_dylint since we just build it with a stable compiler
     - The UI tests in CI are still run against a fixed nightly version
- Fix the CI to use a stable compiler and other small stuff that broke


## Future Work

I don't like this brittle setup of packaging the dylint binary driver **at call**. I suggest we just patch the users manifest on the fly at runtime to contain this:

```toml
[workspace.metadata.dylint]
libraries = [
    { git = "https://github.com/paritytech/cargo-contract/", branch = "$cargo-contract-version", pattern = "ink_dylint/" },
]
```

This will remove all this horror of the build.rs script and also removes the need for this horrible `_Cargo.toml` rename. We just use dylint as it is supposed to be used. Also, this doesn't force the user to run the dylint on the toolchain the driver was build but the one they compile their contract with anyways. And before you ask: The driver compiles quickly and is obviously cached in the users target dir.