### PR TITLE
Limit input length for `decode` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Limit input length for `decode` command - [#982](https://github.com/paritytech/cargo-contract/pull/982)
+
 ## [2.0.1]
 
 ### Fixed

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -361,7 +361,7 @@ impl ContractMessageTranscoder {
                 args.iter().fold(format!("`{label}`"), |init, arg| {
                     format!("{}, `{}`", init, arg.0)
                 });
-            let encoded_bytes = util::encode_bytes(data);
+            let encoded_bytes = hex::encode_upper(data);
             return Err(anyhow::anyhow!(
                 "input length was longer than expected by {} byte(s).\nManaged to decode {} but `{}` bytes were left unread",
                 data.len(),

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -786,7 +786,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "input length was longer than expected by 1 byte(s)")]
+    #[should_panic(
+        expected = "input length was longer than expected by 1 byte(s).\nManaged to decode `flip` but `00` bytes were left unread"
+    )]
     fn fail_decode_input_with_extra_bytes() {
         let metadata = generate_metadata();
         let transcoder = ContractMessageTranscoder::new(metadata);
@@ -794,6 +796,23 @@ mod tests {
         let encoded_bytes = hex::decode("633aa55100").unwrap();
         let _ = transcoder
             .decode_contract_message(&mut &encoded_bytes[..])
+            .unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "input length was longer than expected by 2 byte(s).\nManaged to decode `Event1`, `name`, `from` but `0C10` bytes were left unread"
+    )]
+    fn fail_decode_contract_event_with_extra_bytes() {
+        let metadata = generate_metadata();
+        let transcoder = ContractMessageTranscoder::new(metadata);
+
+        // raw encoded event with event index prefix
+        let encoded = (0u8, [0u32; 8], [1u32; 8], [12u8, 16u8]).encode();
+        // encode again as a Vec<u8> which has a len prefix.
+        let encoded_bytes = encoded.encode();
+        let _ = transcoder
+            .decode_contract_event(&mut &encoded_bytes[..])
             .unwrap();
     }
 }

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -278,9 +278,17 @@ impl ContractMessageTranscoder {
         }
 
         if !data.is_empty() {
+            let arg_list_string: String = args
+                .iter()
+                .fold(format!("`{}`", event_spec.label()), |init, arg| {
+                    format!("{}, `{}`", init, arg.0)
+                });
+            let encoded_bytes = util::encode_bytes(data);
             return Err(anyhow::anyhow!(
-                "input length was longer than expected by {} byte(s)",
-                data.len()
+                "input length was longer than expected by {} byte(s).\nManaged to decode {} but `{}` bytes were left unread",
+                data.len(),
+                arg_list_string,
+                encoded_bytes
             ))
         }
 
@@ -312,9 +320,17 @@ impl ContractMessageTranscoder {
         }
 
         if !data.is_empty() {
+            let arg_list_string: String = args
+                .iter()
+                .fold(format!("`{}`", msg_spec.label()), |init, arg| {
+                    format!("{}, `{}`", init, arg.0)
+                });
+            let encoded_bytes = util::encode_bytes(data);
             return Err(anyhow::anyhow!(
-                "input length was longer than expected by {} byte(s)",
-                data.len()
+                "input length was longer than expected by {} byte(s).\nManaged to decode {} but `{}` bytes were left unread",
+                data.len(),
+                arg_list_string,
+                encoded_bytes
             ))
         }
 
@@ -346,9 +362,17 @@ impl ContractMessageTranscoder {
         }
 
         if !data.is_empty() {
+            let arg_list_string: String = args
+                .iter()
+                .fold(format!("`{}`", msg_spec.label()), |init, arg| {
+                    format!("{}, `{}`", init, arg.0)
+                });
+            let encoded_bytes = util::encode_bytes(data);
             return Err(anyhow::anyhow!(
-                "input length was longer than expected by {} byte(s)",
-                data.len()
+                "input length was longer than expected by {} byte(s).\nManaged to decode {} but `{}` bytes were left unread",
+                data.len(),
+                arg_list_string,
+                encoded_bytes
             ))
         }
 

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -277,20 +277,7 @@ impl ContractMessageTranscoder {
             args.push((Value::String(name), value));
         }
 
