### PR TITLE
Require env_type transcoders to be Send + Sync

### DIFF
--- a/crates/transcode/src/env_types.rs
+++ b/crates/transcode/src/env_types.rs
@@ -134,12 +134,12 @@ impl From<&Path<PortableForm>> for PathKey {
 pub type TypesByPath = HashMap<PathKey, u32>;
 
 /// Implement this trait to define custom encoding for a type in a `scale-info` type registry.
-pub trait CustomTypeEncoder {
+pub trait CustomTypeEncoder: Send + Sync {
     fn encode_value(&self, value: &Value) -> Result<Vec<u8>>;
 }
 
 /// Implement this trait to define custom decoding for a type in a `scale-info` type registry.
-pub trait CustomTypeDecoder {
+pub trait CustomTypeDecoder: Send + Sync {
     fn decode_value(&self, input: &mut &[u8]) -> Result<Value>;
 }
 

--- a/crates/transcode/src/env_types.rs
+++ b/crates/transcode/src/env_types.rs
@@ -45,15 +45,15 @@ use std::{
 /// Provides custom encoding and decoding for predefined environment types.
 #[derive(Default)]
 pub struct EnvTypesTranscoder {
-    encoders: HashMap<u32, Box<dyn CustomTypeEncoder + Send + Sync>>,
-    decoders: HashMap<u32, Box<dyn CustomTypeDecoder + Send + Sync>>,
+    encoders: HashMap<u32, Box<dyn CustomTypeEncoder>>,
+    decoders: HashMap<u32, Box<dyn CustomTypeDecoder>>,
 }
 
 impl EnvTypesTranscoder {
     /// Construct an `EnvTypesTranscoder` from the given type registry.
     pub fn new(
-        encoders: HashMap<u32, Box<dyn CustomTypeEncoder + Send + Sync>>,
-        decoders: HashMap<u32, Box<dyn CustomTypeDecoder + Send + Sync>>,
+        encoders: HashMap<u32, Box<dyn CustomTypeEncoder>>,
+        decoders: HashMap<u32, Box<dyn CustomTypeDecoder>>,
     ) -> Self {
         Self { encoders, decoders }
     }

--- a/crates/transcode/src/env_types.rs
+++ b/crates/transcode/src/env_types.rs
@@ -45,15 +45,15 @@ use std::{
 /// Provides custom encoding and decoding for predefined environment types.
 #[derive(Default)]
 pub struct EnvTypesTranscoder {
-    encoders: HashMap<u32, Box<dyn CustomTypeEncoder>>,
-    decoders: HashMap<u32, Box<dyn CustomTypeDecoder>>,
+    encoders: HashMap<u32, Box<dyn CustomTypeEncoder + Send + Sync>>,
+    decoders: HashMap<u32, Box<dyn CustomTypeDecoder + Send + Sync>>,
 }
 
 impl EnvTypesTranscoder {
     /// Construct an `EnvTypesTranscoder` from the given type registry.
     pub fn new(
-        encoders: HashMap<u32, Box<dyn CustomTypeEncoder>>,
-        decoders: HashMap<u32, Box<dyn CustomTypeDecoder>>,
+        encoders: HashMap<u32, Box<dyn CustomTypeEncoder + Send + Sync>>,
+        decoders: HashMap<u32, Box<dyn CustomTypeDecoder + Send + Sync>>,
     ) -> Self {
         Self { encoders, decoders }
     }

--- a/crates/transcode/src/transcoder.rs
+++ b/crates/transcode/src/transcoder.rs
@@ -78,8 +78,8 @@ impl Transcoder {
 /// Construct a [`Transcoder`], allows registering custom transcoders for certain types.
 pub struct TranscoderBuilder {
     types_by_path: TypesByPath,
-    encoders: HashMap<u32, Box<dyn CustomTypeEncoder + Send + Sync>>,
-    decoders: HashMap<u32, Box<dyn CustomTypeDecoder + Send + Sync>>,
+    encoders: HashMap<u32, Box<dyn CustomTypeEncoder>>,
+    decoders: HashMap<u32, Box<dyn CustomTypeDecoder>>,
 }
 
 impl TranscoderBuilder {
@@ -106,7 +106,7 @@ impl TranscoderBuilder {
     pub fn register_custom_type_transcoder<T, U>(self, transcoder: U) -> Self
     where
         T: TypeInfo + 'static,
-        U: CustomTypeEncoder + CustomTypeDecoder + Clone + Send + Sync + 'static,
+        U: CustomTypeEncoder + CustomTypeDecoder + Clone + 'static,
     {
         self.register_custom_type_encoder::<T, U>(transcoder.clone())
             .register_custom_type_decoder::<T, U>(transcoder)
@@ -115,7 +115,7 @@ impl TranscoderBuilder {
     pub fn register_custom_type_encoder<T, U>(self, encoder: U) -> Self
     where
         T: TypeInfo + 'static,
-        U: CustomTypeEncoder + Send + Sync + 'static,
+        U: CustomTypeEncoder + 'static,
     {
         let mut this = self;
 
@@ -144,7 +144,7 @@ impl TranscoderBuilder {
     pub fn register_custom_type_decoder<T, U>(self, encoder: U) -> Self
     where
         T: TypeInfo + 'static,
-        U: CustomTypeDecoder + Send + Sync + 'static,
+        U: CustomTypeDecoder + 'static,
     {
         let mut this = self;
 

--- a/crates/transcode/src/transcoder.rs
+++ b/crates/transcode/src/transcoder.rs
@@ -78,8 +78,8 @@ impl Transcoder {
 /// Construct a [`Transcoder`], allows registering custom transcoders for certain types.
 pub struct TranscoderBuilder {
     types_by_path: TypesByPath,
-    encoders: HashMap<u32, Box<dyn CustomTypeEncoder>>,
-    decoders: HashMap<u32, Box<dyn CustomTypeDecoder>>,
+    encoders: HashMap<u32, Box<dyn CustomTypeEncoder + Send + Sync>>,
+    decoders: HashMap<u32, Box<dyn CustomTypeDecoder + Send + Sync>>,
 }
 
 impl TranscoderBuilder {
@@ -106,7 +106,7 @@ impl TranscoderBuilder {
     pub fn register_custom_type_transcoder<T, U>(self, transcoder: U) -> Self
     where
         T: TypeInfo + 'static,
-        U: CustomTypeEncoder + CustomTypeDecoder + Clone + 'static,
+        U: CustomTypeEncoder + CustomTypeDecoder + Clone + Send + Sync + 'static,
     {
         self.register_custom_type_encoder::<T, U>(transcoder.clone())
             .register_custom_type_decoder::<T, U>(transcoder)
@@ -115,7 +115,7 @@ impl TranscoderBuilder {
     pub fn register_custom_type_encoder<T, U>(self, encoder: U) -> Self
     where
         T: TypeInfo + 'static,
-        U: CustomTypeEncoder + 'static,
+        U: CustomTypeEncoder + Send + Sync + 'static,
     {
         let mut this = self;
 
@@ -144,7 +144,7 @@ impl TranscoderBuilder {
     pub fn register_custom_type_decoder<T, U>(self, encoder: U) -> Self
     where
         T: TypeInfo + 'static,
-        U: CustomTypeDecoder + 'static,
+        U: CustomTypeDecoder + Send + Sync + 'static,
     {
         let mut this = self;
 


### PR DESCRIPTION
They are already required to be `'static`, so this seems like a reasonable requirement. In practice, it seems only `AccountId` and `Hash` transcoders are inserted into this collection. Adding these two traits allows a `ContractMetadataTranscoder` to be shared between threads via an `Arc`.  This is very useful, especially given a `ContractMetadataTranscoder` is not even `Clone`, which makes it unwieldy to load the metadata once and use it around the program.