### PR TITLE
Remove `nightly` override from decode test

### DIFF
--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -73,13 +73,6 @@ fn decode_works() {
     let lib = project_dir.join("lib.rs");
     std::fs::write(&lib, contract).expect("Failed to write contract lib.rs");
 
-    assert_cmd::Command::new("rustup")
-        .arg("override")
-        .arg("set")
-        .arg("nightly")
-        .assert()
-        .success();
-
     tracing::debug!("Building contract in {}", project_dir.to_string_lossy());
     cargo_contract(&project_dir)
         .arg("build")


### PR DESCRIPTION
I was confused as to why my local toolchain kept getting overriden from `stable` to
`nightly` after a test run. Turns out its from this decode test.