-        if !data.is_empty() {
-            let arg_list_string: String = args
-                .iter()
-                .fold(format!("`{}`", event_spec.label()), |init, arg| {
-                    format!("{}, `{}`", init, arg.0)
-                });
-            let encoded_bytes = util::encode_bytes(data);
-            return Err(anyhow::anyhow!(
-                "input length was longer than expected by {} byte(s).\nManaged to decode {} but `{}` bytes were left unread",
-                data.len(),
-                arg_list_string,
-                encoded_bytes
-            ))
-        }
+        Self::validate_length(data, event_spec.label(), &args)?;
 
         let name = event_spec.label().to_string();
         let map = Map::new(Some(&name), args.into_iter().collect());
@@ -319,20 +306,7 @@ impl ContractMessageTranscoder {
             args.push((Value::String(name), value));
         }
 
-        if !data.is_empty() {
-            let arg_list_string: String = args
-                .iter()
-                .fold(format!("`{}`", msg_spec.label()), |init, arg| {
-                    format!("{}, `{}`", init, arg.0)
-                });
-            let encoded_bytes = util::encode_bytes(data);
-            return Err(anyhow::anyhow!(
-                "input length was longer than expected by {} byte(s).\nManaged to decode {} but `{}` bytes were left unread",
-                data.len(),
-                arg_list_string,
-                encoded_bytes
-            ))
-        }
+        Self::validate_length(data, msg_spec.label(), &args)?;
 
         let name = msg_spec.label().to_string();
         let map = Map::new(Some(&name), args.into_iter().collect());
@@ -361,20 +335,7 @@ impl ContractMessageTranscoder {
             args.push((Value::String(name), value));
         }
 
-        if !data.is_empty() {
-            let arg_list_string: String = args
-                .iter()
-                .fold(format!("`{}`", msg_spec.label()), |init, arg| {
-                    format!("{}, `{}`", init, arg.0)
-                });
-            let encoded_bytes = util::encode_bytes(data);
-            return Err(anyhow::anyhow!(
-                "input length was longer than expected by {} byte(s).\nManaged to decode {} but `{}` bytes were left unread",
-                data.len(),
-                arg_list_string,
-                encoded_bytes
-            ))
-        }
+        Self::validate_length(data, msg_spec.label(), &args)?;
 
         let name = msg_spec.label().to_string();
         let map = Map::new(Some(&name), args.into_iter().collect());
@@ -391,6 +352,24 @@ impl ContractMessageTranscoder {
         } else {
             Ok(Value::Unit)
         }
+    }
+
+    /// Checks if buffer empty, otherwise returns am error
+    fn validate_length(data: &[u8], label: &str, args: &[(Value, Value)]) -> Result<()> {
+        if !data.is_empty() {
+            let arg_list_string: String =
+                args.iter().fold(format!("`{label}`"), |init, arg| {
+                    format!("{}, `{}`", init, arg.0)
+                });
+            let encoded_bytes = util::encode_bytes(data);
+            return Err(anyhow::anyhow!(
+                "input length was longer than expected by {} byte(s).\nManaged to decode {} but `{}` bytes were left unread",
+                data.len(),
+                arg_list_string,
+                encoded_bytes
+            ))
+        }
+        Ok(())
     }
 }
 

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -277,6 +277,13 @@ impl ContractMessageTranscoder {
             args.push((Value::String(name), value));
         }
 
+        if !data.is_empty() {
+            return Err(anyhow::anyhow!(
+                "input length was longer than expected {:?}",
+                data
+            ))
+        }
+
         let name = event_spec.label().to_string();
         let map = Map::new(Some(&name), args.into_iter().collect());
 
