### PR TITLE
Release `v2.0.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [2.0.2]
+
+### Fixed
+- Explicitly enable `std` feature for metadata generation (#977)
+
 ## [2.0.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### [2.0.2]
 
 ### Fixed
-- Explicitly enable `std` feature for metadata generation (#977)
+- Explicitly enable `std` feature for metadata generation [#977](https://github.com/paritytech/cargo-contract/pull/977)
+- Return artifact paths when contracts unchanged [#992](https://github.com/paritytech/cargo-contract/pull/992)
+- Minimum requirements of `ink!` dependencies all updated to `4.0.1`
 
 ## [2.0.1]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "contract-build"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-build"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -36,7 +36,7 @@ wasm-opt = "0.111.0"
 which = "4.4.0"
 zip = { version = "0.6.4", default-features = false }
 
-contract-metadata = { version = "2.0.1", path = "../metadata" }
+contract-metadata = { version = "2.0.2", path = "../metadata" }
 
 [build-dependencies]
 anyhow = "1.0.69"

--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -5,13 +5,13 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "4.0.0", default-features = false }
+ink = { version = "4.0.1", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
-ink_e2e = "4.0.0"
+ink_e2e = "4.0.1"
 
 [lib]
 path = "lib.rs"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-contract-build = { version = "2.0.1", path = "../build" }
-contract-metadata = { version = "2.0.1", path = "../metadata" }
-contract-transcode = { version = "2.0.1", path = "../transcode" }
+contract-build = { version = "2.0.2", path = "../build" }
+contract-metadata = { version = "2.0.2", path = "../metadata" }
+contract-transcode = { version = "2.0.2", path = "../transcode" }
 
 anyhow = "1.0.69"
 clap = { version = "4.1.7", features = ["derive", "env"] }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.69"
-contract-metadata = { version = "2.0.1", path = "../metadata" }
+contract-metadata = { version = "2.0.2", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "1.9.2"

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -37,7 +37,7 @@ sp-runtime = "18.0.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-ink = "4.0.0"
+ink = "4.0.1"
 
 [features]
 # This `std` feature is required for testing using an inline contract's metadata, because `ink!` annotates the metadata


### PR DESCRIPTION
### Fixed
- Explicitly enable `std` feature for metadata generation [#977](https://github.com/paritytech/cargo-contract/pull/977)
- Return artifact paths when contracts unchanged [#992](https://github.com/paritytech/cargo-contract/pull/992)
- Minimum requirements of `ink!` dependencies all updated to `4.0.1`