### PR TITLE
Release `v2.0.0-alpha.4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0-alpha.4] - 2022-10-03
+
 - Fix storage deposit limit encoding - [#751](https://github.com/paritytech/cargo-contract/pull/751)
+- Rewrite relative path for `dev-dependency` - [#760](https://github.com/paritytech/cargo-contract/pull/760)
 
 ## [2.0.0-alpha.3] - 2022-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0-alpha.4] - 2022-10-03
 
+### Fixed
 - Fix storage deposit limit encoding - [#751](https://github.com/paritytech/cargo-contract/pull/751)
 - Rewrite relative path for `dev-dependency` - [#760](https://github.com/paritytech/cargo-contract/pull/760)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -625,7 +625,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contract-metadata"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "impl-serde 0.4.0",
  "pretty_assertions",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -32,8 +32,8 @@ colored = "2.0.0"
 toml = "0.5.9"
 rustc_version = "0.4.0"
 blake2 = "0.10.4"
-contract-metadata = { version = "2.0.0-alpha.3", path = "../metadata" }
-transcode = { package = "contract-transcode", version = "2.0.0-alpha.3", path = "../transcode" }
+contract-metadata = { version = "2.0.0-alpha.4", path = "../metadata" }
+transcode = { package = "contract-transcode", version = "2.0.0-alpha.4", path = "../transcode" }
 semver = { version = "1.0.14", features = ["serde"] }
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 serde_json = "1.0.85"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.65"
-contract-metadata = { version = "2.0.0-alpha.3", path = "../metadata" }
+contract-metadata = { version = "2.0.0-alpha.4", path = "../metadata" }
 env_logger = "0.9.1"
 escape8259 = "0.5.2"
 hex = "0.4.3"


### PR DESCRIPTION
- Fix storage deposit limit encoding - [#751](https://github.com/paritytech/cargo-contract/pull/751)
- Rewrite relative path for `dev-dependency` - [#760](https://github.com/paritytech/cargo-contract/pull/760)