### PR TITLE
Fix `cargo test` warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,15 @@ use clap::{
 };
 use colored::Colorize;
 
+// These crates are only used when we run integration tests `--features integration-tests`. However
+// since we can't have optional `dev-dependencies` we pretend to use them during normal test runs
+// in order to satisfy the `unused_crate_dependencies` lint.
+#[cfg(test)]
+use assert_cmd as _;
+
+#[cfg(test)]
+use predicates as _;
+
 #[derive(Debug, Parser)]
 #[clap(bin_name = "cargo")]
 #[clap(version = env!("CARGO_CONTRACT_CLI_IMPL_VERSION"))]

--- a/src/util.rs
+++ b/src/util.rs
@@ -251,6 +251,7 @@ pub mod tests {
     ///
     /// Currently works only on `unix`.
     #[cfg(unix)]
+    #[cfg(feature = "test-ci-only")]
     pub fn create_executable(path: &Path, content: &str) {
         use std::io::Write;
         #[cfg(unix)]
@@ -272,6 +273,7 @@ pub mod tests {
     /// The logs are not shown by default, logs are only shown when the test fails
     /// or if [`nocapture`](https://doc.rust-lang.org/cargo/commands/cargo-test.html#display-options)
     /// is being used.
+    #[cfg(any(feature = "integration-tests", feature = "test-ci-only"))]
     pub fn init_tracing_subscriber() {
         let _ = tracing_subscriber::fmt()
             .with_max_level(tracing::Level::TRACE)


### PR DESCRIPTION
There have been a couple warnings which were introduced recently which only appear when
running `cargo test`. Since our CI runs with `cargo test --all-features` we didn't end up
seeing these.
