### PR TITLE
Remove `+nightly` from docs and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ docker pull paritytech/contracts-ci-linux:production
 
 # Create a new contract in your current directory.
 docker run --rm -it -v $(pwd):/sources paritytech/contracts-ci-linux:production \
-  cargo +nightly contract new --target-dir /sources my_contract
+  cargo contract new --target-dir /sources my_contract
 
 # Build the contract. This will create the contract file under
 # `my_contract/target/ink/my_contract.contract`.
 docker run --rm -it -v $(pwd):/sources paritytech/contracts-ci-linux:production \
-  cargo +nightly contract build --manifest-path=/sources/my_contract/Cargo.toml
+  cargo contract build --manifest-path=/sources/my_contract/Cargo.toml
 ```
 
 If you want to reproduce other steps of CI process you can use the following
@@ -86,18 +86,11 @@ The contract contains the source code for the [`Flipper`](https://github.com/par
 contract, which is about the simplest "smart" contract you can build ‒ a `bool` which gets flipped
 from `true` to `false` through the `flip()` function.
 
-##### `cargo +nightly contract build`
+##### `cargo contract build`
 
 Compiles the contract into optimized WebAssembly bytecode, generates metadata for it,
 and bundles both together in a `<name>.contract` file, which you can use for
 deploying the contract on-chain.
-
-`cargo contract build` must be run using the `nightly` toolchain. If you have
-[`rustup`](https://github.com/rust-lang/rustup) installed, the simplest way to
-do so is `cargo +nightly contract build`.
-
-To avoid having to always add `+nightly` you can also set `nightly` as the default
-toolchain of a directory by executing `rustup override set nightly` in it.
 
 ##### `cargo contract check`
 

--- a/crates/cargo-contract/src/cmd/test.rs
+++ b/crates/cargo-contract/src/cmd/test.rs
@@ -53,7 +53,7 @@ impl TestCommand {
 
 /// Result of the test runs.
 pub struct TestResult {
-    /// The `cargo +nightly test` child process standard output stream buffer.
+    /// The `cargo test` child process standard output stream buffer.
     pub stdout: Vec<u8>,
     /// The verbosity flags.
     pub verbosity: Verbosity,


### PR DESCRIPTION
New release of `cargo-contract` and `ink!` no longer require nightly toolchain for compiling smart contracts. Therefore, we remove it from docs.