### PR TITLE
Extrinsics: allow specifying contract artifact directly 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # ignore Substrate pallets major updates.
+    # automated Substrate releases cause dependabot PR spam, so these must be updated manually when required.
+    ignore:
+      - dependency-name: "sp-*"
+        update-types: [ "version-update:semver-major" ]
+      - dependency-name: "pallet-*"
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: github-actions
     directory: '/'
     schedule:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.7"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3d466004a8b4cb1bc34044240a2fd29d17607e2e3bd613eb44fd48e8100da3"
+checksum = "9834fcc22e0874394a010230586367d4a3e9f11b560f469262678547e1d2575e"
 dependencies = [
  "bstr",
  "doc-comment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2841,9 +2841,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -137,6 +137,13 @@ impl CrateMetadata {
     pub fn metadata_path(&self) -> PathBuf {
         self.target_directory.join(METADATA_FILE)
     }
+
+    /// Get the path of the contract bundle, containing metadata + code
+    pub fn contract_bundle_path(&self) -> PathBuf {
+        let target_directory = self.target_directory.clone();
+        let fname_bundle = format!("{}.contract", self.contract_artifact_name);
+        target_directory.join(fname_bundle)
+    }
 }
 
 /// Get the result of `cargo metadata`, together with the root package id.

--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -138,7 +138,7 @@ impl CrateMetadata {
         self.target_directory.join(METADATA_FILE)
     }
 
-    /// Get the path of the contract bundle, containing metadata + code
+    /// Get the path of the contract bundle, containing metadata + code.
     pub fn contract_bundle_path(&self) -> PathBuf {
         let target_directory = self.target_directory.clone();
         let fname_bundle = format!("{}.contract", self.contract_artifact_name);

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -732,6 +732,18 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
     })
 }
 
+/// Returns the blake2 hash of the code slice.
+pub fn code_hash(code: &[u8]) -> [u8; 32] {
+    use blake2::digest::{
+        consts::U32,
+        Digest as _,
+    };
+    let mut blake2 = blake2::Blake2b::<U32>::new();
+    blake2.update(code);
+    let result = blake2.finalize();
+    result.into()
+}
+
 /// Testing individual functions where the build itself is not actually invoked. See [`tests`] for
 /// all tests which invoke the `build` command.
 #[cfg(test)]

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -15,8 +15,8 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-    crate_metadata::CrateMetadata,
     code_hash,
