### PR TITLE
Explicitly enable `std` feature for metadata generation

### DIFF
--- a/crates/build/templates/generate-metadata/_Cargo.toml
+++ b/crates/build/templates/generate-metadata/_Cargo.toml
@@ -10,6 +10,6 @@ name = "metadata-gen"
 path = "main.rs"
 
 [dependencies]
-contract = { path = "../.." }
+contract = { path = "../..", features = ["std"] }
 serde = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
Fixes #909.

Currently a contract is required to have `std` set as the default feature e.g. `[features] default = ["std"]`. Otherwise the metadata generation will fail with `undefined reference to __ink_generate_metadata'`, because that method is only generated with `std` enabled.

This PR explicitly imports the contract as a lib with `std` enabled, so it should now work with or without `default = ["std"]` in the contract's `Cargo.toml`