### PR TITLE
Make linting opt in with `--lint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Removed requirement to install binaryen. The `wasm-opt` tool is now compiled into `cargo-contract`.
+- Make linting opt in with `--lint` - [#799](https://github.com/paritytech/cargo-contract/pull/799)
 
 ## [2.0.0-alpha.4] - 2022-10-03
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Modern releases of gcc and clang, as well as Visual Studio 2019+ should work.
 
 * Step 1: `rustup component add rust-src`.
 
-* Step 2: Install `dylint`
+* Step 2: `cargo install --force --locked cargo-contract`.
+
+* Step 3: (**Optional**) Install `dylint` for linting.
   * (MacOS) `brew install openssl`
   * `cargo install cargo-dylint dylint-link`.
 
-* Step 3: `cargo install --force --locked cargo-contract`.
-
-You can always update the `cargo-contract` binary to the latest version by running the Step 3.
+You can always update the `cargo-contract` binary to the latest version by running the Step 2.
 
 ### Installation using Docker Image
 

--- a/crates/cargo-contract/src/cmd/build/tests.rs
+++ b/crates/cargo-contract/src/cmd/build/tests.rs
@@ -80,7 +80,7 @@ fn build_code_only(manifest_path: &ManifestPath) -> Result<()> {
         manifest_path: manifest_path.clone(),
         build_mode: BuildMode::Release,
         build_artifact: BuildArtifacts::CodeOnly,
-        lint: true,
+        lint: false,
         ..Default::default()
     };
 
@@ -120,7 +120,7 @@ fn check_must_not_output_contract_artifacts_in_project_dir(
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
         build_artifact: BuildArtifacts::CheckOnly,
-        lint: true,
+        lint: false,
         ..Default::default()
     };
 
@@ -158,7 +158,7 @@ fn optimization_passes_from_cli_must_take_precedence_over_profile(
         // we choose zero optimization passes as the "cli" parameter
         optimization_passes: Some(OptimizationPasses::Zero),
         keep_debug_symbols: false,
-        lint: true,
+        lint: false,
         output_json: false,
     };
 
@@ -199,7 +199,7 @@ fn optimization_passes_from_profile_must_be_used(
         // we choose no optimization passes as the "cli" parameter
         optimization_passes: None,
         keep_debug_symbols: false,
-        lint: true,
+        lint: false,
         output_json: false,
     };
 
@@ -241,7 +241,7 @@ fn contract_lib_name_different_from_package_name_must_build(
         unstable_options: UnstableOptions::default(),
         optimization_passes: None,
         keep_debug_symbols: false,
-        lint: true,
+        lint: false,
         output_json: false,
     };
     let res = cmd.exec().expect("build failed");
@@ -262,7 +262,7 @@ fn building_template_in_debug_mode_must_work(manifest_path: &ManifestPath) -> Re
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
         build_mode: BuildMode::Debug,
-        lint: true,
+        lint: false,
         ..Default::default()
     };
 
@@ -281,7 +281,7 @@ fn building_template_in_release_mode_must_work(
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
         build_mode: BuildMode::Release,
-        lint: true,
+        lint: false,
         ..Default::default()
     };
 
@@ -311,7 +311,7 @@ fn building_contract_with_source_file_in_subfolder_must_work(
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
         build_artifact: BuildArtifacts::CheckOnly,
-        lint: true,
+        lint: false,
         ..Default::default()
     };
 
@@ -329,7 +329,7 @@ fn keep_debug_symbols_in_debug_mode(manifest_path: &ManifestPath) -> Result<()> 
         build_mode: BuildMode::Debug,
         build_artifact: BuildArtifacts::CodeOnly,
         keep_debug_symbols: true,
-        lint: true,
+        lint: false,
         ..Default::default()
     };
 
@@ -347,7 +347,7 @@ fn keep_debug_symbols_in_release_mode(manifest_path: &ManifestPath) -> Result<()
         build_mode: BuildMode::Release,
         build_artifact: BuildArtifacts::CodeOnly,
         keep_debug_symbols: true,
-        lint: true,
+        lint: false,
         ..Default::default()
     };
 
@@ -364,7 +364,7 @@ fn build_with_json_output_works(manifest_path: &ManifestPath) -> Result<()> {
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
         output_type: OutputType::Json,
-        lint: true,
+        lint: false,
         ..Default::default()
     };
 
@@ -436,7 +436,7 @@ fn generates_metadata(manifest_path: &ManifestPath) -> Result<()> {
     fs::write(final_contract_wasm_path, "TEST FINAL WASM BLOB").unwrap();
 
     let mut args = crate::cmd::build::ExecuteArgs {
-        lint: true,
+        lint: false,
         ..Default::default()
     };
     args.manifest_path = manifest_path.clone();

--- a/crates/cargo-contract/src/cmd/build/tests.rs
+++ b/crates/cargo-contract/src/cmd/build/tests.rs
@@ -80,7 +80,7 @@ fn build_code_only(manifest_path: &ManifestPath) -> Result<()> {
         manifest_path: manifest_path.clone(),
         build_mode: BuildMode::Release,
         build_artifact: BuildArtifacts::CodeOnly,
-        skip_linting: true,
+        lint: true,
         ..Default::default()
     };
 
@@ -120,7 +120,7 @@ fn check_must_not_output_contract_artifacts_in_project_dir(
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
         build_artifact: BuildArtifacts::CheckOnly,
-        skip_linting: true,
+        lint: true,
         ..Default::default()
     };
 
@@ -158,7 +158,7 @@ fn optimization_passes_from_cli_must_take_precedence_over_profile(
         // we choose zero optimization passes as the "cli" parameter
         optimization_passes: Some(OptimizationPasses::Zero),
         keep_debug_symbols: false,
-        skip_linting: true,
+        lint: true,
         output_json: false,
     };
 
@@ -199,7 +199,7 @@ fn optimization_passes_from_profile_must_be_used(
         // we choose no optimization passes as the "cli" parameter
         optimization_passes: None,
         keep_debug_symbols: false,
-        skip_linting: true,
+        lint: true,
         output_json: false,
     };
 
@@ -241,7 +241,7 @@ fn contract_lib_name_different_from_package_name_must_build(
         unstable_options: UnstableOptions::default(),
         optimization_passes: None,
         keep_debug_symbols: false,
-        skip_linting: true,
+        lint: true,
         output_json: false,
     };
     let res = cmd.exec().expect("build failed");
@@ -262,7 +262,7 @@ fn building_template_in_debug_mode_must_work(manifest_path: &ManifestPath) -> Re
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
         build_mode: BuildMode::Debug,
-        skip_linting: true,
+        lint: true,
         ..Default::default()
     };
 
@@ -281,7 +281,7 @@ fn building_template_in_release_mode_must_work(
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
         build_mode: BuildMode::Release,
-        skip_linting: true,
+        lint: true,
         ..Default::default()
     };
 
@@ -311,7 +311,7 @@ fn building_contract_with_source_file_in_subfolder_must_work(
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
         build_artifact: BuildArtifacts::CheckOnly,
-        skip_linting: true,
+        lint: true,
         ..Default::default()
     };
 
@@ -329,7 +329,7 @@ fn keep_debug_symbols_in_debug_mode(manifest_path: &ManifestPath) -> Result<()> 
         build_mode: BuildMode::Debug,
         build_artifact: BuildArtifacts::CodeOnly,
         keep_debug_symbols: true,
-        skip_linting: true,
+        lint: true,
         ..Default::default()
     };
 
@@ -347,7 +347,7 @@ fn keep_debug_symbols_in_release_mode(manifest_path: &ManifestPath) -> Result<()
         build_mode: BuildMode::Release,
         build_artifact: BuildArtifacts::CodeOnly,
         keep_debug_symbols: true,
-        skip_linting: true,
+        lint: true,
         ..Default::default()
     };
 
@@ -364,7 +364,7 @@ fn build_with_json_output_works(manifest_path: &ManifestPath) -> Result<()> {
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
         output_type: OutputType::Json,
-        skip_linting: true,
+        lint: true,
         ..Default::default()
     };
 
@@ -436,7 +436,7 @@ fn generates_metadata(manifest_path: &ManifestPath) -> Result<()> {
     fs::write(final_contract_wasm_path, "TEST FINAL WASM BLOB").unwrap();
 
     let mut args = crate::cmd::build::ExecuteArgs {
-        skip_linting: true,
+        lint: true,
         ..Default::default()
     };
     args.manifest_path = manifest_path.clone();

--- a/crates/cargo-contract/src/cmd/build/tests.rs
+++ b/crates/cargo-contract/src/cmd/build/tests.rs
@@ -394,6 +394,7 @@ fn missing_cargo_dylint_installation_must_be_detected(
     // when
     let args = crate::cmd::build::ExecuteArgs {
         manifest_path: manifest_path.clone(),
+        lint: true,
         ..Default::default()
     };
     let res = super::execute(args).map(|_| ()).unwrap_err();

--- a/crates/cargo-contract/src/cmd/metadata.rs
+++ b/crates/cargo-contract/src/cmd/metadata.rs
@@ -117,6 +117,7 @@ pub(crate) fn execute(
     final_contract_wasm: &Path,
     network: Network,
     verbosity: Verbosity,
+    mut next_step: usize,
     total_steps: usize,
     unstable_options: &UnstableFlags,
     build_info: BuildInfo,
@@ -135,11 +136,10 @@ pub(crate) fn execute(
     } = extended_metadata(crate_metadata, final_contract_wasm, build_info)?;
 
     let generate_metadata = |manifest_path: &ManifestPath| -> Result<()> {
-        let mut current_progress = 5;
         maybe_println!(
             verbosity,
             " {} {}",
-            format!("[{}/{}]", current_progress, total_steps).bold(),
+            format!("[{}/{}]", next_step, total_steps).bold(),
             "Generating metadata".bright_green().bold()
         );
         let target_dir_arg =
@@ -167,13 +167,13 @@ pub(crate) fn execute(
             metadata.remove_source_wasm_attribute();
             let contents = serde_json::to_string_pretty(&metadata)?;
             fs::write(&out_path_metadata, contents)?;
-            current_progress += 1;
+            next_step += 1;
         }
 
         maybe_println!(
             verbosity,
             " {} {}",
-            format!("[{}/{}]", current_progress, total_steps).bold(),
+            format!("[{}/{}]", next_step, total_steps).bold(),
             "Generating bundle".bright_green().bold()
         );
         let contents = serde_json::to_string(&metadata)?;

--- a/crates/cargo-contract/src/cmd/metadata.rs
+++ b/crates/cargo-contract/src/cmd/metadata.rs
@@ -23,6 +23,7 @@ use crate::{
         Workspace,
     },
     BuildMode,
+    BuildSteps,
     Network,
     OptimizationPasses,
     UnstableFlags,
@@ -117,8 +118,7 @@ pub(crate) fn execute(
     final_contract_wasm: &Path,
     network: Network,
     verbosity: Verbosity,
-    mut next_step: usize,
-    total_steps: usize,
+    mut build_steps: BuildSteps,
     unstable_options: &UnstableFlags,
     build_info: BuildInfo,
 ) -> Result<MetadataResult> {
@@ -139,7 +139,7 @@ pub(crate) fn execute(
         maybe_println!(
             verbosity,
             " {} {}",
-            format!("[{}/{}]", next_step, total_steps).bold(),
+            format!("{}", build_steps).bold(),
             "Generating metadata".bright_green().bold()
         );
         let target_dir_arg =
@@ -167,13 +167,13 @@ pub(crate) fn execute(
             metadata.remove_source_wasm_attribute();
             let contents = serde_json::to_string_pretty(&metadata)?;
             fs::write(&out_path_metadata, contents)?;
-            next_step += 1;
+            build_steps.increment_current();
         }
 
         maybe_println!(
             verbosity,
             " {} {}",
-            format!("[{}/{}]", next_step, total_steps).bold(),
+            format!("{}", build_steps).bold(),
             "Generating bundle".bright_green().bold()
         );
         let contents = serde_json::to_string(&metadata)?;

--- a/crates/cargo-contract/src/main.rs
+++ b/crates/cargo-contract/src/main.rs
@@ -284,9 +284,9 @@ impl BuildArtifacts {
     /// Used as output on the cli.
     pub fn steps(&self) -> usize {
         match self {
-            BuildArtifacts::All => 6,
+            BuildArtifacts::All => 5,
             BuildArtifacts::CodeOnly => 4,
-            BuildArtifacts::CheckOnly => 2,
+            BuildArtifacts::CheckOnly => 1,
         }
     }
 }

--- a/crates/cargo-contract/src/main.rs
+++ b/crates/cargo-contract/src/main.rs
@@ -282,11 +282,11 @@ pub enum BuildArtifacts {
 impl BuildArtifacts {
     /// Returns the number of steps required to complete a build artifact.
     /// Used as output on the cli.
-    pub fn steps(&self) -> usize {
+    pub fn steps(&self) -> BuildSteps {
         match self {
-            BuildArtifacts::All => 5,
-            BuildArtifacts::CodeOnly => 4,
-            BuildArtifacts::CheckOnly => 1,
+            BuildArtifacts::All => BuildSteps::new(5),
+            BuildArtifacts::CodeOnly => BuildSteps::new(4),
+            BuildArtifacts::CheckOnly => BuildSteps::new(1),
         }
     }
 }
@@ -294,6 +294,32 @@ impl BuildArtifacts {
 impl Default for BuildArtifacts {
     fn default() -> Self {
         BuildArtifacts::All
+    }
+}
+
+/// Track and display the current and total number of steps.
+#[derive(Debug, Clone, Copy)]
+pub struct BuildSteps {
+    pub current_step: usize,
+    pub total_steps: usize,
+}
+
+impl BuildSteps {
+    pub fn new(total_steps: usize) -> Self {
+        Self {
+            current_step: 1,
+            total_steps,
+        }
+    }
+
+    pub fn increment_current(&mut self) {
+        self.current_step += 1;
+    }
+}
+
+impl Display for BuildSteps {
+    fn fmt(&self, f: &mut Formatter<'_>) -> DisplayResult {
+        write!(f, "[{}/{}]", self.current_step, self.total_steps)
     }
 }
 

--- a/crates/cargo-contract/tests/decode.rs
+++ b/crates/cargo-contract/tests/decode.rs
@@ -72,10 +72,7 @@ fn decode_works() {
     std::fs::write(&lib, contract).expect("Failed to write contract lib.rs");
 
     tracing::debug!("Building contract in {}", project_dir.to_string_lossy());
-    cargo_contract(&project_dir)
-        .arg("build")
-        .assert()
-        .success();
+    cargo_contract(&project_dir).arg("build").assert().success();
 
     let msg_data: &str = "babebabe01";
     let msg_decoded: &str = r#"switch { value: true }"#;

--- a/crates/cargo-contract/tests/decode.rs
+++ b/crates/cargo-contract/tests/decode.rs
@@ -74,7 +74,6 @@ fn decode_works() {
     tracing::debug!("Building contract in {}", project_dir.to_string_lossy());
     cargo_contract(&project_dir)
         .arg("build")
-        .arg("--skip-linting")
         .assert()
         .success();
 


### PR DESCRIPTION
Since the release of `ink 4.0`, lints are optional and currently there are no lints which are run from the `ink!` repo.

This PR replaces `--skip-linting` with the inverse `--lint` to make linting opt-in by default instead of opt out. That way if/when we do add lints to `ink` there will be no changes required here.