+    crate_metadata::CrateMetadata,
     maybe_println,
     util,
     workspace::{

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -16,6 +16,7 @@
 
 use crate::{
     crate_metadata::CrateMetadata,
+    code_hash,
     maybe_println,
     util,
     workspace::{
@@ -31,13 +32,8 @@ use crate::{
 };
 
 use anyhow::Result;
-use blake2::digest::{
-    consts::U32,
-    Digest as _,
-};
 use colored::Colorize;
 use contract_metadata::{
-    CodeHash,
     Compiler,
     Contract,
     ContractMetadata,
@@ -233,7 +229,7 @@ fn extended_metadata(
         let hash = code_hash(wasm.as_slice());
         Source::new(
             Some(SourceWasm::new(wasm)),
-            hash,
+            hash.into(),
             lang,
             compiler,
             Some(build_info.try_into()?),
@@ -279,12 +275,4 @@ fn extended_metadata(
         contract,
         user,
     })
-}
-
-/// Returns the blake2 hash of the code slice.
-pub fn code_hash(code: &[u8]) -> CodeHash {
-    let mut blake2 = blake2::Blake2b::<U32>::new();
-    blake2.update(code);
-    let result = blake2.finalize();
-    CodeHash(result.into())
 }

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -230,7 +230,7 @@ fn extended_metadata(
         let lang = SourceLanguage::new(Language::Ink, ink_version.clone());
         let compiler = SourceCompiler::new(Compiler::RustC, rust_version);
         let wasm = fs::read(final_contract_wasm)?;
-        let hash = blake2_hash(wasm.as_slice());
+        let hash = code_hash(wasm.as_slice());
         Source::new(
             Some(SourceWasm::new(wasm)),
             hash,
@@ -281,8 +281,8 @@ fn extended_metadata(
     })
 }
 
-/// Returns the blake2 hash of the submitted slice.
-pub fn blake2_hash(code: &[u8]) -> CodeHash {
+/// Returns the blake2 hash of the code slice.
+pub fn code_hash(code: &[u8]) -> CodeHash {
     let mut blake2 = blake2::Blake2b::<U32>::new();
     blake2.update(code);
     let result = blake2.finalize();

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -118,11 +118,8 @@ pub(crate) fn execute(
     unstable_options: &UnstableFlags,
     build_info: BuildInfo,
 ) -> Result<MetadataResult> {
-    let target_directory = crate_metadata.target_directory.clone();
-    let out_path_metadata = target_directory.join(METADATA_FILE);
-
-    let fname_bundle = format!("{}.contract", crate_metadata.contract_artifact_name);
-    let out_path_bundle = target_directory.join(fname_bundle);
+    let out_path_metadata = crate_metadata.metadata_path();
+    let out_path_bundle = crate_metadata.contract_bundle_path();
 
     // build the extended contract project metadata
     let ExtendedMetadataResult {
@@ -138,8 +135,10 @@ pub(crate) fn execute(
             format!("{}", build_steps).bold(),
             "Generating metadata".bright_green().bold()
         );
-        let target_dir_arg =
-            format!("--target-dir={}", target_directory.to_string_lossy());
+        let target_dir_arg = format!(
+            "--target-dir={}",
+            crate_metadata.target_directory.to_string_lossy()
+        );
         let stdout = util::invoke_cargo(
             "run",
             [

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -58,7 +58,7 @@ use std::{
 };
 use url::Url;
 
-const METADATA_FILE: &str = "metadata.json";
+pub const METADATA_FILE: &str = "metadata.json";
 
 /// Metadata generation result.
 #[derive(serde::Serialize)]

--- a/crates/build/src/tests.rs
+++ b/crates/build/src/tests.rs
@@ -497,7 +497,7 @@ fn generates_metadata(manifest_path: &ManifestPath) -> Result<()> {
 
     // calculate wasm hash
     let fs_wasm = fs::read(&crate_metadata.dest_wasm)?;
-    let expected_hash = crate::metadata::blake2_hash(&fs_wasm[..]);
+    let expected_hash = crate::metadata::code_hash(&fs_wasm[..]);
     let expected_wasm = build_byte_str(&fs_wasm);
 
     let expected_language =

--- a/crates/build/src/tests.rs
+++ b/crates/build/src/tests.rs
@@ -497,7 +497,7 @@ fn generates_metadata(manifest_path: &ManifestPath) -> Result<()> {
 
     // calculate wasm hash
     let fs_wasm = fs::read(&crate_metadata.dest_wasm)?;
-    let expected_hash = crate::metadata::code_hash(&fs_wasm[..]);
+    let expected_hash = crate::code_hash(&fs_wasm[..]);
     let expected_wasm = build_byte_str(&fs_wasm);
 
     let expected_language =
@@ -514,7 +514,7 @@ fn generates_metadata(manifest_path: &ManifestPath) -> Result<()> {
         serde_json::Value::Array(vec!["and".into(), "their".into(), "values".into()]),
     );
 
-    assert_eq!(build_byte_str(&expected_hash.0[..]), hash.as_str().unwrap());
+    assert_eq!(build_byte_str(&expected_hash[..]), hash.as_str().unwrap());
     assert_eq!(expected_wasm, wasm.as_str().unwrap());
     assert_eq!(expected_language, language.as_str().unwrap());
     assert_eq!(expected_compiler, compiler.as_str().unwrap());

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -51,7 +51,7 @@ which = "4.3.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.8"
-regex = "1.7.0"
+regex = "1.7.1"
 predicates = "2.1.5"
 tempfile = "3.3.0"
 

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -50,7 +50,7 @@ current_platform = "0.2.0"
 which = "4.3.0"
 
 [dev-dependencies]
-assert_cmd = "2.0.7"
+assert_cmd = "2.0.8"
 regex = "1.7.0"
 predicates = "2.1.5"
 tempfile = "3.3.0"

--- a/crates/cargo-contract/src/cmd/extrinsics/events.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/events.rs
@@ -31,7 +31,10 @@ use contract_transcode::{
 };
 
 use anyhow::Result;
-use std::fmt::Write;
+use std::{
+    fmt::Write,
+    str::FromStr,
+};
 use subxt::{
     self,
     blocks::ExtrinsicEvents,
@@ -117,9 +120,10 @@ impl DisplayEvents {
                             Ok(contract_event) => contract_event,
                             Err(err) => {
                                 tracing::warn!(
-                                        "Decoding contract event failed: {:?}. It might have come from another contract.",
-                                        err
-                                    )
+                                    "Decoding contract event failed: {:?}. It might have come from another contract.",
+                                    err
+                                );
+                                Value::Hex(Hex::from_str(&hex::encode(&event_data))?)
                             }
                         }
                     } else {

--- a/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
@@ -490,22 +490,3 @@ enum Code {
     /// The code hash of an on-chain Wasm blob.
     Existing(<DefaultConfig as Config>::Hash),
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_code_hash_works() {
-        // with 0x prefix
-        assert!(parse_code_hash(
-            "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
-        )
-        .is_ok());
-        // without 0x prefix
-        assert!(parse_code_hash(
-            "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
-        )
-        .is_ok())
-    }
-}

--- a/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
@@ -25,7 +25,6 @@ use super::{
     Client,
     CodeHash,
     ContractMessageTranscoder,
-    CrateMetadata,
     DefaultConfig,
     ExtrinsicOpts,
     PairSigner,
@@ -62,29 +61,17 @@ use sp_core::{
 use sp_weights::Weight;
 use std::{
     fs,
-    path::{
-        Path,
-        PathBuf,
-    },
+    path::Path,
 };
 use subxt::{
     blocks::ExtrinsicEvents,
     Config,
     OnlineClient,
 };
+use crate::cmd::extrinsics::WasmCode;
 
 #[derive(Debug, clap::Args)]
 pub struct InstantiateCommand {
-    /// Path to Wasm contract code, defaults to `./target/ink/<name>.wasm`.
-    /// Use to instantiate contracts which have not yet been uploaded.
-    /// If the contract has already been uploaded use `--code-hash` instead.
-    #[clap(value_parser)]
-    wasm_path: Option<PathBuf>,
-    /// The hash of the smart contract code already uploaded to the chain.
-    /// If the contract has not already been uploaded use `--wasm-path` or run the `upload` command
-    /// first.
-    #[clap(long, value_parser = parse_code_hash)]
-    code_hash: Option<<DefaultConfig as Config>::Hash>,
     /// The name of the contract constructor to call
     #[clap(name = "constructor", long, default_value = "new")]
     constructor: String,
@@ -140,10 +127,8 @@ impl InstantiateCommand {
     /// Creates an extrinsic with the `Contracts::instantiate` Call, submits via RPC, then waits for
     /// the `ContractsEvent::Instantiated` event.
     pub fn run(&self) -> Result<(), ErrorVariant> {
-        let crate_metadata = CrateMetadata::from_manifest_path(
-            self.extrinsic_opts.manifest_path.as_ref(),
-        )?;
-        let transcoder = ContractMessageTranscoder::load(crate_metadata.metadata_path())?;
+        let artifacts = self.extrinsic_opts.contract_artifacts()?;
+        let transcoder = artifacts.contract_transcoder()?;
         let data = transcoder.encode(&self.constructor, &self.args)?;
         let signer = super::pair_signer(self.extrinsic_opts.signer()?);
         let url = self.extrinsic_opts.url_to_string();
@@ -156,20 +141,22 @@ impl InstantiateCommand {
             Ok(Code::Upload(code))
         }
 
-        let code = match (self.wasm_path.as_ref(), self.code_hash.as_ref()) {
-            (Some(_), Some(_)) => {
-                Err(anyhow!(
-                    "Specify either `--wasm-path` or `--code-hash` but not both"
-                ))
-            }
-            (Some(wasm_path), None) => load_code(wasm_path),
-            (None, None) => {
-                // default to the target contract wasm in the current project,
-                // inferred via the crate metadata.
-                load_code(&crate_metadata.dest_wasm)
-            }
-            (None, Some(code_hash)) => Ok(Code::Existing(*code_hash)),
-        }?;
+        // let code = match (self.wasm_path.as_ref(), self.code_hash.as_ref()) {
+        //     (Some(_), Some(_)) => {
+        //         Err(anyhow!(
+        //             "Specify either `--wasm-path` or `--code-hash` but not both"
+        //         ))
+        //     }
+        //     (Some(wasm_path), None) => load_code(wasm_path),
+        //     (None, None) => {
+        //         // default to the target contract wasm in the current project,
+        //         // inferred via the crate metadata.
+        //         load_code(&crate_metadata.dest_wasm)
+        //     }
+        //     (None, Some(code_hash)) => Ok(Code::Existing(*code_hash)),
+        // }?;
+
+
         let salt = self.salt.clone().map(|s| s.0).unwrap_or_default();
 
         async_std::task::block_on(async move {
@@ -204,7 +191,7 @@ impl InstantiateCommand {
                 output_json: self.output_json,
             };
 
-            exec.exec(code, self.extrinsic_opts.dry_run).await
+            exec.exec(self.extrinsic_opts.dry_run).await
         })
     }
 }
@@ -216,6 +203,7 @@ struct InstantiateArgs {
     gas_limit: Option<u64>,
     proof_size: Option<u64>,
     storage_deposit_limit: Option<Balance>,
+    code: WasmCode,
     data: Vec<u8>,
     salt: Vec<u8>,
 }
@@ -238,10 +226,10 @@ pub struct Exec {
 }
 
 impl Exec {
-    async fn exec(&self, code: Code, dry_run: bool) -> Result<(), ErrorVariant> {
+    async fn exec(&self, dry_run: bool) -> Result<(), ErrorVariant> {
         tracing::debug!("instantiate data {:?}", self.args.data);
         if dry_run {
-            let result = self.instantiate_dry_run(code).await?;
+            let result = self.instantiate_dry_run().await?;
             match result.result {
                 Ok(ref ret_val) => {
                     let dry_run_result = InstantiateDryRunResult {
@@ -287,6 +275,10 @@ impl Exec {
             }
             Ok(())
         }
+    }
+
+    fn code(&self) -> Code {
+        todo!()
     }
 
     async fn instantiate_with_code(&self, code: Vec<u8>) -> Result<(), ErrorVariant> {
@@ -368,7 +360,7 @@ impl Exec {
     ) -> Result<(), ErrorVariant> {
         let events = DisplayEvents::from_events(
             result,
-            &self.transcoder,
+            Some(&self.transcoder),
             &self.client.metadata(),
         )?;
         let contract_address = contract_address.to_ss58check();
@@ -398,7 +390,6 @@ impl Exec {
 
     async fn instantiate_dry_run(
         &self,
-        code: Code,
     ) -> Result<ContractInstantiateResult<<DefaultConfig as Config>::AccountId, Balance>>
     {
         let storage_deposit_limit = self.args.storage_deposit_limit;

--- a/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
@@ -37,6 +37,7 @@ use crate::{
         events::DisplayEvents,
         ErrorVariant,
         TokenMetadata,
+        WasmCode,
     },
     DEFAULT_KEY_COL_WIDTH,
 };
@@ -68,7 +69,6 @@ use subxt::{
     Config,
     OnlineClient,
 };
-use crate::cmd::extrinsics::WasmCode;
 
 #[derive(Debug, clap::Args)]
 pub struct InstantiateCommand {
@@ -155,7 +155,6 @@ impl InstantiateCommand {
         //     }
         //     (None, Some(code_hash)) => Ok(Code::Existing(*code_hash)),
         // }?;
-
 
         let salt = self.salt.clone().map(|s| s.0).unwrap_or_default();
 

--- a/crates/cargo-contract/src/cmd/extrinsics/mod.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/mod.rs
@@ -99,10 +99,10 @@ type Client = OnlineClient<DefaultConfig>;
 pub struct ExtrinsicOpts {
     /// Path to a contract build artifact file: a raw `.wasm` file, a `.contract` bundle,
     /// or a `.json` metadata file.
-    #[clap(value_parser)]
+    #[clap(value_parser, conflicts_with = "manifest_path")]
     file: Option<PathBuf>,
     /// Path to the `Cargo.toml` of the contract.
-    #[clap(long, value_parser, conflicts_with = "artifact_path")]
+    #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
     /// Websockets url of a substrate node.
     #[clap(

--- a/crates/cargo-contract/src/cmd/extrinsics/mod.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/mod.rs
@@ -237,18 +237,29 @@ impl ContractArtifacts {
         })
     }
 
-    /// Construct a [`ContractMessageTranscoder`] from contract metadata.
+    /// Get contract metadata, if available.
     ///
     /// ## Errors
     /// - No contract metadata could be found.
     /// - Invalid contract metadata.
-    pub fn contract_transcoder(&self) -> Result<ContractMessageTranscoder> {
-        let metadata = self.metadata.clone().ok_or_else(|| {
+    pub fn metadata(&self) -> Result<ContractMetadata> {
+        self.metadata.clone().ok_or_else(|| {
             anyhow!(
                 "No contract metadata found. Expected file {}",
                 self.metadata_path.as_path().display()
             )
-        })?;
+        })
+    }
+
+    /// Get the code hash from the contract metadata.
+    pub fn code_hash(&self) -> Result<[u8; 32]> {
+        let metadata = self.metadata()?;
+        Ok(metadata.source.hash.0)
+    }
+
+    /// Construct a [`ContractMessageTranscoder`] from contract metadata.
+    pub fn contract_transcoder(&self) -> Result<ContractMessageTranscoder> {
+        let metadata = self.metadata()?;
         ContractMessageTranscoder::try_from(metadata)
             .context("Failed to deserialize ink project metadata from contract metadata")
     }

--- a/crates/cargo-contract/src/cmd/extrinsics/mod.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/mod.rs
@@ -222,7 +222,7 @@ impl ContractArtifacts {
                 }
                 Some("wasm") => {
                     let code = Some(WasmCode(std::fs::read(path)?));
-                    let dir = path.parent().map_or_else(|| PathBuf::new(), PathBuf::from);
+                    let dir = path.parent().map_or_else(PathBuf::new, PathBuf::from);
                     let metadata_path = dir.join(METADATA_FILE);
                     if !metadata_path.exists() {
                         (metadata_path, None, code)

--- a/crates/cargo-contract/src/cmd/extrinsics/mod.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/mod.rs
@@ -201,6 +201,8 @@ impl ExtrinsicOpts {
 /// Contract artifacts for use with extrinsic commands.
 #[derive(Debug)]
 pub struct ContractArtifacts {
+    /// The original artifact path
+    artifacts_path: PathBuf,
     /// The expected path of the file containing the contract metadata.
     metadata_path: PathBuf,
     /// The deserialized contract metadata if the expected metadata file exists.
@@ -241,10 +243,16 @@ impl ContractArtifacts {
                 }
             };
         Ok(Self {
+            artifacts_path: path.into(),
             metadata_path,
             metadata,
             code,
         })
+    }
+
+    /// Get the path of the artifact file used to load the artifacts.
+    pub fn artifact_path(&self) -> &Path {
+        self.artifacts_path.as_path()
     }
 
     /// Get contract metadata, if available.
@@ -280,6 +288,7 @@ impl ContractArtifacts {
 pub struct WasmCode(Vec<u8>);
 
 impl WasmCode {
+    /// The hash of the contract code: uniquely identifies the contract code on-chain.
     pub fn code_hash(&self) -> [u8; 32] {
         contract_build::code_hash(&self.0)
     }

--- a/crates/cargo-contract/src/cmd/extrinsics/mod.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/mod.rs
@@ -97,13 +97,13 @@ type Client = OnlineClient<DefaultConfig>;
 /// Arguments required for creating and sending an extrinsic to a substrate node.
 #[derive(Clone, Debug, clap::Args)]
 pub struct ExtrinsicOpts {
-    /// Path to the `Cargo.toml` of the contract.
-    #[clap(long, value_parser, conflicts_with = "artifact_path")]
-    manifest_path: Option<PathBuf>,
     /// Path to a contract build artifact file: a raw `.wasm` file, a `.contract` bundle,
     /// or a `.json` metadata file.
     #[clap(value_parser)]
     file: Option<PathBuf>,
+    /// Path to the `Cargo.toml` of the contract.
+    #[clap(long, value_parser, conflicts_with = "artifact_path")]
+    manifest_path: Option<PathBuf>,
     /// Websockets url of a substrate node.
     #[clap(
         name = "url",

--- a/crates/cargo-contract/src/cmd/extrinsics/upload.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/upload.rs
@@ -65,10 +65,11 @@ impl UploadCommand {
         let artifacts = self.extrinsic_opts.contract_artifacts()?;
         let signer = super::pair_signer(self.extrinsic_opts.signer()?);
 
+        let artifacts_path = artifacts.artifact_path().to_path_buf();
         let code = artifacts.code.ok_or_else(|| {
             anyhow::anyhow!(
                 "Contract code not found from artifact file {}",
-                artifacts.artifacts_path().display()
+                artifacts_path.display()
             )
         })?;
         let code_hash = code.code_hash();

--- a/crates/cargo-contract/src/cmd/extrinsics/upload.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/upload.rs
@@ -65,9 +65,12 @@ impl UploadCommand {
         let artifacts = self.extrinsic_opts.contract_artifacts()?;
         let signer = super::pair_signer(self.extrinsic_opts.signer()?);
 
-        let code = artifacts
-            .code
-            .ok_or_else(|| anyhow::anyhow!("Contract code not found"))?; // todo: add more detail
+        let code = artifacts.code.ok_or_else(|| {
+            anyhow::anyhow!(
+                "Contract code not found from artifact file {}",
+                artifacts.artifacts_path().display()
+            )
+        })?;
         let code_hash = code.code_hash();
 
         async_std::task::block_on(async {

--- a/crates/cargo-contract/src/cmd/extrinsics/upload.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/upload.rs
@@ -40,10 +40,7 @@ use crate::{
 use anyhow::Result;
 use pallet_contracts_primitives::CodeUploadResult;
 use scale::Encode;
-use std::{
-    fmt::Debug,
-    path::PathBuf,
-};
+use std::fmt::Debug;
 use subxt::{
     Config,
     OnlineClient,
@@ -52,9 +49,6 @@ use subxt::{
 #[derive(Debug, clap::Args)]
 #[clap(name = "upload", about = "Upload a contract's code")]
 pub struct UploadCommand {
-    /// Path to Wasm contract code, defaults to `./target/ink/<name>.wasm`.
-    #[clap(value_parser)]
-    wasm_path: Option<PathBuf>,
     #[clap(flatten)]
     extrinsic_opts: ExtrinsicOpts,
     /// Export the call output in JSON format.

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -121,7 +121,7 @@ impl ContractMetadata {
     }
 
     /// Reads the file and tries to parse it as instance of `ContractMetadata`.
-    pub fn load<P>(metadata_path: &P) -> Result<Self>
+    pub fn load<P>(metadata_path: P) -> Result<Self>
     where
         P: AsRef<Path>,
     {

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -146,6 +146,12 @@ pub struct CodeHash(
     pub [u8; 32],
 );
 
+impl From<[u8; 32]> for CodeHash {
+    fn from(value: [u8; 32]) -> Self {
+        CodeHash(value)
+    }
+}
+
 /// Information about the contract's Wasm code.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Source {

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -105,6 +105,7 @@ mod util;
 
 pub use self::{
     scon::{
+        Hex,
         Map,
         Tuple,
         Value,

--- a/docs/extrinsics.md
+++ b/docs/extrinsics.md
@@ -101,7 +101,7 @@ cargo contract call \
 
 The above examples assume the working directory is the contract source code where the `Cargo.toml` file is located.
 This is used to determine the location of the contract artifacts. Alternatively, there is an optional positional 
-argument to each of the extrinsic commands which allows specifying the contract artifact file directly. e.g.
+argument to each of the extrinsic commands which allows specifying the contract artifact file directly. E.g.
 
 
 `cargo upload ../path/to/mycontract.wasm`

--- a/docs/extrinsics.md
+++ b/docs/extrinsics.md
@@ -97,6 +97,17 @@ cargo contract call \
 - `--message` the name of the contract message to invoke.
 - `--args` accepts a space separated list of values, encoded in order as the arguments of the message to invoke. 
 
+## Specifying the contract artifact
+
+The above examples assume the working directory is the contract source code where the `Cargo.toml` file is located.
+This is used to determine the location of the contract artifacts. Alternatively, there is an optional positional 
+argument to each of the extrinsic commands which allows specifying the contract artifact file directly. e.g.
+
+
+`cargo upload ../path/to/mycontract.wasm`
+`cargo instantiate ../path/to/mycontract.contract`
+`cargo call ..path/to/metadata.json`
+
 
 
 


### PR DESCRIPTION
Extrinsic commands need to locate contract artifacts: for `upload` we require the contract Wasm and for `instantiate` and `call` the contract metadata. Currently this is designed to be similar to other `cargo` commands: providing a `--manifest-path` argument to point to the `Cargo.toml` of the contract project, if not present assuming the working directory is the project root. From there it can locate the artifacts in the `./target/ink/` directory. This is good for a development workflow from inside a project dir like:

`cargo contract build --release` 
`cargo contract upload --suri //Alice`
`cargo contract instantiate ...` 

Or from a different directory relative to the contract project directory:

`cargo contract build --manifest-path ../my-contract/Cargo.toml --release` 
`cargo contract upload --manifest-path ../my-contract/Cargo.toml --suri //Alice`
`cargo contract instantiate --manifest-path ../my-contract/Cargo.toml ...` 

However, this workflow is designed for a developer who is working with the contract source locally. 

This PR adds the ability to provide the path to a contract artifact file directly, for use cases where a user does not have the contract source project locally.

For all extrinsics, there is now an optional positional argument for the path to an artifact file. This can be one of `.wasm` (code only), `.json` (metadata only) or `.contract` (metadata + wasm). e.g.

`cargo upload ../path/to/mycontract.wasm`
`cargo instantiate ../path/to/mycontract.contract`
`cargo call ..path/to/metadata.json`

When specified, it will use that artifact file. When not specified it will fall back to the existing `--manifest-path` method.

**Note:** The existing `instantiate` command has a `--wasm-path` argument. This has been replaced by this new positional argument for consistency across the extrinsic commands.

Closes #892