### PR TITLE
Upgrade wasm-opt to 0.111.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,9 +4405,9 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-opt"
-version = "0.110.2"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68e8037b4daf711393f4be2056246d12d975651b14d581520ad5d1f19219cec"
+checksum = "84a303793cbc01fb96551badfc7367db6007396bba6bac97936b3c8b6f7fdb41"
 dependencies = [
  "anyhow",
  "libc",
@@ -4421,9 +4421,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.110.2"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91adbad477e97bba3fbd21dd7bfb594e7ad5ceb9169ab1c93ab9cb0ada636b6f"
+checksum = "d9c9deb56f8a9f2ec177b3bd642a8205621835944ed5da55f2388ef216aca5a4"
 dependencies = [
  "anyhow",
  "cxx",
@@ -4433,9 +4433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.110.2"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4fa5a322a4e6ac22fd141f498d56afbdbf9df5debeac32380d2dcaa3e06941"
+checksum = "4432e28b542738a9776cedf92e8a99d8991c7b4667ee2c7ccddfb479dd2856a7"
 dependencies = [
  "anyhow",
  "cc",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1.0.91"
 tempfile = "3.3.0"
 url = { version = "2.3.1", features = ["serde"] }
-wasm-opt = "0.110.1"
+wasm-opt = "0.111.0"
 which = "4.3.0"
 zip = { version = "0.6.3", default-features = false }
 


### PR DESCRIPTION
This upgrades binaryen to version 111.

Binaryen (and wasm-opt) now enables the `SignExt` and `MutableGlobals` features by default, which are also enabled in the LLVM backend. In the future Binaryen will align its default feature selection with the LLVM backend.

This is _probably_ is ok for cargo-contract - I assume, but don't know, that the substrate wasm vm allows these two common features.

This also points to potential future optimizations by explicitly turning on more features that the substrate vm supports, but aren't being enabled in wasm-opt.

The [changelog](https://github.com/brson/wasm-opt-rs/blob/master/CHANGELOG.md) for 0.111.0.

I see that the cargo-contract current version is a beta. If a major release is impending, it might be prudent to delay merging this.