### PR TITLE
Remove `unstable` module check, add `--skip-wasm-validation`

### DIFF
--- a/crates/cargo-contract/src/cmd/build/mod.rs
+++ b/crates/cargo-contract/src/cmd/build/mod.rs
@@ -541,7 +541,9 @@ fn post_process_wasm(
         maybe_println!(
             verbosity,
             " {}",
-            "Skipping wasm validation! Contract code may be invalid.".bright_yellow().bold()
+            "Skipping wasm validation! Contract code may be invalid."
+                .bright_yellow()
+                .bold()
         );
     }
 

--- a/crates/cargo-contract/src/cmd/build/mod.rs
+++ b/crates/cargo-contract/src/cmd/build/mod.rs
@@ -85,6 +85,7 @@ pub(crate) struct ExecuteArgs {
     pub keep_debug_symbols: bool,
     pub lint: bool,
     pub output_type: OutputType,
+    pub skip_wasm_validation: bool,
 }
 
 /// Executes build of the smart contract which produces a Wasm binary that is ready for deploying.
@@ -158,6 +159,9 @@ pub struct BuildCommand {
     /// Export the build output in JSON format.
     #[clap(long, conflicts_with = "verbose")]
     output_json: bool,
+    /// Don't perform wasm validation checks e.g. for permitted imports.
+    #[clap(long)]
+    skip_wasm_validation: bool,
 }
 
 impl BuildCommand {
@@ -219,6 +223,7 @@ impl BuildCommand {
             keep_debug_symbols: self.keep_debug_symbols,
             lint: self.lint,
             output_type,
+            skip_wasm_validation: self.skip_wasm_validation,
         };
 
         execute(args)
@@ -255,6 +260,7 @@ impl CheckCommand {
             keep_debug_symbols: false,
             lint: false,
             output_type: OutputType::default(),
+            skip_wasm_validation: false,
         };
 
         execute(args)
@@ -516,7 +522,7 @@ fn load_module<P: AsRef<Path>>(path: P) -> Result<Module> {
 }
 
 /// Performs required post-processing steps on the Wasm artifact.
-fn post_process_wasm(crate_metadata: &CrateMetadata) -> Result<()> {
+fn post_process_wasm(crate_metadata: &CrateMetadata, skip_wasm_validation: bool) -> Result<()> {
     // Deserialize Wasm module from a file.
     let mut module = load_module(&crate_metadata.original_wasm)
         .context("Loading of original wasm failed")?;
@@ -525,7 +531,9 @@ fn post_process_wasm(crate_metadata: &CrateMetadata) -> Result<()> {
     ensure_maximum_memory_pages(&mut module, MAX_MEMORY_PAGES)?;
     strip_custom_sections(&mut module);
 
-    validate_wasm::validate_import_section(&module)?;
+    if !skip_wasm_validation {
+        validate_wasm::validate_import_section(&module)?;
+    }
 
     debug_assert!(
         !module.clone().into_bytes().unwrap().is_empty(),
@@ -596,6 +604,7 @@ pub(crate) fn execute(args: ExecuteArgs) -> Result<BuildResult> {
         keep_debug_symbols,
         lint,
         output_type,
+        skip_wasm_validation,
     } = args;
 
     let crate_metadata = CrateMetadata::collect(&manifest_path)?;
@@ -651,7 +660,7 @@ pub(crate) fn execute(args: ExecuteArgs) -> Result<BuildResult> {
             "Post processing wasm file".bright_green().bold()
         );
         build_steps.increment_current();
-        post_process_wasm(&crate_metadata)?;
+        post_process_wasm(&crate_metadata, skip_wasm_validation)?;
 
         maybe_println!(
             verbosity,

--- a/crates/cargo-contract/src/cmd/build/tests.rs
+++ b/crates/cargo-contract/src/cmd/build/tests.rs
@@ -160,6 +160,7 @@ fn optimization_passes_from_cli_must_take_precedence_over_profile(
         keep_debug_symbols: false,
         lint: false,
         output_json: false,
+        skip_wasm_validation: false,
     };
 
     // when
@@ -201,6 +202,7 @@ fn optimization_passes_from_profile_must_be_used(
         keep_debug_symbols: false,
         lint: false,
         output_json: false,
+        skip_wasm_validation: false,
     };
 
     // when
@@ -243,6 +245,7 @@ fn contract_lib_name_different_from_package_name_must_build(
         keep_debug_symbols: false,
         lint: false,
         output_json: false,
+        skip_wasm_validation: false,
     };
     let res = cmd.exec().expect("build failed");
 

--- a/crates/cargo-contract/src/validate_wasm.rs
+++ b/crates/cargo-contract/src/validate_wasm.rs
@@ -122,18 +122,15 @@ pub fn validate_import_section(module: &Module) -> Result<()> {
     Ok(())
 }
 
-/// Returns `true` if the import is allowed.
+/// Returns `Ok` if the import is allowed.
 fn check_import(module: &str, field: &str) -> Result<(), String> {
-    if module.starts_with("seal")
-        || module == "__unstable__"
-        || field.starts_with("memory")
-    {
+    if module.starts_with("seal") || field.starts_with("memory") {
         Ok(())
     } else {
         Err(format!(
             "An unexpected import function was found in the contract Wasm: {}.\n\
             Import funtions must either be prefixed with 'memory', or part \
-            of a module prefixed with 'seal' or '__unstable__",
+            of a module prefixed with 'seal'",
             field
         ))
     }

--- a/crates/cargo-contract/src/validate_wasm.rs
+++ b/crates/cargo-contract/src/validate_wasm.rs
@@ -112,7 +112,7 @@ pub fn validate_import_section(module: &Module) -> Result<()> {
 
     if original_imports_len != filtered_imports.count() {
         anyhow::bail!(format!(
-            "Validation of the Wasm failed.\n\n\n{}",
+            "Validation of the Wasm failed.\n\n\n{}\n\nIgnore with `--skip-wasm-validation`",
             errs.into_iter()
                 .map(|err| format!("{} {}", "ERROR:".to_string().bold(), err))
                 .collect::<Vec<String>>()

--- a/crates/cargo-contract/src/validate_wasm.rs
+++ b/crates/cargo-contract/src/validate_wasm.rs
@@ -291,7 +291,6 @@ mod tests {
             (module
                 (type (;0;) (func (param i32 i32 i32)))
                 (import "seal" "foo" (func (;5;) (type 0)))
-                (import "__unstable__" "bar" (func (;5;) (type 0)))
                 (import "env" "memory" (func (;5;) (type 0)))
                 (func (;5;) (type 0))
             )"#;


### PR DESCRIPTION
Companion to https://github.com/paritytech/ink/pull/1522.

Imports from `__unstable__` modules now invalid. However I have added an escape hatch `--skip-wasm-validation` which skips this check in case the user wants to build an incompatible version of `ink!`.