### PR TITLE
Remove rust toolchain channel check

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -260,10 +260,10 @@ fn exec_cargo_for_wasm_target(
             "RUSTFLAGS",
             Some("-C link-arg=-zstack-size=65536 -C link-arg=--import-memory -Clinker-plugin-lto -C target-cpu=mvp"),
         )];
-        // if rustc_version::version_meta()?.channel == Channel::Stable {
-        //     // Allow nightly features on a stable toolchain
-        //     env.push(("RUSTC_BOOTSTRAP", Some("1")))
-        // }
+        if rustc_version::version_meta()?.channel == rustc_version::Channel::Stable {
+            // Allow nightly features on a stable toolchain
+            env.push(("RUSTC_BOOTSTRAP", Some("1")))
+        }
 
         util::invoke_cargo(command, &args, manifest_path.directory(), verbosity, env)?;
 

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -256,10 +256,15 @@ fn exec_cargo_for_wasm_target(
         } else {
             args.push("-Zbuild-std-features=panic_immediate_abort");
         }
-        let env = vec![(
+        let mut env = vec![(
             "RUSTFLAGS",
             Some("-C link-arg=-zstack-size=65536 -C link-arg=--import-memory -Clinker-plugin-lto -C target-cpu=mvp"),
         )];
+        // if rustc_version::version_meta()?.channel == Channel::Stable {
+        //     // Allow nightly features on a stable toolchain
+        //     env.push(("RUSTC_BOOTSTRAP", Some("1")))
+        // }
+
         util::invoke_cargo(command, &args, manifest_path.directory(), verbosity, env)?;
 
         Ok(())


### PR DESCRIPTION
@HCastano reported the [following](https://github.com/paritytech/ink/pull/1523#pullrequestreview-1201375457) error when using `cargo +nighlty test` for E2E tests using the new [`contract-build`](https://github.com/paritytech/ink/pull/1523) library. First of all the error is misleading and is an occurrence of https://github.com/paritytech/cargo-contract/issues/746.

The issue is that the `+nightly` gets inherited and the `assert_channel` check fails. This PR removes this check entirely and allows the underlying `cargo build` command to inherit whatever toolchain the user needs. It still does add `RUSTC_BOOTSTRAP` in case we are building with `stable`.

This should now be more in line with `cargo` philosophy and give more flexibility to contract authors with their toolchain management.

See also https://github.com/paritytech/cargo-contract/pull/698 where stable toolchain was first introduced.