### PR TITLE
Display the causes of an error

### DIFF
--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -155,8 +155,8 @@ fn get_cargo_metadata(manifest_path: &ManifestPath) -> Result<(CargoMetadata, Pa
     let mut cmd = MetadataCommand::new();
     let metadata = cmd
         .manifest_path(manifest_path.as_ref())
-        .exec()
-        .context("Error invoking `cargo metadata`")?;
+        .exec()?;
+        // .with_context(|| format!("Error invoking `cargo metadata` for {}", manifest_path.as_ref().display()))?;
     let root_package_id = metadata
         .resolve
         .as_ref()

--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -155,8 +155,13 @@ fn get_cargo_metadata(manifest_path: &ManifestPath) -> Result<(CargoMetadata, Pa
     let mut cmd = MetadataCommand::new();
     let metadata = cmd
         .manifest_path(manifest_path.as_ref())
-        .exec()?;
-        // .with_context(|| format!("Error invoking `cargo metadata` for {}", manifest_path.as_ref().display()))?;
+        .exec()
+        .with_context(|| {
+            format!(
+                "Error invoking `cargo metadata` for {}",
+                manifest_path.as_ref().display()
+            )
+        })?;
     let root_package_id = metadata
         .resolve
         .as_ref()

--- a/crates/cargo-contract/src/cmd/extrinsics/error.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/error.rs
@@ -15,7 +15,11 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use sp_runtime::DispatchError;
-use std::fmt::Display;
+use std::fmt::{
+    self,
+    Debug,
+    Display,
+};
 
 #[derive(serde::Serialize)]
 pub enum ErrorVariant {
@@ -93,8 +97,14 @@ impl ErrorVariant {
     }
 }
 
+impl Debug for ErrorVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        <Self as Display>::fmt(self, f)
+    }
+}
+
 impl Display for ErrorVariant {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ErrorVariant::Module(err) => {
                 f.write_fmt(format_args!(

--- a/crates/cargo-contract/src/main.rs
+++ b/crates/cargo-contract/src/main.rs
@@ -34,7 +34,7 @@ use contract_build::{
     OutputType,
 };
 use std::{
-    fmt::Display,
+    fmt::Debug,
     path::PathBuf,
     str::FromStr,
 };
@@ -136,7 +136,7 @@ fn main() {
     match exec(args.cmd) {
         Ok(()) => {}
         Err(err) => {
-            eprintln!("{err:#}");
+            eprintln!("{err:?}");
             std::process::exit(1);
         }
     }
@@ -207,10 +207,10 @@ fn map_extrinsic_err(err: ErrorVariant, is_json: bool) -> Error {
     }
 }
 
-fn format_err<E: Display>(err: E) -> Error {
+fn format_err<E: Debug>(err: E) -> Error {
     anyhow!(
         "{} {}",
         "ERROR:".bright_red().bold(),
-        format!("{err}").bright_red()
+        format!("{err:?}").bright_red()
     )
 }

--- a/crates/cargo-contract/src/main.rs
+++ b/crates/cargo-contract/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
     match exec(args.cmd) {
         Ok(()) => {}
         Err(err) => {
-            eprintln!("{err}");
+            eprintln!("{err:#}");
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
Error information was missing the error chain, and only displaying the `context` message:

![image](https://user-images.githubusercontent.com/75586/215089645-fc02aefe-e13b-4b6b-bf66-f6d3018b1537.png)

This PR use the `Debug` impl to display the error chain with the cause:

![image](https://user-images.githubusercontent.com/75586/215089813-78f13b44-0496-44e6-9f3a-87d0d25c9d6e.png)
