### PR TITLE
Pretty-print call dry-run return data

### DIFF
--- a/crates/cargo-contract/src/cmd/extrinsics/call.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/call.rs
@@ -323,6 +323,6 @@ impl CallDryRunResult {
             format!("{:?}", self.reverted),
             DEFAULT_KEY_COL_WIDTH
         );
-        name_value_println!("Data", format!("{:?}", self.data), DEFAULT_KEY_COL_WIDTH);
+        name_value_println!("Data", format!("{}", self.data), DEFAULT_KEY_COL_WIDTH);
     }
 }


### PR DESCRIPTION
Regression introduced in #722 where it uses the `Debug` output for the returned dry-run value, instead of the `Display`. See before and after:

![image](https://user-images.githubusercontent.com/75586/218117306-ed6b44e7-0c84-4996-b0a2-86a5d70e5633.png)
