### PR TITLE
Fix storage deposit limit encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix storage deposit limit encoding - [#751](https://github.com/paritytech/cargo-contract/pull/751)
+
 ## [2.0.0-alpha.3] - 2022-09-21
 
 This release supports compatibility with the [`v4.0.0-alpha.3`](https://github.com/paritytech/ink/releases/tag/v4.0.0-alpha.3)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.1.2"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b44461635bbb1a0300f100a841e571e7d919c81c73075ef5d152ffdb521066"
+checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
 dependencies = [
  "arrayvec 0.7.2",
  "bitvec",
@@ -2090,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c45ed1f39709f5a89338fab50e59816b2e8815f5bb58276e7ddf9afd495f73f8"
+checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2626,13 +2626,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "scale-decode"
+name = "scale-bits"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70dece385bc3e5918109830d9509806b5d4525fdf594e3463078c529122979e"
+checksum = "8dd7aca73785181cc41f0bbe017263e682b585ca660540ba569133901d013ecf"
 dependencies = [
- "bitvec",
  "parity-scale-codec",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d823d4be477fc33321f93d08fb6c2698273d044f01362dc27573a750deb7c233"
+dependencies = [
+ "parity-scale-codec",
+ "scale-bits",
  "scale-info",
  "thiserror",
 ]
@@ -2665,14 +2676,14 @@ dependencies = [
 
 [[package]]
 name = "scale-value"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae8b296b3ebcb3425661e9b612ccc34cb1064483a61dc379c65e6b1463498f1"
+checksum = "16a5e7810815bd295da73e4216d1dfbced3c7c7c7054d70fa5f6e4c58123fff4"
 dependencies = [
- "bitvec",
  "either",
  "frame-metadata",
  "parity-scale-codec",
+ "scale-bits",
  "scale-decode",
  "scale-info",
  "serde",
@@ -3325,8 +3336,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "subxt"
-version = "0.23.0"
-source = "git+https://github.com/paritytech/subxt?branch=master#3bf7ddc18c527cbb13397ffbc033b4de77375db3"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a8757ee0e19f87e722577282ab1386c86592a4b13ff963b9c6ec4176348104c"
 dependencies = [
  "bitvec",
  "derivative",
@@ -3351,8 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.23.0"
-source = "git+https://github.com/paritytech/subxt?branch=master#3bf7ddc18c527cbb13397ffbc033b4de77375db3"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb77f93e11e6ff3ff95fe33e3d24c27c342e16feca8ef47759993614ebe90d2c"
 dependencies = [
  "darling",
  "frame-metadata",
@@ -3368,8 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.23.0"
-source = "git+https://github.com/paritytech/subxt?branch=master#3bf7ddc18c527cbb13397ffbc033b4de77375db3"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051cc21d77a54ae944b872eafdf9edfe1d9134fdfcfc3477dc10f763c76564a9"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -3379,8 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.23.0"
-source = "git+https://github.com/paritytech/subxt?branch=master#3bf7ddc18c527cbb13397ffbc033b4de77375db3"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed78d80db3a97d55e8b1cfecc1f6f9e21793a589d4e2e5f4fe2d6d5850c2e54"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,8 +3326,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "subxt"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5d7eafcc9b412a74269e0eaa413e9228d8b9da812e0d29c43c883da9b98b57"
+source = "git+https://github.com/paritytech/subxt?branch=aj/compact-generic-params#2143ec7bba8385f27dddf47afe70cd68cc543124"
 dependencies = [
  "bitvec",
  "derivative",
@@ -3353,8 +3352,7 @@ dependencies = [
 [[package]]
 name = "subxt-codegen"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d024e9b6fec95eba52fbe4512bf95b0ad079be3792ab190eec478d1731a17358"
+source = "git+https://github.com/paritytech/subxt?branch=aj/compact-generic-params#2143ec7bba8385f27dddf47afe70cd68cc543124"
 dependencies = [
  "darling",
  "frame-metadata",
@@ -3371,8 +3369,7 @@ dependencies = [
 [[package]]
 name = "subxt-macro"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dbe609475b86207792e1021a4f958e0381ebc2c17cf4eddd4d885883b96f8a"
+source = "git+https://github.com/paritytech/subxt?branch=aj/compact-generic-params#2143ec7bba8385f27dddf47afe70cd68cc543124"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -3383,8 +3380,7 @@ dependencies = [
 [[package]]
 name = "subxt-metadata"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7b9f8c2b42d3626dc18856727fc23cf6a04c4c044507735f55110e44a3986c"
+source = "git+https://github.com/paritytech/subxt?branch=aj/compact-generic-params#2143ec7bba8385f27dddf47afe70cd68cc543124"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,7 +3326,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "subxt"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/subxt?branch=aj/compact-generic-params#2143ec7bba8385f27dddf47afe70cd68cc543124"
+source = "git+https://github.com/paritytech/subxt?branch=master#3bf7ddc18c527cbb13397ffbc033b4de77375db3"
 dependencies = [
  "bitvec",
  "derivative",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "subxt-codegen"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/subxt?branch=aj/compact-generic-params#2143ec7bba8385f27dddf47afe70cd68cc543124"
+source = "git+https://github.com/paritytech/subxt?branch=master#3bf7ddc18c527cbb13397ffbc033b4de77375db3"
 dependencies = [
  "darling",
  "frame-metadata",
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "subxt-macro"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/subxt?branch=aj/compact-generic-params#2143ec7bba8385f27dddf47afe70cd68cc543124"
+source = "git+https://github.com/paritytech/subxt?branch=master#3bf7ddc18c527cbb13397ffbc033b4de77375db3"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "subxt-metadata"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/subxt?branch=aj/compact-generic-params#2143ec7bba8385f27dddf47afe70cd68cc543124"
+source = "git+https://github.com/paritytech/subxt?branch=master#3bf7ddc18c527cbb13397ffbc033b4de77375db3"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -46,7 +46,8 @@ regex = "1.6.0"
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 sp-core = "6.0.0"
 pallet-contracts-primitives = "6.0.0"
-subxt = "0.23.0"
+# todo: before merging, use new subxt release once available
+subxt = { git = "https://github.com/paritytech/subxt", branch = "aj/compact-generic-params" }
 hex = "0.4.3"
 jsonrpsee = { version = "0.15.1", features = ["ws-client"] }
 

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -46,8 +46,7 @@ regex = "1.6.0"
 async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 sp-core = "6.0.0"
 pallet-contracts-primitives = "6.0.0"
-# todo: before merging, use new subxt release once available
-subxt = { git = "https://github.com/paritytech/subxt", branch = "master" }
+subxt = "0.24.0"
 hex = "0.4.3"
 jsonrpsee = { version = "0.15.1", features = ["ws-client"] }
 

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -47,7 +47,7 @@ async-std = { version = "1.12.0", features = ["attributes", "tokio1"] }
 sp-core = "6.0.0"
 pallet-contracts-primitives = "6.0.0"
 # todo: before merging, use new subxt release once available
-subxt = { git = "https://github.com/paritytech/subxt", branch = "aj/compact-generic-params" }
+subxt = { git = "https://github.com/paritytech/subxt", branch = "master" }
 hex = "0.4.3"
 jsonrpsee = { version = "0.15.1", features = ["ws-client"] }
 

--- a/crates/cargo-contract/src/cmd/extrinsics/call.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/call.rs
@@ -199,7 +199,7 @@ impl CallCommand {
             self.contract.clone().into(),
             self.value,
             gas_limit,
-            self.extrinsic_opts.storage_deposit_limit,
+            self.extrinsic_opts.storage_deposit_limit(),
             data,
         );
 

--- a/crates/cargo-contract/src/cmd/extrinsics/events.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/events.rs
@@ -111,11 +111,12 @@ impl DisplayEvents {
                     let field = Field::new(String::from("data"), contract_event);
                     event_entry.fields.push(field);
                 } else {
-                    let field_name = field.name().map(ToOwned::to_owned).unwrap_or_else(|| {
-                        let name = unnamed_field_name.to_string();
-                        unnamed_field_name += 1;
-                        name
-                    });
+                    let field_name =
+                        field.name().map(ToOwned::to_owned).unwrap_or_else(|| {
+                            let name = unnamed_field_name.to_string();
+                            unnamed_field_name += 1;
+                            name
+                        });
 
                     let decoded_field = events_transcoder.decode(
                         &runtime_metadata.types,

--- a/crates/cargo-contract/src/cmd/extrinsics/events.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/events.rs
@@ -104,7 +104,7 @@ impl DisplayEvents {
                 if <ContractEmitted as StaticEvent>::is_event(
                     event.pallet_name(),
                     event.variant_name(),
-                ) && field.name() == Some(&"data".to_string())
+                ) && field.name() == Some("data")
                 {
                     tracing::debug!("event data: {:?}", hex::encode(&event_data));
                     let contract_event = transcoder.decode_contract_event(event_data)?;

--- a/crates/cargo-contract/src/cmd/extrinsics/events.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/events.rs
@@ -100,18 +100,18 @@ impl DisplayEvents {
 
             let event_data = &mut event.field_bytes();
             let mut unnamed_field_name = 0;
-            for (field, field_ty) in event_fields {
+            for field in event_fields {
                 if <ContractEmitted as StaticEvent>::is_event(
                     event.pallet_name(),
                     event.variant_name(),
-                ) && field.as_ref() == Some(&"data".to_string())
+                ) && field.name() == Some(&"data".to_string())
                 {
                     tracing::debug!("event data: {:?}", hex::encode(&event_data));
                     let contract_event = transcoder.decode_contract_event(event_data)?;
                     let field = Field::new(String::from("data"), contract_event);
                     event_entry.fields.push(field);
                 } else {
-                    let field_name = field.clone().unwrap_or_else(|| {
+                    let field_name = field.name().map(ToOwned::to_owned).unwrap_or_else(|| {
                         let name = unnamed_field_name.to_string();
                         unnamed_field_name += 1;
                         name
@@ -119,7 +119,7 @@ impl DisplayEvents {
 
                     let decoded_field = events_transcoder.decode(
                         &runtime_metadata.types,
-                        *field_ty,
+                        field.type_id(),
                         event_data,
                     )?;
                     let field = Field::new(field_name, decoded_field);

--- a/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
@@ -174,7 +174,7 @@ impl InstantiateCommand {
             raw_args: self.args.clone(),
             value: self.value,
             gas_limit: self.gas_limit.map(Weight::from_ref_time),
-            storage_deposit_limit: self.extrinsic_opts.storage_deposit_limit,
+            storage_deposit_limit: self.extrinsic_opts.storage_deposit_limit(),
             data,
             salt,
         };
@@ -203,7 +203,7 @@ struct InstantiateArgs {
     raw_args: Vec<String>,
     value: Balance,
     gas_limit: Option<Weight>,
-    storage_deposit_limit: Option<Balance>,
+    storage_deposit_limit: Option<scale::Compact<Balance>>,
     data: Vec<u8>,
     salt: Vec<u8>,
 }
@@ -495,7 +495,7 @@ struct InstantiateRequest {
     origin: <DefaultConfig as Config>::AccountId,
     value: Balance,
     gas_limit: Weight,
-    storage_deposit_limit: Option<Balance>,
+    storage_deposit_limit: Option<scale::Compact<Balance>>,
     code: Code,
     data: Vec<u8>,
     salt: Vec<u8>,

--- a/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
@@ -174,7 +174,7 @@ impl InstantiateCommand {
             raw_args: self.args.clone(),
             value: self.value,
             gas_limit: self.gas_limit.map(Weight::from_ref_time),
-            storage_deposit_limit: self.extrinsic_opts.storage_deposit_limit(),
+            storage_deposit_limit: self.extrinsic_opts.storage_deposit_limit,
             data,
             salt,
         };
@@ -203,9 +203,15 @@ struct InstantiateArgs {
     raw_args: Vec<String>,
     value: Balance,
     gas_limit: Option<Weight>,
-    storage_deposit_limit: Option<scale::Compact<Balance>>,
+    storage_deposit_limit: Option<Balance>,
     data: Vec<u8>,
     salt: Vec<u8>,
+}
+
+impl InstantiateArgs {
+    fn storage_deposit_limit_compact(&self) -> Option<scale::Compact<Balance>> {
+        self.storage_deposit_limit.map(Into::into)
+    }
 }
 
 pub struct Exec {
@@ -283,7 +289,7 @@ impl Exec {
         let call = api::tx().contracts().instantiate_with_code(
             self.args.value,
             gas_limit,
-            self.args.storage_deposit_limit,
+            self.args.storage_deposit_limit_compact(),
             code.to_vec(),
             self.args.data.clone(),
             self.args.salt.clone(),
@@ -322,7 +328,7 @@ impl Exec {
         let call = api::tx().contracts().instantiate(
             self.args.value,
             gas_limit,
-            self.args.storage_deposit_limit,
+            self.args.storage_deposit_limit_compact(),
             code_hash,
             self.args.data.clone(),
             self.args.salt.clone(),
@@ -495,7 +501,7 @@ struct InstantiateRequest {
     origin: <DefaultConfig as Config>::AccountId,
     value: Balance,
     gas_limit: Weight,
-    storage_deposit_limit: Option<scale::Compact<Balance>>,
+    storage_deposit_limit: Option<Balance>,
     code: Code,
     data: Vec<u8>,
     salt: Vec<u8>,

--- a/crates/cargo-contract/src/cmd/extrinsics/mod.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/mod.rs
@@ -138,6 +138,11 @@ impl ExtrinsicOpts {
             _ => res,
         }
     }
+
+    /// Get the storage deposit limit converted to compact for passing to extrinsics.
+    pub fn storage_deposit_limit(&self) -> Option<scale::Compact<Balance>> {
+        self.storage_deposit_limit.map(Into::into)
+    }
 }
 
 /// Parse Rust style integer balance literals which can contain underscores.

--- a/crates/cargo-contract/src/cmd/extrinsics/upload.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/upload.rs
@@ -155,7 +155,7 @@ impl UploadCommand {
     ) -> Result<Option<api::contracts::events::CodeStored>, ErrorVariant> {
         let call = super::runtime_api::api::tx()
             .contracts()
-            .upload_code(code, self.extrinsic_opts.storage_deposit_limit);
+            .upload_code(code, self.extrinsic_opts.storage_deposit_limit());
 
         let result = submit_extrinsic(client, &call, signer).await?;
         let display_events =


### PR DESCRIPTION
A bug in the `subxt` codegen meant that compact types as type parameters were not generated correctly. `storage_deposit_limit` is an `Option<Compact<u128>>` but was generated as a `Option<u128>` which resulted in incorrect encoding. https://github.com/paritytech/subxt/pull/651 fixes that issue and this PR uses the new `subxt` release and fixes the issue here.

Fixes https://github.com/paritytech/cargo-contract/issues/734