### PR TITLE
Error if mismatching # of args for instantiate/call

### DIFF
--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -205,6 +205,15 @@ impl ContractMessageTranscoder {
             }
         };
 
+        let args: Vec<_> = args.into_iter().collect();
+        if spec_args.len() != args.len() {
+            anyhow::bail!(
+                "Invalid number of call arguments: expected {}, {} provided",
+                spec_args.len(),
+                args.len()
+            )
+        }
+
         let mut encoded = selector.to_bytes().to_vec();
         for (spec, arg) in spec_args.iter().zip(args) {
             let value = scon::parse_value(arg.as_ref())?;
@@ -501,6 +510,26 @@ mod tests {
 
         assert_eq!(true.encode(), encoded_args);
         Ok(())
+    }
+
+    #[test]
+    fn encode_mismatching_args_length() {
+        let metadata = generate_metadata();
+        let transcoder = ContractMessageTranscoder::new(metadata);
+
+        let result: Result<Vec<u8>> = transcoder.encode("new", Vec::<&str>::new());
+        assert!(result.is_err(), "Should return an error");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid number of call arguments: expected 1, 0 provided"
+        );
+
+        let result: Result<Vec<u8>> = transcoder.encode("new", ["true", "false"]);
+        assert!(result.is_err(), "Should return an error");
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "Invalid number of call arguments: expected 1, 2 provided"
+        );
     }
 
     #[test]

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -208,7 +208,7 @@ impl ContractMessageTranscoder {
         let args: Vec<_> = args.into_iter().collect();
         if spec_args.len() != args.len() {
             anyhow::bail!(
-                "Invalid number of call arguments: expected {}, {} provided",
+                "Invalid number of input arguments: expected {}, {} provided",
                 spec_args.len(),
                 args.len()
             )
@@ -521,14 +521,14 @@ mod tests {
         assert!(result.is_err(), "Should return an error");
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Invalid number of call arguments: expected 1, 0 provided"
+            "Invalid number of input arguments: expected 1, 0 provided"
         );
 
         let result: Result<Vec<u8>> = transcoder.encode("new", ["true", "false"]);
         assert!(result.is_err(), "Should return an error");
         assert_eq!(
             result.unwrap_err().to_string(),
-            "Invalid number of call arguments: expected 1, 2 provided"
+            "Invalid number of input arguments: expected 1, 2 provided"
         );
     }
 


### PR DESCRIPTION
Currently if you forget to supply `--args` to an instantiate/call, it will fail with a trap because of invalid input. e.g calling a constructor which has args but forgetting to add `--args`:

```
contract contract instantiate --suri //Alice
```

This PR adds a simple check which validates the number of args supplied is equal to the expected number of arguments to the ink! constructor or message.