### PR TITLE
Release `v2.0.0-alpha.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0-alpha.3] - 2022-09-21
 
+This release supports compatibility with the [`v4.0.0-alpha.3`](https://github.com/paritytech/ink/releases/tag/v4.0.0-alpha.3)
+release of `ink!`. It is *not* backwards compatible with older versions of `ink!`.
+
 ### Added
 - `--output-json` support for `call`, `instantiate` and `upload` commands - [#722](https://github.com/paritytech/cargo-contract/pull/722)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.0.0-alpha.3] - 2022-09-21
+
+### Added
 - `--output-json` support for `call`, `instantiate` and `upload` commands - [#722](https://github.com/paritytech/cargo-contract/pull/722)
+
+### Fixed
+- Skip linting if running building in --offline mode -  [#737](https://github.com/paritytech/cargo-contract/pull/737)
 
 ## [2.0.0-alpha.2] - 2022-09-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,7 +627,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contract-metadata"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 dependencies = [
  "impl-serde 0.4.0",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -33,7 +33,7 @@ toml = "0.5.9"
 rustc_version = "0.4.0"
 blake2 = "0.10.4"
 contract-metadata = { version = "2.0.0-alpha.3", path = "../metadata" }
-transcode = { package = "contract-transcode", version = "2.0.0-alpha.2", path = "../transcode" }
+transcode = { package = "contract-transcode", version = "2.0.0-alpha.3", path = "../transcode" }
 semver = { version = "1.0.14", features = ["serde"] }
 serde = { version = "1.0.144", default-features = false, features = ["derive"] }
 serde_json = "1.0.85"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -32,7 +32,7 @@ colored = "2.0.0"
 toml = "0.5.9"
 rustc_version = "0.4.0"
 blake2 = "0.10.4"
-contract-metadata = { version = "2.0.0-alpha.2", path = "../metadata" }
+contract-metadata = { version = "2.0.0-alpha.3", path = "../metadata" }
 transcode = { package = "contract-transcode", version = "2.0.0-alpha.2", path = "../transcode" }
 semver = { version = "1.0.14", features = ["serde"] }
 serde = { version = "1.0.144", default-features = false, features = ["derive"] }

--- a/crates/cargo-contract/src/workspace/manifest.rs
+++ b/crates/cargo-contract/src/workspace/manifest.rs
@@ -289,7 +289,7 @@ impl Manifest {
         let ink_dylint = {
             let mut map = value::Table::new();
             map.insert("git".into(), "https://github.com/paritytech/ink/".into());
-            map.insert("branch".into(), "master".into());
+            map.insert("tag".into(), "v4.0.0-alpha.3".into());
             map.insert("pattern".into(), "linting/".into());
             value::Value::Table(map)
         };

--- a/crates/cargo-contract/templates/new/_Cargo.toml
+++ b/crates/cargo-contract/templates/new/_Cargo.toml
@@ -5,11 +5,11 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "4.0.0-alpha.1", default-features = false }
-ink_metadata = { version = "4.0.0-alpha.1", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "4.0.0-alpha.1", default-features = false }
-ink_storage = { version = "4.0.0-alpha.1", default-features = false }
-ink_lang = { version = "4.0.0-alpha.1", default-features = false }
+ink_primitives = { version = "4.0.0-alpha.3", default-features = false }
+ink_metadata = { version = "4.0.0-alpha.3", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "4.0.0-alpha.3", default-features = false }
+ink_storage = { version = "4.0.0-alpha.3", default-features = false }
+ink_lang = { version = "4.0.0-alpha.3", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.65"
-contract-metadata = { version = "2.0.0-alpha.2", path = "../metadata" }
+contract-metadata = { version = "2.0.0-alpha.3", path = "../metadata" }
 env_logger = "0.9.1"
 escape8259 = "0.5.2"
 hex = "0.4.3"

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
## [2.0.0-alpha.3] 

This release supports compatibility with the [`v4.0.0-alpha.3`](https://github.com/paritytech/ink/releases/tag/v4.0.0-alpha.3)
release of `ink!`. It is *not* backwards compatible with older versions of `ink!`.

### Added
- `--output-json` support for `call`, `instantiate` and `upload` commands - [#722](https://github.com/paritytech/cargo-contract/pull/722)

### Fixed
- Skip linting if running building in --offline mode -  [#737](https://github.com/paritytech/cargo-contract/pull/737)
