### PR TITLE
Pass contract features to metadata gen package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Limit input length for `decode` command - [#982](https://github.com/paritytech/cargo-contract/pull/982)
+- Pass contract features to metadata gen package - [#1005](https://github.com/paritytech/cargo-contract/pull/1005)
 
 ### [2.0.2]
 

--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -243,7 +243,7 @@ impl TryFrom<&UnstableOptions> for UnstableFlags {
 #[derive(Default, Clone, Debug, Args)]
 pub struct Features {
     /// Space or comma separated list of features to activate
-    #[clap(long, value_delimiter=',')]
+    #[clap(long, value_delimiter = ',')]
     features: Vec<String>,
 }
 
@@ -257,12 +257,11 @@ impl Features {
     pub fn append_to_args(&self, args: &mut Vec<String>) {
         if !self.features.is_empty() {
             args.push("--features".to_string());
-            let features =
-                if self.features.len() == 1 {
-                    self.features[0].clone()
-                } else {
-                    self.features.join(",")
-                };
+            let features = if self.features.len() == 1 {
+                self.features[0].clone()
+            } else {
+                self.features.join(",")
+            };
             args.push(features);
         }
     }

--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -254,12 +254,10 @@ impl Features {
     }
 
     /// Appends the raw features args to pass through to the `cargo` invocation.
-    pub fn append_to_args<'a>(&'a self, args: &mut Vec<&'a str>) {
+    pub fn append_to_args(&self, args: &mut Vec<String>) {
         if !self.features.is_empty() {
-            args.push("--features");
-            for feature in &self.features {
-                args.push(feature)
-            }
+            args.push("--features".to_string());
+            args.push(self.features.join(","));
         }
     }
 }

--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -86,11 +86,12 @@ impl Default for Network {
     }
 }
 
-impl fmt::Display for Network {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Network {
+    /// If `Network::Offline` append the `--offline` flag for cargo invocations.
+    pub fn append_to_args(&self, args: &mut Vec<String>) {
         match self {
-            Self::Online => write!(f, ""),
-            Self::Offline => write!(f, "--offline"),
+            Self::Online => (),
+            Self::Offline => args.push("--offline".to_owned()),
         }
     }
 }

--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -243,7 +243,7 @@ impl TryFrom<&UnstableOptions> for UnstableFlags {
 #[derive(Default, Clone, Debug, Args)]
 pub struct Features {
     /// Space or comma separated list of features to activate
-    #[clap(long)]
+    #[clap(long, value_delimiter=',')]
     features: Vec<String>,
 }
 
@@ -257,7 +257,13 @@ impl Features {
     pub fn append_to_args(&self, args: &mut Vec<String>) {
         if !self.features.is_empty() {
             args.push("--features".to_string());
-            args.push(self.features.join(","));
+            let features =
+                if self.features.len() == 1 {
+                    self.features[0].clone()
+                } else {
+                    self.features.join(",")
+                };
+            args.push(features);
         }
     }
 }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -750,6 +750,7 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
                     &crate_metadata,
                     dest_wasm.as_path(),
                     &metadata_result,
+                    &features,
                     network,
                     verbosity,
                     build_steps,

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -242,20 +242,20 @@ fn exec_cargo_for_wasm_target(
         let target_dir = format!("--target-dir={}", target_dir.to_string_lossy());
 
         let mut args = vec![
-            "--target=wasm32-unknown-unknown",
-            "-Zbuild-std",
-            "--no-default-features",
-            "--release",
-            &target_dir,
+            "--target=wasm32-unknown-unknown".to_owned(),
+            "-Zbuild-std".to_owned(),
+            "--no-default-features".to_owned(),
+            "--release".to_owned(),
+            target_dir,
         ];
         let mut features = features.clone();
         if network == Network::Offline {
-            args.push("--offline");
+            args.push("--offline".to_owned());
         }
         if build_mode == BuildMode::Debug {
             features.push("ink/ink-debug");
         } else {
-            args.push("-Zbuild-std-features=panic_immediate_abort");
+            args.push("-Zbuild-std-features=panic_immediate_abort".to_owned());
         }
         features.append_to_args(&mut args);
         let mut env = vec![(

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -248,10 +248,9 @@ fn exec_cargo_for_wasm_target(
             "--release".to_owned(),
             target_dir,
         ];
+        network.append_to_args(&mut args);
+
         let mut features = features.clone();
-        if network == Network::Offline {
-            args.push("--offline".to_owned());
-        }
         if build_mode == BuildMode::Debug {
             features.push("ink/ink-debug");
         } else {

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -138,7 +138,7 @@ pub(crate) fn execute(
             "--package".to_owned(),
             "metadata-gen".to_owned(),
             manifest_path.cargo_arg()?,
-            "--target-dir",
+            "--target-dir".to_owned(),
             crate_metadata.target_directory.to_string_lossy(),
             "--release".to_owned(),
             network.to_owned(),

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -134,14 +134,18 @@ pub(crate) fn execute(
             format!("{build_steps}").bold(),
             "Generating metadata".bright_green().bold()
         );
+        let target_dir = crate_metadata
+            .target_directory
+            .to_string_lossy()
+            .to_string();
         let mut args = vec![
             "--package".to_owned(),
             "metadata-gen".to_owned(),
             manifest_path.cargo_arg()?,
             "--target-dir".to_owned(),
-            crate_metadata.target_directory.to_string_lossy(),
+            target_dir,
             "--release".to_owned(),
-            network.to_owned(),
+            network.to_string(),
         ];
         features.append_to_args(&mut args);
 

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -145,8 +145,8 @@ pub(crate) fn execute(
             "--target-dir".to_owned(),
             target_dir,
             "--release".to_owned(),
-            network.to_string(),
         ];
+        network.append_to_args(&mut args);
         features.append_to_args(&mut args);
 
         let stdout = util::invoke_cargo(

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -134,19 +134,18 @@ pub(crate) fn execute(
             format!("{build_steps}").bold(),
             "Generating metadata".bright_green().bold()
         );
-        let cargo_arg = manifest_path.cargo_arg()?;
         let target_dir_arg = format!(
             "--target-dir={}",
             crate_metadata.target_directory.to_string_lossy()
         );
         let network = network.to_string();
         let mut args = vec![
-            "--package",
-            "metadata-gen",
-            &cargo_arg,
-            &target_dir_arg,
-            "--release",
-            &network,
+            "--package".to_owned(),
+            "metadata-gen".to_owned(),
+            manifest_path.cargo_arg()?,
+            target_dir_arg,
+            "--release".to_owned(),
+            network,
         ];
         features.append_to_args(&mut args);
 

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -25,6 +25,7 @@ use crate::{
     },
     BuildMode,
     BuildSteps,
+    Features,
     Network,
     OptimizationPasses,
     UnstableFlags,
@@ -112,6 +113,7 @@ pub(crate) fn execute(
     crate_metadata: &CrateMetadata,
     final_contract_wasm: &Path,
     metadata_artifacts: &MetadataArtifacts,
+    features: &Features,
     network: Network,
     verbosity: Verbosity,
     mut build_steps: BuildSteps,
@@ -132,20 +134,25 @@ pub(crate) fn execute(
             format!("{build_steps}").bold(),
             "Generating metadata".bright_green().bold()
         );
+        let cargo_arg = manifest_path.cargo_arg()?;
         let target_dir_arg = format!(
             "--target-dir={}",
             crate_metadata.target_directory.to_string_lossy()
         );
+        let network = network.to_string();
+        let mut args = vec![
+            "--package",
+            "metadata-gen",
+            &cargo_arg,
+            &target_dir_arg,
+            "--release",
+            &network,
+        ];
+        features.append_to_args(&mut args);
+
         let stdout = util::invoke_cargo(
             "run",
-            [
-                "--package",
-                "metadata-gen",
-                &manifest_path.cargo_arg()?,
-                &target_dir_arg,
-                "--release",
-                &network.to_string(),
-            ],
+            args,
             crate_metadata.manifest_path.directory(),
             verbosity,
             vec![],

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -134,18 +134,14 @@ pub(crate) fn execute(
             format!("{build_steps}").bold(),
             "Generating metadata".bright_green().bold()
         );
-        let target_dir_arg = format!(
-            "--target-dir={}",
-            crate_metadata.target_directory.to_string_lossy()
-        );
-        let network = network.to_string();
         let mut args = vec![
             "--package".to_owned(),
             "metadata-gen".to_owned(),
             manifest_path.cargo_arg()?,
-            target_dir_arg,
+            "--target-dir",
+            crate_metadata.target_directory.to_string_lossy(),
             "--release".to_owned(),
-            network,
+            network.to_owned(),
         ];
         features.append_to_args(&mut args);
 

--- a/crates/build/src/workspace/manifest.rs
+++ b/crates/build/src/workspace/manifest.rs
@@ -387,7 +387,19 @@ impl Manifest {
                 .as_table()
                 .ok_or_else(|| anyhow::anyhow!("ink dependency should be a table"))?;
 
-            metadata::generate_package(dir, contract_package_name, ink_crate.clone())?;
+            let features = self
+                .toml
+                .get("features")
+                .ok_or_else(|| anyhow::anyhow!("[features] section not found"))?
+                .as_table()
+                .ok_or_else(|| anyhow::anyhow!("[features] section should be a table"))?;
+
+            metadata::generate_package(
+                dir,
+                contract_package_name,
+                ink_crate.clone(),
+                features,
+            )?;
         }
 
         let updated_toml = toml::to_string(&self.toml)?;

--- a/crates/build/src/workspace/metadata.rs
+++ b/crates/build/src/workspace/metadata.rs
@@ -78,10 +78,12 @@ pub(super) fn generate_package<P: AsRef<Path>>(
         .ok_or_else(|| anyhow::anyhow!("features should be a table"))?;
 
     for (feature, _) in contract_features {
-        features.insert(
-            feature.to_string(),
-            Value::Array(vec![format!("contract/{feature}").into()]),
-        );
+        if feature != "default" && feature != "std" {
+            features.insert(
+                feature.to_string(),
+                Value::Array(vec![format!("contract/{feature}").into()]),
+            );
+        }
     }
 
     let cargo_toml = toml::to_string(&cargo_toml)?;

--- a/crates/build/src/workspace/metadata.rs
+++ b/crates/build/src/workspace/metadata.rs
@@ -19,7 +19,10 @@ use std::{
     fs,
     path::Path,
 };
-use toml::value;
+use toml::{
+    Table,
+    Value,
+};
 
 /// Generates a cargo workspace package `metadata-gen` which will be invoked via `cargo run` to
 /// generate contract metadata.
@@ -31,7 +34,8 @@ use toml::value;
 pub(super) fn generate_package<P: AsRef<Path>>(
     target_dir: P,
     contract_package_name: &str,
-    mut ink_crate_dependency: value::Table,
+    mut ink_crate_dependency: Table,
+    contract_features: &Table,
 ) -> Result<()> {
     let dir = target_dir.as_ref();
     tracing::debug!(
@@ -43,7 +47,7 @@ pub(super) fn generate_package<P: AsRef<Path>>(
     let cargo_toml = include_str!("../../templates/generate-metadata/_Cargo.toml");
     let main_rs = include_str!("../../templates/generate-metadata/main.rs");
 
-    let mut cargo_toml: value::Table = toml::from_str(cargo_toml)?;
+    let mut cargo_toml: Table = toml::from_str(cargo_toml)?;
     let deps = cargo_toml
         .get_mut("dependencies")
         .expect("[dependencies] section specified in the template")
@@ -65,8 +69,22 @@ pub(super) fn generate_package<P: AsRef<Path>>(
 
     // add ink dependencies copied from contract manifest
     deps.insert("ink".into(), ink_crate_dependency.into());
-    let cargo_toml = toml::to_string(&cargo_toml)?;
 
+    // add features from contract
+    let features = cargo_toml
+        .entry("features")
+        .or_insert(Value::Table(Default::default()))
+        .as_table_mut()
+        .ok_or_else(|| anyhow::anyhow!("features should be a table"))?;
+
+    for (feature, _) in contract_features {
+        features.insert(
+            feature.to_string(),
+            Value::Array(vec![format!("contract/{feature}").into()]),
+        );
+    }
+
+    let cargo_toml = toml::to_string(&cargo_toml)?;
     fs::write(dir.join("Cargo.toml"), cargo_toml)?;
     fs::write(dir.join("main.rs"), main_rs)?;
     Ok(())

--- a/crates/build/templates/generate-metadata/_Cargo.toml
+++ b/crates/build/templates/generate-metadata/_Cargo.toml
@@ -10,6 +10,12 @@ name = "metadata-gen"
 path = "main.rs"
 
 [dependencies]
-contract = { path = "../..", features = ["std"] }
+contract = { path = "../.." }
 serde = "1.0"
 serde_json = "1.0"
+
+[features]
+default = ["std"]
+std = [
+    "contract/std"
+]


### PR DESCRIPTION
Fixes #1004.

- copies features from the contract package to the metadata-gen package manifest
- passes the features to the invoking of the generated metadata package
- fixes feature CLI args to be either comma separated or quoted space separated as per cargo: https://doc.rust-lang.org/cargo/reference/features.html#command-line-feature-options