### PR TITLE
Don't use `--quiet` verbosity by default when running dylint

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -190,10 +190,15 @@ impl BuildCommand {
             false => OutputType::HumanReadable,
         };
 
+        let output_json = matches!(output_type, OutputType::Json);
+
         // We want to ensure that the only thing in `STDOUT` is our JSON formatted string.
-        if matches!(output_type, OutputType::Json) {
+        if output_json {
             verbosity = Verbosity::Quiet;
         }
+
+        // We don't need to lint the contract if we're outputting JSON artifacts.
+        let skip_linting = output_json || self.skip_linting;
 
         let args = ExecuteArgs {
             manifest_path,
@@ -204,7 +209,7 @@ impl BuildCommand {
             unstable_flags,
             optimization_passes,
             keep_debug_symbols: self.keep_debug_symbols,
-            skip_linting: self.skip_linting,
+            skip_linting,
             output_type,
         };
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -333,11 +333,10 @@ fn exec_cargo_for_wasm_target(
 fn exec_cargo_dylint(crate_metadata: &CrateMetadata, verbosity: Verbosity) -> Result<()> {
     check_dylint_requirements(crate_metadata.manifest_path.directory())?;
 
-    let verbosity = if verbosity == Verbosity::Verbose {
-        // `dylint` is verbose by default, it doesn't have a `--verbose` argument,
-        Verbosity::Default
-    } else {
-        verbosity
+    // `dylint` is verbose by default, it doesn't have a `--verbose` argument,
+    let verbosity = match verbosity {
+        Verbosity::Verbose => Verbosity::Default,
+        Verbosity::Default | Verbosity::Quiet => Verbosity::Quiet,
     };
 
     let target_dir = &crate_metadata.target_directory.to_string_lossy();

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -190,15 +190,10 @@ impl BuildCommand {
             false => OutputType::HumanReadable,
         };
 
-        let output_json = matches!(output_type, OutputType::Json);
-
         // We want to ensure that the only thing in `STDOUT` is our JSON formatted string.
-        if output_json {
+        if matches!(output_type, OutputType::Json) {
             verbosity = Verbosity::Quiet;
         }
-
-        // We don't need to lint the contract if we're outputting JSON artifacts.
-        let skip_linting = output_json || self.skip_linting;
 
         let args = ExecuteArgs {
             manifest_path,
@@ -209,7 +204,7 @@ impl BuildCommand {
             unstable_flags,
             optimization_passes,
             keep_debug_symbols: self.keep_debug_symbols,
-            skip_linting,
+            skip_linting: self.skip_linting,
             output_type,
         };
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -341,7 +341,7 @@ fn exec_cargo_dylint(crate_metadata: &CrateMetadata, verbosity: Verbosity) -> Re
     };
 
     let target_dir = &crate_metadata.target_directory.to_string_lossy();
-    let args = vec!["--lib=ink_linting", "--quiet"];
+    let args = vec!["--lib=ink_linting"];
     let env = vec![
         // We need to set the `CARGO_TARGET_DIR` environment variable in
         // case `cargo dylint` is invoked.


### PR DESCRIPTION
It looks like as part of #703 we added [a `--quiet` flag](https://github.com/paritytech/cargo-contract/pull/703/files#diff-46230eb6eb9a3792464a39b022f624c28ce91fed38482b30f47f483f7ef14967R344)
when running the linter. The `--output-json` flag also adds a `--quiet` flag resulting in
a failed run due to duplicate flags.

```
❮ RUSTC_BOOTSTRAP=1 cargo +stable contract build --output-json
error: The argument '--quiet' was provided more than once, but cannot be used multiple times

USAGE:
    cargo dylint [OPTIONS] [NAMES]... [-- <ARGS>...]

For more information try --help
ERROR: `"/.../bin/cargo" "dylint" "--lib=ink_linting" "--quiet" "--quiet"` failed with exit code: Some(2)
```

~~I figured that we probably don't want to run the linting step when running with
`--output-json` anyways, and by skipping that step we can avoidget this duplicate flag
conflict in the first place.~~

I've instead changed this PR to not run `dylint` with `--quiet`, and instead it'll use the verbosity
specified by the user. In your PR, @athei, you specified `--quiet` runs by default. Is there any
reason for this?
