### PR TITLE
Enable `wasm-opt` MVP features only

### DIFF
--- a/crates/build/src/wasm_opt.rs
+++ b/crates/build/src/wasm_opt.rs
@@ -66,6 +66,10 @@ impl WasmOptHandler {
         );
 
         OptimizationOptions::from(self.optimization_level)
+            // Binaryen (and wasm-opt) now enables the `SignExt` and `MutableGlobals`
+            // features by default, so we want to disable those for now since
+            // `pallet-contracts` still needs to enable these.
+            .mvp_features_only()
             // the memory in our module is imported, `wasm-opt` needs to be told that
             // the memory is initialized to zeroes, otherwise it won't run the
             // memory-packing pre-pass.


### PR DESCRIPTION
As @brson pointed out in https://github.com/paritytech/cargo-contract/pull/888, this upgrade brings new Wasm features enabled by default. @Robbepop says these are supported by `wasmi` but still need to be enabled in `pallet-contracts` (/cc @athei). 

Originally I intended just to revert to `wasm-opt` `0.110`, but noticed in the [`CHANGELOG`](https://github.com/brson/wasm-opt-rs/blob/master/CHANGELOG.md) that there is the option of `.mvp_features_only()`, which I have added as an alternative in this PR.