### PR TITLE
Release `v2.0.0-beta.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.2] - 2023-01-09
+
+### Changed
+- Upgrade wasm-opt to 0.111.0 [#888](https://github.com/paritytech/cargo-contract/pull/888)
+- Enable `wasm-opt` MVP features only [#891](https://github.com/paritytech/cargo-contract/pull/891)
+- Require env_type transcoders to be Send + Sync [#879](https://github.com/paritytech/cargo-contract/pull/879)
+
+### Fixed
+- Add determinism arg to upload TX (#870)
+
 ## [2.0.0-beta.1] - 2022-12-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require env_type transcoders to be Send + Sync [#879](https://github.com/paritytech/cargo-contract/pull/879)
 
 ### Fixed
-- Add determinism arg to upload TX (#870)
+- Add determinism arg to upload TX [#870](https://github.com/paritytech/cargo-contract/pull/870)
 
 ## [2.0.0-beta.1] - 2022-12-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "contract-build"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-build"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -36,7 +36,7 @@ wasm-opt = "0.111.0"
 which = "4.3.0"
 zip = { version = "0.6.3", default-features = false }
 
-contract-metadata = { version = "2.0.0-beta.1", path = "../metadata" }
+contract-metadata = { version = "2.0.0-beta.2", path = "../metadata" }
 
 [build-dependencies]
 anyhow = "1.0.68"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-contract-build = { version = "2.0.0-beta.1", path = "../build" }
-contract-metadata = { version = "2.0.0-beta.1", path = "../metadata" }
-contract-transcode = { version = "2.0.0-beta.1", path = "../transcode" }
+contract-build = { version = "2.0.0-beta.2", path = "../build" }
+contract-metadata = { version = "2.0.0-beta.2", path = "../metadata" }
+contract-transcode = { version = "2.0.0-beta.2", path = "../transcode" }
 
 anyhow = "1.0.68"
 clap = { version = "4.0.32", features = ["derive", "env"] }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.68"
-contract-metadata = { version = "2.0.0-beta.1", path = "../metadata" }
+contract-metadata = { version = "2.0.0-beta.2", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "1.9.2"


### PR DESCRIPTION
### Changed
- Upgrade wasm-opt to 0.111.0 [#888](https://github.com/paritytech/cargo-contract/pull/888)
- Enable `wasm-opt` MVP features only [#891](https://github.com/paritytech/cargo-contract/pull/891)
- Require env_type transcoders to be Send + Sync [#879](https://github.com/paritytech/cargo-contract/pull/879)

### Fixed
- Add determinism arg to upload TX [#870](https://github.com/paritytech/cargo-contract/pull/870)