### PR TITLE
Bump `secp256k1` to `v0.24.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,9 +3166,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secp256k1"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
+checksum = "d9512ffd81e3a3503ed401f79c33168b9148c75038956039166cd750eaa037c3"
 dependencies = [
  "secp256k1-sys",
 ]


### PR DESCRIPTION
The `v0.24.1` release has been yanked due to a soundness bug. See here
for more: https://github.com/rustsec/advisory-db/pull/1480
