### PR TITLE
dependabot: ignore substrate deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,9 @@ updates:
     # automated Substrate releases cause dependabot PR spam, so these must be updated manually when required.
     ignore:
       - dependency-name: "sp-*"
-        update-types: [ "major" ]
+        update-types: [ "version-update:semver-major" ]
       - dependency-name: "pallet-*"
-        update-types: [ "major" ]
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: github-actions
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    # ignore Substrate pallets major updates.
+    # automated Substrate releases cause dependabot PR spam, so these must be updated manually when required.
+    ignore:
+      - dependency-name: "sp-*"
+        update-types: [ "major" ]
+      - dependency-name: "pallet-*"
+        update-types: [ "major" ]
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: daily
-  - ignore:
-    - dependency-name: sp-core
-    - dependency-name: sp-runtime
-    - dependency-name: sp-weights
-    - dependency-name: pallet-contracts-primitives

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+  - ignore:
+    - dependency-name: sp-core
+    - dependency-name: sp-runtime
+    - dependency-name: sp-weights
+    - dependency-name: pallet-contracts-primitives


### PR DESCRIPTION
Substrate deps should all be updated as a group, and manually. See[ PR spam ](https://github.com/paritytech/cargo-contract/pulls?q=is%3Apr+sp-).

See also https://github.com/paritytech/ink/pull/1588