### PR TITLE
Fix decoding of `LangError`

### DIFF
--- a/crates/cargo-contract/src/cmd/extrinsics/call.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/call.rs
@@ -44,6 +44,7 @@ use contract_build::name_value_println;
 
 use anyhow::{
     anyhow,
+    Context,
     Result,
 };
 
@@ -112,7 +113,11 @@ impl CallCommand {
                 match result.result {
                     Ok(ref ret_val) => {
                         let value = transcoder
-                            .decode_return(&self.message, &mut &ret_val.data[..])?;
+                            .decode_return(&self.message, &mut &ret_val.data[..])
+                            .context(format!(
+                                "Failed to decode return value {:?}",
+                                &ret_val
+                            ))?;
                         let dry_run_result = CallDryRunResult {
                             result: String::from("Success!"),
                             reverted: ret_val.did_revert(),

--- a/crates/transcode/src/decode.rs
+++ b/crates/transcode/src/decode.rs
@@ -180,7 +180,8 @@ impl<'a> Decoder<'a> {
         let discriminant = input.read_byte()?;
         let variant = variant_type
             .variants()
-            .get(discriminant as usize)
+            .iter()
+            .find(|v| v.index == discriminant)
             .ok_or_else(|| {
                 anyhow::anyhow!("No variant found with discriminant {}", discriminant)
             })?;

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -630,6 +630,30 @@ mod tests {
     }
 
     #[test]
+    fn decode_lang_error() {
+        use ink::primitives::LangError;
+
+        let metadata = generate_metadata();
+        let transcoder = ContractMessageTranscoder::new(metadata);
+
+        let encoded =
+            Result::<bool, LangError>::Err(LangError::CouldNotReadInput).encode();
+        let decoded = transcoder
+            .decode_return("get", &mut &encoded[..])
+            .unwrap_or_else(|e| panic!("Error decoding return value {}", e));
+
+        let expected = Value::Tuple(Tuple::new(
+            "Err".into(),
+            [Value::Tuple(Tuple::new(
+                Some("CouldNotReadInput".into()),
+                Vec::new(),
+            ))]
+            .to_vec(),
+        ));
+        assert_eq!(expected, decoded);
+    }
+
+    #[test]
     fn decode_contract_event() -> Result<()> {
         let metadata = generate_metadata();
         let transcoder = ContractMessageTranscoder::new(metadata);

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -645,7 +645,7 @@ mod tests {
         let expected = Value::Tuple(Tuple::new(
             "Err".into(),
             [Value::Tuple(Tuple::new(
-                Some("CouldNotReadInput".into()),
+                Some("CouldNotReadInput"),
                 Vec::new(),
             ))]
             .to_vec(),


### PR DESCRIPTION
As reported by @lean-apple, there was a bug decoding a `LangError`:

```
cargo contract call -m switch --dry-run --suri //Alice  --contract $CONTRACT
ERROR: Error decoding type 6: Result

Caused by:
    0: Error decoding type 8: ink_primitives::LangError
    1: No variant found with discriminant 1
```
This is because we were ignoring the explicitly assigned discriminant:

```rust
pub enum LangError {
    /// Failed to read execution input for the dispatchable.
    CouldNotReadInput = 1u32,
}
```
and instead using the implicit discriminant to decode.

The issue now is that the result is possibly not very useful to the user:

![image](https://user-images.githubusercontent.com/75586/214312032-a1eb5157-1129-4fdd-a9d2-1c2ffc1c607b.png)

Perhaps we should consider explicitly decoding the `LangError`?
