### PR TITLE
Suggested refactorings for PR #722 (`--output-json`)

### DIFF
--- a/crates/cargo-contract/src/cmd/extrinsics/call.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/call.rs
@@ -35,7 +35,6 @@ use crate::{
         display_contract_exec_result_debug,
         events::CallResult,
         ErrorVariant,
-        GenericError,
     },
     name_value_println,
     DEFAULT_KEY_COL_WIDTH,
@@ -223,17 +222,11 @@ impl CallCommand {
             }
             Err(err) => {
                 if self.output_json {
-                    eprintln!(
-                        "{}",
-                        serde_json::to_string_pretty(&ErrorVariant::Generic(
-                            GenericError {
-                                error: err.to_string()
-                            }
-                        ))?
-                    );
+                    let err = ErrorVariant::from_subxt_error(&err)?;
+                    eprintln!("{}", serde_json::to_string_pretty(&err)?);
                     Ok(())
                 } else {
-                    Err(err)
+                    Err(err.into())
                 }
             }
         }

--- a/crates/cargo-contract/src/cmd/extrinsics/call.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/call.rs
@@ -33,7 +33,7 @@ use super::{
 use crate::{
     cmd::extrinsics::{
         display_contract_exec_result_debug,
-        events::CallResult,
+        events::DisplayEvents,
         ErrorVariant,
     },
     name_value_println,
@@ -206,15 +206,13 @@ impl CallCommand {
 
         match result {
             Ok(result) => {
-                let mut call_result =
-                    CallResult::from_events(&result, transcoder, &client.metadata())?;
+                let display_events =
+                    DisplayEvents::from_events(&result, transcoder, &client.metadata())?;
 
-                call_result.estimated_gas = gas_limit;
-
-                let output: String = if self.output_json {
-                    call_result.to_json()?
+                let output = if self.output_json {
+                    display_events.to_json()?
                 } else {
-                    call_result.display_events(self.extrinsic_opts.verbosity()?)
+                    display_events.display_events(self.extrinsic_opts.verbosity()?)
                 };
                 println!("{}", output);
 

--- a/crates/cargo-contract/src/cmd/extrinsics/events.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/events.rs
@@ -40,7 +40,7 @@ use subxt::{
     tx::TxEvents,
 };
 
-/// Field that represent data of the event from contract call
+/// Field that represent data of an event from invoking a contract extrinsic.
 #[derive(serde::Serialize)]
 pub struct Field {
     /// name of a field
@@ -55,7 +55,7 @@ impl Field {
     }
 }
 
-/// Events produced from calling a contract
+/// An event produced from from invoking a contract extrinsic.
 #[derive(serde::Serialize)]
 pub struct Event {
     /// name of a pallet
@@ -66,28 +66,17 @@ pub struct Event {
     pub fields: Vec<Field>,
 }
 
-/// Result of the contract call
-#[derive(Default, serde::Serialize)]
-pub struct CallResult {
-    /// Instantiated contract hash
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub contract: Option<String>,
-    /// Instantiated code hash
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub code_hash: Option<String>,
-    /// Estimated amount of gas required to run a contract
-    pub estimated_gas: u64,
-    /// Events that were produced from calling a contract
-    pub events: Vec<Event>,
-}
+/// Displays events produced from invoking a contract extrinsic.
+#[derive(serde::Serialize)]
+pub struct DisplayEvents(Vec<Event>);
 
-impl CallResult {
+impl DisplayEvents {
     /// Parses events and returns an object which can be serialised
     pub fn from_events(
         result: &TxEvents<DefaultConfig>,
         transcoder: &ContractMessageTranscoder,
         subxt_metadata: &subxt::Metadata,
-    ) -> Result<CallResult> {
+    ) -> Result<DisplayEvents> {
         let mut events: Vec<Event> = vec![];
 
         let runtime_metadata = subxt_metadata.runtime_metadata();
@@ -140,12 +129,7 @@ impl CallResult {
             events.push(event_entry);
         }
 
-        Ok(CallResult {
-            events,
-            contract: Default::default(),
-            code_hash: Default::default(),
-            estimated_gas: Default::default(),
-        })
+        Ok(DisplayEvents(events))
     }
 
     /// Displays events in a human readable format
@@ -156,7 +140,7 @@ impl CallResult {
             "Events".bold(),
             width = DEFAULT_KEY_COL_WIDTH
         );
-        for event in &self.events {
+        for event in &self.0 {
             let _ = writeln!(
                 out,
                 "{:>width$} {} ➜ {}",

--- a/crates/cargo-contract/src/cmd/extrinsics/upload.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/upload.rs
@@ -29,7 +29,7 @@ use super::{
 };
 use crate::{
     cmd::extrinsics::{
-        events::CallResult,
+        events::DisplayEvents,
         ErrorVariant,
     },
     name_value_println,
@@ -149,10 +149,10 @@ impl UploadCommand {
 
         let result = submit_extrinsic(client, &call, signer).await?;
 
-        let call_result =
-            CallResult::from_events(&result, transcoder, &client.metadata())?;
+        let display_events =
+            DisplayEvents::from_events(&result, transcoder, &client.metadata())?;
 
-        let display = call_result.display_events(self.extrinsic_opts.verbosity()?);
+        let display = display_events.display_events(self.extrinsic_opts.verbosity()?);
         println!("{}", display);
 
         let code_stored = result.find_first::<api::contracts::events::CodeStored>()?;


### PR DESCRIPTION
Some suggested refactorings for #722, feel free to accept or reject as you please. **NOT TESTED**, it compiles only.

- Proper handling and display of `subxt::Error` returned from `submit_extrinsic`, consistent with the dry run
- Removes some duplication in `instantiate` for displaying the extrinsic result.
- Moves `is_json` to a field in `Instantiate::exec`
- Moves unrelated fields from `events.rs` and moves them to their local and relevant extrinsics
- Removes `estaimated_gas` field, it is an input not an output.