### PR TITLE
Fixed installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Modern releases of gcc and clang, as well as Visual Studio 2019+ should work.
 
 * Step 1: `rustup component add rust-src`.
 
-* Step 2: `cargo install --force --locked cargo-contract`.
-
-* Step 3: (**Optional**) Install `dylint` for linting.
+* Step 2: (**Optional**) Install `dylint` for linting.
   * (MacOS) `brew install openssl`
   * `cargo install cargo-dylint dylint-link`.
 
-You can always update the `cargo-contract` binary to the latest version by running the Step 2.
+* Step 3: `cargo install --force --locked cargo-contract`.
+
+You can always update the `cargo-contract` binary to the latest version by running the Step 3.
 
 ### Installation using Docker Image
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Modern releases of gcc and clang, as well as Visual Studio 2019+ should work.
 
 * Step 1: `rustup component add rust-src`.
 
-* Step 2: (**Optional**) Install `dylint` for linting.
+* Step 2: Install `dylint` for linting.
   * (MacOS) `brew install openssl`
   * `cargo install cargo-dylint dylint-link`.
 


### PR DESCRIPTION
`cargo install --force --locked cargo-contract` requires `dylint-link` being installed. Otherwise,  compile fails.

To avoid developers' confusion when starting with cargo-contract for the first time, The installation order should be reversed.

<img width="1512" alt="Screen Shot 2022-12-21 at 15 43 38" src="https://user-images.githubusercontent.com/28953860/208838922-8b679754-36be-4ec5-a919-959e2d899c1c.png">