### PR TITLE
Bump template to ink! 4.0

### DIFF
--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -5,7 +5,7 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "4.0.0-rc", default-features = false }
+ink = { version = "4.0.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }

--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -10,6 +10,9 @@ ink = { version = "4.0.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
+[dev-dependencies]
+ink_e2e = "4.0.0"
+
 [lib]
 path = "lib.rs"
 
@@ -21,3 +24,4 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
+e2e-tests = []

--- a/crates/build/templates/new/lib.rs
+++ b/crates/build/templates/new/lib.rs
@@ -68,62 +68,73 @@ mod {{name}} {
     }
 
 
+    /// This is how you'd write end-to-end (E2E) or integration tests for ink! contracts.
+    ///
+    /// When running these you need to make sure that you:
+    /// - Compile the tests with the `e2e-tests` feature flag enabled (`--features e2e-tests`)
+    /// - Are running a Substrate node which contains `pallet-contracts` in the background
     #[cfg(all(test, feature = "e2e-tests"))]
     mod e2e_tests {
+        /// Imports all the definitions from the outer scope so we can use them here.
         use super::*;
+
+        /// A helper function used for calling contract messages.
         use ink_e2e::build_message;
 
+        /// The End-to-End test `Result` type.
         type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+        /// We test that we can upload and instantiate the contract using its default constructor.
         #[ink_e2e::test]
         async fn default_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
-            // given
+            // Given
             let constructor = {{camel_name}}Ref::default();
 
-            // when
-            let contract_acc_id = client
+            // When
+            let contract_account_id = client
                 .instantiate("{{name}}", &ink_e2e::alice(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;
 
-            // then
-            let get = build_message::<{{camel_name}}Ref>(contract_acc_id.clone())
+            // Then
+            let get = build_message::<{{camel_name}}Ref>(contract_account_id.clone())
                 .call(|{{name}}| {{name}}.get());
-            let get_res = client.call_dry_run(&ink_e2e::alice(), &get, 0, None).await;
-            assert!(matches!(get_res.return_value(), false));
+            let get_result = client.call_dry_run(&ink_e2e::alice(), &get, 0, None).await;
+            assert!(matches!(get_result.return_value(), false));
 
             Ok(())
         }
 
+        /// We test that we can read and write a value from the on-chain contract contract.
         #[ink_e2e::test]
         async fn it_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
-            // given
+            // Given
             let constructor = {{camel_name}}Ref::new(false);
-            let contract_acc_id = client
+            let contract_account_id = client
                 .instantiate("{{name}}", &ink_e2e::bob(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;
 
-            let get = build_message::<{{camel_name}}Ref>(contract_acc_id.clone())
+            let get = build_message::<{{camel_name}}Ref>(contract_account_id.clone())
                 .call(|{{name}}| {{name}}.get());
-            let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
-            assert!(matches!(get_res.return_value(), false));
+            let get_result = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
+            assert!(matches!(get_result.return_value(), false));
 
-            // when
-            let flip = build_message::<{{camel_name}}Ref>(contract_acc_id.clone())
+            // When
+            let flip = build_message::<{{camel_name}}Ref>(contract_account_id.clone())
                 .call(|{{name}}| {{name}}.flip());
-            let _flip_res = client
+            let _flip_result = client
                 .call(&ink_e2e::bob(), flip, 0, None)
                 .await
                 .expect("flip failed");
 
-            // then
-            let get = build_message::<{{camel_name}}Ref>(contract_acc_id.clone())
+            // Then
+            let get = build_message::<{{camel_name}}Ref>(contract_account_id.clone())
                 .call(|{{name}}| {{name}}.get());
-            let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
-            assert!(matches!(get_res.return_value(), true));
+            let get_result = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
+            assert!(matches!(get_result.return_value(), true));
 
             Ok(())
         }

--- a/crates/build/templates/new/lib.rs
+++ b/crates/build/templates/new/lib.rs
@@ -82,7 +82,7 @@ mod {{name}} {
 
             // when
             let contract_acc_id = client
-                .instantiate("flipper", &ink_e2e::bob(), constructor, 0, None)
+                .instantiate("flipper", &ink_e2e::alice(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;
@@ -90,7 +90,7 @@ mod {{name}} {
             // then
             let get = build_message::<FlipperRef>(contract_acc_id.clone())
                 .call(|flipper| flipper.get());
-            let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
+            let get_res = client.call_dry_run(&ink_e2e::alice(), &get, 0, None).await;
             assert!(matches!(get_res.return_value(), false));
 
             Ok(())
@@ -101,7 +101,7 @@ mod {{name}} {
             // given
             let constructor = FlipperRef::new(false);
             let contract_acc_id = client
-                .instantiate("flipper", &ink_e2e::alice(), constructor, 0, None)
+                .instantiate("flipper", &ink_e2e::bob(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;

--- a/crates/build/templates/new/lib.rs
+++ b/crates/build/templates/new/lib.rs
@@ -66,4 +66,66 @@ mod {{name}} {
             assert_eq!({{name}}.get(), true);
         }
     }
+
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use super::*;
+        use ink_e2e::build_message;
+
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn default_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let constructor = FlipperRef::default();
+
+            // when
+            let contract_acc_id = client
+                .instantiate("flipper", &ink_e2e::bob(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            // then
+            let get = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.get());
+            let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
+            assert!(matches!(get_res.return_value(), false));
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn it_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let constructor = FlipperRef::new(false);
+            let contract_acc_id = client
+                .instantiate("flipper", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            let get = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.get());
+            let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
+            assert!(matches!(get_res.return_value(), false));
+
+            // when
+            let flip = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.flip());
+            let _flip_res = client
+                .call(&ink_e2e::bob(), flip, 0, None)
+                .await
+                .expect("flip failed");
+
+            // then
+            let get = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.get());
+            let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
+            assert!(matches!(get_res.return_value(), true));
+
+            Ok(())
+        }
+    }
 }

--- a/crates/build/templates/new/lib.rs
+++ b/crates/build/templates/new/lib.rs
@@ -78,18 +78,18 @@ mod {{name}} {
         #[ink_e2e::test]
         async fn default_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
             // given
-            let constructor = FlipperRef::default();
+            let constructor = {{camel_name}}Ref::default();
 
             // when
             let contract_acc_id = client
-                .instantiate("flipper", &ink_e2e::alice(), constructor, 0, None)
+                .instantiate("{{name}}", &ink_e2e::alice(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;
 
             // then
-            let get = build_message::<FlipperRef>(contract_acc_id.clone())
-                .call(|flipper| flipper.get());
+            let get = build_message::<{{camel_name}}Ref>(contract_acc_id.clone())
+                .call(|{{name}}| {{name}}.get());
             let get_res = client.call_dry_run(&ink_e2e::alice(), &get, 0, None).await;
             assert!(matches!(get_res.return_value(), false));
 
@@ -99,29 +99,29 @@ mod {{name}} {
         #[ink_e2e::test]
         async fn it_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
             // given
-            let constructor = FlipperRef::new(false);
+            let constructor = {{camel_name}}Ref::new(false);
             let contract_acc_id = client
-                .instantiate("flipper", &ink_e2e::bob(), constructor, 0, None)
+                .instantiate("{{name}}", &ink_e2e::bob(), constructor, 0, None)
                 .await
                 .expect("instantiate failed")
                 .account_id;
 
-            let get = build_message::<FlipperRef>(contract_acc_id.clone())
-                .call(|flipper| flipper.get());
+            let get = build_message::<{{camel_name}}Ref>(contract_acc_id.clone())
+                .call(|{{name}}| {{name}}.get());
             let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
             assert!(matches!(get_res.return_value(), false));
 
             // when
-            let flip = build_message::<FlipperRef>(contract_acc_id.clone())
-                .call(|flipper| flipper.flip());
+            let flip = build_message::<{{camel_name}}Ref>(contract_acc_id.clone())
+                .call(|{{name}}| {{name}}.flip());
             let _flip_res = client
                 .call(&ink_e2e::bob(), flip, 0, None)
                 .await
                 .expect("flip failed");
 
             // then
-            let get = build_message::<FlipperRef>(contract_acc_id.clone())
-                .call(|flipper| flipper.get());
+            let get = build_message::<{{camel_name}}Ref>(contract_acc_id.clone())
+                .call(|{{name}}| {{name}}.get());
             let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
             assert!(matches!(get_res.return_value(), true));
 


### PR DESCRIPTION
Looks like we forgot to do this in #970.

Not a huge deal since `cargo` will still pull in ink! 4.0, but we'll
probably want to issue a patch release soon in order to not confuse
users.
