### PR TITLE
Release `v2.0.0-beta.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.0.0-beta.1] - 2022-12-07
+
+### Changed
+- Pass `--features` through to `cargo` - [#853](https://github.com/paritytech/cargo-contract/pull/853/files)
+- Remove rust toolchain channel check - [#848](https://github.com/paritytech/cargo-contract/pull/848/files)
+- Bump minimum requirement of `scale-info` in template to `2.3` - [#847](https://github.com/paritytech/cargo-contract/pull/847/files)
+- Remove `unstable` module check, add `--skip-wasm-validation` - [#846](https://github.com/paritytech/cargo-contract/pull/846/files)
+- Extract lib for invoking contract build - [#787](https://github.com/paritytech/cargo-contract/pull/787/files)
+
+### Fixed
 - Fixed having non-JSON output after calling `instantiate` with `--output-json` - [#839](https://github.com/paritytech/cargo-contract/pull/839/files)
+- add `-C target-cpu=mvp` rust flag to build command - [#838](https://github.com/paritytech/cargo-contract/pull/838/files)
 
 ## [2.0.0-beta] - 2022-11-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "2.0.0-beta"
+version = "2.0.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "contract-build"
-version = "2.0.0-beta"
+version = "2.0.0-beta.1"
 dependencies = [
  "anyhow",
  "blake2",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "2.0.0-beta"
+version = "2.0.0-beta.1"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "2.0.0-beta"
+version = "2.0.0-beta.1"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-build"
-version = "2.0.0-beta"
+version = "2.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -36,7 +36,7 @@ wasm-opt = "0.110.1"
 which = "4.3.0"
 zip = { version = "0.6.3", default-features = false }
 
-contract-metadata = { version = "2.0.0-beta", path = "../metadata" }
+contract-metadata = { version = "2.0.0-beta.1", path = "../metadata" }
 
 [build-dependencies]
 anyhow = "1.0.65"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "2.0.0-beta"
+version = "2.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-contract-build = { version = "2.0.0-beta", path = "../build" }
-contract-metadata = { version = "2.0.0-beta", path = "../metadata" }
-contract-transcode = { version = "2.0.0-beta", path = "../transcode" }
+contract-build = { version = "2.0.0-beta.1", path = "../build" }
+contract-metadata = { version = "2.0.0-beta.1", path = "../metadata" }
+contract-transcode = { version = "2.0.0-beta.1", path = "../transcode" }
 
 anyhow = "1.0.66"
 clap = { version = "4.0.29", features = ["derive", "env"] }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "2.0.0-beta"
+version = "2.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "2.0.0-beta"
+version = "2.0.0-beta.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.66"
-contract-metadata = { version = "2.0.0-beta", path = "../metadata" }
+contract-metadata = { version = "2.0.0-beta.1", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "1.9.2"


### PR DESCRIPTION
### Changed
- Pass `--features` through to `cargo` - [#853](https://github.com/paritytech/cargo-contract/pull/853/files)
- Remove rust toolchain channel check - [#848](https://github.com/paritytech/cargo-contract/pull/848/files)
- Bump minimum requirement of `scale-info` in template to `2.3` - [#847](https://github.com/paritytech/cargo-contract/pull/847/files)
- Remove `unstable` module check, add `--skip-wasm-validation` - [#846](https://github.com/paritytech/cargo-contract/pull/846/files)
- Extract lib for invoking contract build - [#787](https://github.com/paritytech/cargo-contract/pull/787/files)

### Fixed
- Fixed having non-JSON output after calling `instantiate` with `--output-json` - [#839](https://github.com/paritytech/cargo-contract/pull/839/files)
- add `-C target-cpu=mvp` rust flag to build command - [#838](https://github.com/paritytech/cargo-contract/pull/838/files)