### PR TITLE
Bump minimum requirement of `scale-info` in template to `2.3`

### DIFF
--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 ink = { version = "4.0.0-beta", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "{{name}}"


### PR DESCRIPTION
Since https://github.com/paritytech/ink/pull/1357 we require a minimum version of `2.3`