### PR TITLE
Fix numbering of steps during `build`

### DIFF
--- a/src/cmd/metadata.rs
+++ b/src/cmd/metadata.rs
@@ -98,7 +98,7 @@ pub(crate) fn execute(
     } = extended_metadata(crate_metadata, final_contract_wasm)?;
 
     let generate_metadata = |manifest_path: &ManifestPath| -> Result<()> {
-        let mut current_progress = 4;
+        let mut current_progress = 5;
         maybe_println!(
             verbosity,
             " {} {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,8 +260,8 @@ impl BuildArtifacts {
     /// Used as output on the cli.
     pub fn steps(&self) -> usize {
         match self {
-            BuildArtifacts::All => 5,
-            BuildArtifacts::CodeOnly => 3,
+            BuildArtifacts::All => 6,
+            BuildArtifacts::CodeOnly => 4,
             BuildArtifacts::CheckOnly => 2,
         }
     }


### PR DESCRIPTION
The solution simply bumps the number of steps in the build workflow.

The result for build with `all` flag:
```bash
cargo contract build --skip-linting --generate all
 [1/6] Skip ink! linting rules
 [2/6] Building cargo project
    Updating crates.io index
    Finished release [optimized] target(s) in 0.26s
 [3/6] Post processing wasm file
 [4/6] Optimizing wasm file
 [5/6] Generating metadata
    Updating crates.io index
   Compiling metadata-gen v0.1.0 (/private/var/folders/4v/n3610fp154z5qxgdqf8nnpj80000gn/T/cargo-contract_dxoOs4/.ink/metadata_gen)
    Finished release [optimized] target(s) in 0.79s
     Running `target/ink/release/metadata-gen '' `
 [6/6] Generating bundle
...
```

The result for build with `code-only` flag:
```bash
cargo contract build --skip-linting --generate code-only
 [1/4] Skip ink! linting rules
 [2/4] Building cargo project
    Updating crates.io index
    Finished release [optimized] target(s) in 1.36s
 [3/4] Post processing wasm file
 [4/4] Optimizing wasm file

Original wasm size: 47.5K, Optimized: 22.0K

The contract was built in DEBUG mode.

Your contract's code is ready. You can find it here:
...
```