### PR TITLE
Rewrite relative path for `dev-dependency`

### DIFF
--- a/crates/cargo-contract/src/workspace/manifest.rs
+++ b/crates/cargo-contract/src/workspace/manifest.rs
@@ -316,6 +316,16 @@ impl Manifest {
         Ok(self)
     }
 
+    /// Replace relative paths with absolute paths with the working directory.
+    ///
+    /// Enables the use of a temporary amended copy of the manifest.
+    ///
+    /// # Rewrites
+    ///
+    /// - `[lib]/path`
+    /// - `[dependencies]`
+    ///
+    /// Dependencies with package names specified in `exclude_deps` will not be rewritten.
     pub fn rewrite_relative_paths(&mut self, exclude_deps: &[String]) -> Result<()> {
         let manifest_dir = self.path.absolute_directory()?;
         let path_rewrite = PathRewrite {
@@ -373,6 +383,7 @@ impl Manifest {
     }
 }
 
+/// Replace relative paths with absolute paths with the working directory.
 struct PathRewrite<'a> {
     exclude_deps: &'a [String],
     manifest_dir: PathBuf,
@@ -380,15 +391,6 @@ struct PathRewrite<'a> {
 
 impl<'a> PathRewrite<'a> {
     /// Replace relative paths with absolute paths with the working directory.
-    ///
-    /// Enables the use of a temporary amended copy of the manifest.
-    ///
-    /// # Rewrites
-    ///
-    /// - `[lib]/path`
-    /// - `[dependencies]`
-    ///
-    /// Dependencies with package names specified in `exclude_deps` will not be rewritten.
     fn rewrite_relative_paths(&self, toml: &mut value::Table) -> Result<()> {
         // Rewrite `[lib] path = /path/to/lib.rs`
         if let Some(lib) = toml.get_mut("lib") {

--- a/crates/cargo-contract/src/workspace/manifest.rs
+++ b/crates/cargo-contract/src/workspace/manifest.rs
@@ -26,7 +26,6 @@ use super::{
 use crate::OptimizationPasses;
 
 use std::{
-    collections::HashSet,
     convert::TryFrom,
     fs,
     path::{
@@ -477,11 +476,6 @@ impl<'a> PathRewrite<'a> {
         section_name: &str,
     ) -> Result<()> {
         if let Some(dependencies) = toml.get_mut(section_name) {
-            let exclude = self
-                .exclude_deps
-                .into_iter()
-                .map(|s| s.clone())
-                .collect::<HashSet<_>>();
             let table = dependencies
                 .as_table_mut()
                 .ok_or_else(|| anyhow::anyhow!("dependencies should be a table"))?;
@@ -492,7 +486,7 @@ impl<'a> PathRewrite<'a> {
                     package_name.to_string()
                 };
 
-                if !exclude.contains(&package_name) {
+                if !self.exclude_deps.contains(&package_name) {
                     if let Some(dependency) = value.as_table_mut() {
                         if let Some(dep_path) = dependency.get_mut("path") {
                             self.to_absolute_path(


### PR DESCRIPTION
Because contracts are built in a temp directory, dependencies with relative paths e.g. `ink = { path = "../../crates/ink", default-features = false }` are rewritten to their absolute paths.

However this currently only happens for dependencies in the `[dependencies]` section, and will not work for `[dev-dependencies]`.

This PR supports rewriting the `dev-dependencies` relative paths. 

Required for https://github.com/paritytech/ink/pull/1429