### PR TITLE
Respect the lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Respect the lockfile [#948](https://github.com/paritytech/cargo-contract/pull/948)
+
 ## [2.0.0-rc.1] - 2023-02-01
 Second release candidate compatible with `ink! 4.0.0-rc`.
 


### PR DESCRIPTION
Closes https://github.com/paritytech/cargo-contract/issues/926 and https://github.com/paritytech/cargo-contract/issues/938.

Copies the `Cargo.lock` to the tmp dir.

Before: 

![image](https://user-images.githubusercontent.com/75586/216585935-d5a3c72b-0a92-4ecd-a1c5-b51d7f289ab2.png)

After:

![image](https://user-images.githubusercontent.com/75586/216586216-bfbd2d0d-3d5c-4191-8bd9-8deb5fdbbd0f.png)
