### PR TITLE
transcode: update ink! deps to beta, remove env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,6 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "contract-metadata",
- "env_logger 0.10.0",
  "escape8259",
  "hex",
  "indexmap",
@@ -1087,19 +1086,6 @@ checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -1708,7 +1694,7 @@ dependencies = [
  "blake2",
  "derive_more",
  "either",
- "env_logger 0.9.3",
+ "env_logger",
  "heck",
  "impl-serde",
  "ink_ir",

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -19,11 +19,10 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0.66"
 contract-metadata = { version = "2.0.0-beta", path = "../metadata" }
-env_logger = "0.10.0"
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "1.9.2"
-ink_env = "4.0.0-alpha.3"
+ink_env = "4.0.0-beta"
 ink_metadata = { package = "ink_metadata", version = "4.0.0-beta" }
 itertools = "0.10.5"
 tracing = "0.1.37"
@@ -38,7 +37,7 @@ sp-runtime = "7.0.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-ink = "4.0.0-alpha.3"
+ink = "4.0.0-beta"
 
 [features]
 # This `std` feature is required for testing using an inline contract's metadata, because `ink!` annotates the metadata

--- a/crates/transcode/src/transcoder.rs
+++ b/crates/transcode/src/transcoder.rs
@@ -687,8 +687,6 @@ mod tests {
 
     #[test]
     fn transcode_account_id_custom_ss58_encoding() -> Result<()> {
-        env_logger::init();
-
         type AccountId = sp_runtime::AccountId32;
 
         #[allow(dead_code)]


### PR DESCRIPTION
- forgot to update transcode `ink!` dependencies in https://github.com/paritytech/cargo-contract/pull/828
- remove unused `env_logger` dependency