### PR TITLE
Misc extrinsics display improvements

### DIFF
--- a/crates/cargo-contract/src/cmd/extrinsics/events.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/events.rs
@@ -160,7 +160,7 @@ impl DisplayEvents {
         let event_field_indent: usize = DEFAULT_KEY_COL_WIDTH - 3;
         let mut out = format!(
             "{:>width$}\n",
-            "Events".bold(),
+            "Events".bright_purple().bold(),
             width = DEFAULT_KEY_COL_WIDTH
         );
         for event in &self.0 {

--- a/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
@@ -336,11 +336,11 @@ impl Exec {
             };
             println!("{}", display_instantiate_result.to_json()?)
         } else {
+            println!("{}", events.display_events(self.verbosity, token_metadata)?);
             if let Some(code_hash) = code_hash {
                 name_value_println!("Code hash", format!("{:?}", code_hash));
             }
             name_value_println!("Contract", contract_address);
-            println!("{}", events.display_events(self.verbosity, token_metadata)?)
         };
         Ok(())
     }

--- a/crates/cargo-contract/src/cmd/extrinsics/upload.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/upload.rs
@@ -116,8 +116,9 @@ impl UploadCommand {
                 }
                 Ok(())
             } else {
+                let code_hash = hex::encode(&code_hash);
                 Err(anyhow::anyhow!(
-                    "This contract has already been uploaded with code hash: {code_hash:?}"
+                    "This contract has already been uploaded with code hash: 0x{code_hash}"
                 )
                 .into())
             }

--- a/crates/cargo-contract/src/cmd/extrinsics/upload.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/upload.rs
@@ -116,7 +116,7 @@ impl UploadCommand {
                 }
                 Ok(())
             } else {
-                let code_hash = hex::encode(&code_hash);
+                let code_hash = hex::encode(code_hash);
                 Err(anyhow::anyhow!(
                     "This contract has already been uploaded with code hash: 0x{code_hash}"
                 )


### PR DESCRIPTION
Just a few small UI fixes:

Instantate: display Contract Account *after* the events so you don't have to scroll up:

![image](https://user-images.githubusercontent.com/75586/214283824-7a3c8e66-41aa-4662-8ba7-a51baab42c6c.png)

Match "Events" header colour with other properties

![image](https://user-images.githubusercontent.com/75586/214284038-11c82f78-64db-4b0e-b301-b192b0203666.png)

Upload: Display code hash with hex

![image](https://user-images.githubusercontent.com/75586/214284172-0dd0c308-70db-4981-a528-3e0498838c4f.png)

