### PR TITLE
Fix `tracing_subscriber` filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,7 +3662,7 @@ dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "regex",
  "serde",
  "serde_json",
@@ -3673,9 +3682,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term",
+ "matchers 0.1.0",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 anyhow = "1.0.62"
 clap = { version = "3.2.17", features = ["derive", "env"] }
 tracing = "0.1.36"
-tracing-subscriber = "0.3.15"
+tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 heck = "0.4.0"
 zip = { version = "0.6.2", default-features = false }
 parity-wasm = "0.45.0"

--- a/src/cmd/extrinsics/integration_tests.rs
+++ b/src/cmd/extrinsics/integration_tests.rs
@@ -121,22 +121,6 @@ impl ContractsNodeProcess {
     }
 }
 
-/// Init a tracing subscriber for logging in tests.
-///
-/// Be aware that this enables `TRACE` by default. It also ignores any error
-/// while setting up the logger.
-///
-/// The logs are not shown by default, logs are only shown when the test fails
-/// or if [`nocapture`](https://doc.rust-lang.org/cargo/commands/cargo-test.html#display-options)
-/// is being used.
-#[cfg(feature = "std")]
-pub fn init_tracing_subscriber() {
-    let _ = tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::TRACE)
-        .with_test_writer()
-        .try_init();
-}
-
 /// Sanity test the whole lifecycle of:
 ///   new -> build -> upload -> instantiate -> call
 ///
@@ -152,7 +136,7 @@ pub fn init_tracing_subscriber() {
 #[ignore]
 #[async_std::test]
 async fn build_upload_instantiate_call() {
-    init_tracing_subscriber();
+    crate::util::tests::init_tracing_subscriber();
 
     let tmp_dir = tempfile::Builder::new()
         .prefix("cargo-contract.cli.test.")

--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn generate_metadata() {
-        tracing_subscriber::fmt::init();
+        crate::util::tests::init_tracing_subscriber();
         with_new_contract_project(|manifest_path| {
             // add optional metadata fields
             let mut test_manifest = TestContractManifest::new(manifest_path)?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -251,6 +251,22 @@ pub mod tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o777))
             .expect("setting permissions failed");
     }
+
+
+    /// Init a tracing subscriber for logging in tests.
+    ///
+    /// Be aware that this enables `TRACE` by default. It also ignores any error
+    /// while setting up the logger.
+    ///
+    /// The logs are not shown by default, logs are only shown when the test fails
+    /// or if [`nocapture`](https://doc.rust-lang.org/cargo/commands/cargo-test.html#display-options)
+    /// is being used.
+    pub fn init_tracing_subscriber() {
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_test_writer()
+            .try_init();
+    }
 }
 
 // Unzips the file at `template` to `out_dir`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -252,7 +252,6 @@ pub mod tests {
             .expect("setting permissions failed");
     }
 
-
     /// Init a tracing subscriber for logging in tests.
     ///
     /// Be aware that this enables `TRACE` by default. It also ignores any error


### PR DESCRIPTION
Enables the `env_filter` feature of `tracing_subscriber`. Previously all messages above `INFO` were displayed even if `RUST_LOG` was not set:

![image](https://user-images.githubusercontent.com/75586/186117292-bafec032-fe05-4473-8e97-d8409bd4400a.png)

Now:

![image](https://user-images.githubusercontent.com/75586/186117443-ecf72179-7639-4cb1-acab-a78bec6e05d5.png)

Also enabled special init function for testing.
