### PR TITLE
Return artifact paths when contracts unchanged

### DIFF
--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -116,8 +116,7 @@ pub(crate) fn execute(
     unstable_options: &UnstableFlags,
     build_info: BuildInfo,
 ) -> Result<MetadataResult> {
-    let out_path_metadata = crate_metadata.metadata_path();
-    let out_path_bundle = crate_metadata.contract_bundle_path();
+
 
     // build the extended contract project metadata
     let ExtendedMetadataResult {


### PR DESCRIPTION
*WIP*

Since #964, if the contract is unchanged the contract optimization and metadata generation steps are skipped. Currently this means that the `optimization_result` and `metadata_result` fields on `BuildResult` are both `None`. Tools and library users depend on those results to get the paths to the contract Wasm and metadata artifacts. So on a fresh contract build those would have values, and on a subsequent build with no changes to the contract those results will both be `None`

This PR ensures that users can still determine those artifact paths even if the optimization and metadata steps are skipped.