### PR TITLE
Update validation for renamed FFI functions

### DIFF
--- a/crates/cargo-contract/src/validate_wasm.rs
+++ b/crates/cargo-contract/src/validate_wasm.rs
@@ -124,7 +124,6 @@ pub fn validate_import_section(module: &Module) -> Result<()> {
 
 /// Returns `true` if the import is allowed.
 fn check_import(module: &str, field: &str) -> Result<(), String> {
-    println!("module {}, field {}", module, field);
     if module.starts_with("seal")
         || module == "__unstable__"
         || field.starts_with("memory")


### PR DESCRIPTION
`seal` prefixes have been removed, need to check for the module name now.

See https://github.com/paritytech/ink/pull/1482#issuecomment-1309424077