@@ -298,10 +305,18 @@ impl ContractMessageTranscoder {
         tracing::debug!("Decoding contract message '{}'", msg_spec.label());
 
         let mut args = Vec::new();
+        // let args_length = msg_spec.args().first().unwrap().ty().ty()
         for arg in msg_spec.args() {
             let name = arg.label().to_string();
             let value = self.decode(arg.ty().ty().id(), data)?;
             args.push((Value::String(name), value));
+        }
+
+        if !data.is_empty() {
+            return Err(anyhow::anyhow!(
+                "input length was longer than expected {:?}",
+                data
+            ))
         }
 
         let name = msg_spec.label().to_string();
@@ -329,6 +344,13 @@ impl ContractMessageTranscoder {
             let name = arg.label().to_string();
             let value = self.decode(arg.ty().ty().id(), data)?;
             args.push((Value::String(name), value));
+        }
+
+        if !data.is_empty() {
+            return Err(anyhow::anyhow!(
+                "input length was longer than expected {:?}",
+                data
+            ))
         }
 
         let name = msg_spec.label().to_string();

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -279,8 +279,8 @@ impl ContractMessageTranscoder {
 
         if !data.is_empty() {
             return Err(anyhow::anyhow!(
-                "input length was longer than expected {:?}",
-                data
+                "input length was longer than expected by {} byte(s)",
+                data.len()
             ))
         }
 
@@ -314,8 +314,8 @@ impl ContractMessageTranscoder {
 
         if !data.is_empty() {
             return Err(anyhow::anyhow!(
-                "input length was longer than expected {:?}",
-                data
+                "input length was longer than expected by {} byte(s)",
+                data.len()
             ))
         }
 
@@ -348,8 +348,8 @@ impl ContractMessageTranscoder {
 
         if !data.is_empty() {
             return Err(anyhow::anyhow!(
-                "input length was longer than expected {:?}",
-                data
+                "input length was longer than expected by {} byte(s)",
+                data.len()
             ))
         }
 
@@ -710,7 +710,7 @@ mod tests {
         let transcoder = ContractMessageTranscoder::new(metadata);
 
         // raw encoded event with event index prefix
-        let encoded = (0u8, [0u32; 32], [1u32; 32]).encode();
+        let encoded = (0u8, [0u32; 8], [1u32; 8]).encode();
         // encode again as a Vec<u8> which has a len prefix.
         let encoded_bytes = encoded.encode();
         let _ = transcoder.decode_contract_event(&mut &encoded_bytes[..])?;
@@ -728,7 +728,7 @@ mod tests {
             83, 118, 135, 56, 220, 172, 95, 131, 171, 125, 130, 167, 10, 15, 242, 222,
         ];
         // raw encoded event with event index prefix
-        let encoded = (0u8, hash, [0u32; 32]).encode();
+        let encoded = (0u8, hash, [0u32; 8]).encode();
         // encode again as a Vec<u8> which has a len prefix.
         let encoded_bytes = encoded.encode();
         let decoded = transcoder.decode_contract_event(&mut &encoded_bytes[..])?;

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -305,7 +305,6 @@ impl ContractMessageTranscoder {
         tracing::debug!("Decoding contract message '{}'", msg_spec.label());
 
         let mut args = Vec::new();
-        // let args_length = msg_spec.args().first().unwrap().ty().ty()
         for arg in msg_spec.args() {
             let name = arg.label().to_string();
             let value = self.decode(arg.ty().ty().id(), data)?;
@@ -760,5 +759,17 @@ mod tests {
         let _ = transcoder.decode_contract_message(&mut &encoded_bytes[..])?;
 
         Ok(())
+    }
+
+    #[test]
+    #[should_panic(expected = "input length was longer than expected by 1 byte(s)")]
+    fn fail_decode_input_with_extra_bytes() {
+        let metadata = generate_metadata();
+        let transcoder = ContractMessageTranscoder::new(metadata);
+
+        let encoded_bytes = hex::decode("633aa55100").unwrap();
+        let _ = transcoder
+            .decode_contract_message(&mut &encoded_bytes[..])
+            .unwrap();
     }
 }

--- a/crates/transcode/src/util.rs
+++ b/crates/transcode/src/util.rs
@@ -18,3 +18,7 @@
 pub fn decode_hex(input: &str) -> Result<Vec<u8>, hex::FromHexError> {
     hex::decode(input.trim_start_matches("0x"))
 }
+
+pub fn encode_bytes(buffer: &[u8]) -> String {
+    hex::encode_upper(buffer)
+}

--- a/crates/transcode/src/util.rs
+++ b/crates/transcode/src/util.rs
@@ -18,7 +18,3 @@
 pub fn decode_hex(input: &str) -> Result<Vec<u8>, hex::FromHexError> {
     hex::decode(input.trim_start_matches("0x"))
 }
-
-pub fn encode_bytes(buffer: &[u8]) -> String {
-    hex::encode_upper(buffer)
-}


### PR DESCRIPTION
Closes #980 

The hex bytes are consumed for decoding values of arguments on demand. If there is not enough data to fill the buffer, the error is already thrown. Previously, spare bytes were just ignored. Since this PR, an error will be thrown if input buffer contains spare bytes.

Here is the small demo demonstrating that extra bytes in buffer do not affect decoding of value.
```rust
//boolean is 1 byte long
let value = true;
let encoded: Vec<u8> = vec![1, 12, 3];
let mut encoded: &[u8] = encoded.as_ref();
let decoded: bool = bool::decode::<&[u8]>(&mut encoded).unwrap();
// is true
assert_eq!(decoded, value);
//prints [12, 3]
println!("{encoded:?}")
```