### PR TITLE
add `-C target-cpu=mvp` rust flag to `build` command

### DIFF
--- a/crates/cargo-contract/src/cmd/build/mod.rs
+++ b/crates/cargo-contract/src/cmd/build/mod.rs
@@ -308,7 +308,7 @@ fn exec_cargo_for_wasm_target(
         }
         let env = vec![(
             "RUSTFLAGS",
-            Some("-C link-arg=-zstack-size=65536 -C link-arg=--import-memory -Clinker-plugin-lto"),
+            Some("-C link-arg=-zstack-size=65536 -C link-arg=--import-memory -Clinker-plugin-lto -C target-cpu=mvp"),
         )];
         util::invoke_cargo(command, &args, manifest_path.directory(), verbosity, env)?;
 


### PR DESCRIPTION
`nightly` rust [adds](https://github.com/paritytech/cargo-contract/issues/832) some new WASM features which are out of WASM MVP and hence not supported by `pallet_contracts` . 

This change should catch\avoid such cases on the `cargo contract build` step.