### PR TITLE
Custom `AccountId32` impl, remove substrate deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Limit input length for `decode` command - [#982](https://github.com/paritytech/cargo-contract/pull/982)
 - Pass contract features to metadata gen package - [#1005](https://github.com/paritytech/cargo-contract/pull/1005)
+- Custom AccountId32 impl, remove substrate deps - [#1010](https://github.com/paritytech/cargo-contract/pull/1010)
+  - Fixes issue with with incompatible `wasmtime` versions when dependant project has old substrate dependencies.
 
 ### [2.0.2]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,9 +581,9 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sp-core",
- "sp-runtime",
- "sp-weights",
+ "sp-core 16.0.0",
+ "sp-runtime 18.0.0",
+ "sp-weights 14.0.0",
  "substrate-build-script-utils",
  "subxt",
  "tempfile",
@@ -769,6 +769,8 @@ version = "2.0.2"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "base58",
+ "blake2",
  "contract-metadata",
  "escape8259",
  "hex",
@@ -780,11 +782,13 @@ dependencies = [
  "nom",
  "nom-supreme",
  "parity-scale-codec",
+ "primitive-types",
  "scale-info",
  "serde",
  "serde_json",
- "sp-core",
- "sp-runtime",
+ "sp-core 18.0.0",
+ "sp-keyring",
+ "thiserror",
  "tracing",
 ]
 
@@ -827,6 +831,15 @@ name = "cranelift-entity"
 version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9e39cfc857e7e539aa623e03bb6bec11f54aef3dfdef41adcfa7b594af3b54"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.93.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf583f7b093f291005f9fb1323e2c37f6ee4c7909e39ce016b2e8360d461705"
 dependencies = [
  "serde",
 ]
@@ -2547,9 +2560,9 @@ dependencies = [
  "bitflags",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
- "sp-std",
- "sp-weights",
+ "sp-runtime 18.0.0",
+ "sp-std 6.0.0",
+ "sp-weights 14.0.0",
 ]
 
 [[package]]
@@ -3519,9 +3532,23 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
- "sp-std",
+ "sp-core 16.0.0",
+ "sp-io 17.0.0",
+ "sp-std 6.0.0",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d37b83c90bbd092b1cd1a0c180a0b202e34d2d3b70030c6c421f19116b460c9"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 18.0.0",
+ "sp-io 20.0.0",
+ "sp-std 7.0.0",
 ]
 
 [[package]]
@@ -3535,7 +3562,22 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-std",
+ "sp-std 6.0.0",
+ "static_assertions",
+]
+
+[[package]]
+name = "sp-arithmetic"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3f6d7f526e77997eafaed30554d65fbe84dd508bfd5f744d383d0fc0135776e"
+dependencies = [
+ "integer-sqrt",
+ "num-traits",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-std 7.0.0",
  "static_assertions",
 ]
 
@@ -3570,12 +3612,56 @@ dependencies = [
  "secp256k1 0.24.3",
  "secrecy",
  "serde",
- "sp-core-hashing",
- "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
- "sp-std",
- "sp-storage",
+ "sp-core-hashing 6.0.0",
+ "sp-debug-derive 6.0.0",
+ "sp-externalities 0.17.0",
+ "sp-runtime-interface 13.0.0",
+ "sp-std 6.0.0",
+ "sp-storage 11.0.0",
+ "ss58-registry",
+ "substrate-bip39",
+ "thiserror",
+ "tiny-bip39",
+ "zeroize",
+]
+
+[[package]]
+name = "sp-core"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea27a1d8de728306d17502ba13127a1b1149c66e0ef348f67dafad630b50c1d"
+dependencies = [
+ "array-bytes",
+ "base58",
+ "bitflags",
+ "blake2",
+ "bounded-collections",
+ "dyn-clonable",
+ "ed25519-zebra",
+ "futures",
+ "hash-db",
+ "hash256-std-hasher",
+ "impl-serde",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "parity-scale-codec",
+ "parking_lot",
+ "primitive-types",
+ "rand 0.8.5",
+ "regex",
+ "scale-info",
+ "schnorrkel",
+ "secp256k1 0.24.3",
+ "secrecy",
+ "serde",
+ "sp-core-hashing 7.0.0",
+ "sp-debug-derive 7.0.0",
+ "sp-externalities 0.18.0",
+ "sp-runtime-interface 15.0.0",
+ "sp-std 7.0.0",
+ "sp-storage 12.0.0",
  "ss58-registry",
  "substrate-bip39",
  "thiserror",
@@ -3594,7 +3680,22 @@ dependencies = [
  "digest 0.10.6",
  "sha2 0.10.6",
  "sha3",
- "sp-std",
+ "sp-std 6.0.0",
+ "twox-hash",
+]
+
+[[package]]
+name = "sp-core-hashing"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d607f7209b1b9571177fc3722a03312df03606bb65f89317ba686d5fa59d438f"
+dependencies = [
+ "blake2",
+ "byteorder",
+ "digest 0.10.6",
+ "sha2 0.10.6",
+ "sha3",
+ "sp-std 7.0.0",
  "twox-hash",
 ]
 
@@ -3610,6 +3711,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-debug-derive"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62211eed9ef9dac4b9d837c56ccc9f8ee4fc49d9d9b7e6b9daf098fe173389ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sp-externalities"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3617,8 +3729,20 @@ checksum = "57052935c9c9b070ea6b339ef0da3bf241b7e065fc37f9c551669ee83ecfc3c1"
 dependencies = [
  "environmental",
  "parity-scale-codec",
- "sp-std",
- "sp-storage",
+ "sp-std 6.0.0",
+ "sp-storage 11.0.0",
+]
+
+[[package]]
+name = "sp-externalities"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae0f275760689aaefe967943331d458cd99f5169d18364365d4cb584b246d1c"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "sp-std 7.0.0",
+ "sp-storage 12.0.0",
 ]
 
 [[package]]
@@ -3635,16 +3759,54 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "secp256k1 0.24.3",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface",
- "sp-state-machine",
- "sp-std",
- "sp-tracing",
- "sp-trie",
+ "sp-core 16.0.0",
+ "sp-externalities 0.17.0",
+ "sp-keystore 0.22.0",
+ "sp-runtime-interface 13.0.0",
+ "sp-state-machine 0.22.0",
+ "sp-std 6.0.0",
+ "sp-tracing 8.0.0",
+ "sp-trie 16.0.0",
  "tracing",
  "tracing-core",
+]
+
+[[package]]
+name = "sp-io"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6cb8c02a92a0d1b4b207a869c69b25af69ad3757893effe10e7b16f018b0b9a"
+dependencies = [
+ "bytes",
+ "ed25519",
+ "ed25519-dalek",
+ "futures",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "secp256k1 0.24.3",
+ "sp-core 18.0.0",
+ "sp-externalities 0.18.0",
+ "sp-keystore 0.24.0",
+ "sp-runtime-interface 15.0.0",
+ "sp-state-machine 0.25.0",
+ "sp-std 7.0.0",
+ "sp-tracing 9.0.0",
+ "sp-trie 19.0.0",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "sp-keyring"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc7a176a78d5f1277143a1e7c463d5c1b41b896d9d04fb703070b2494f82779"
+dependencies = [
+ "lazy_static",
+ "sp-core 18.0.0",
+ "sp-runtime 21.0.0",
+ "strum",
 ]
 
 [[package]]
@@ -3659,8 +3821,25 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot",
  "schnorrkel",
- "sp-core",
- "sp-externalities",
+ "sp-core 16.0.0",
+ "sp-externalities 0.17.0",
+ "thiserror",
+]
+
+[[package]]
+name = "sp-keystore"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811b1f0e8fc5b71fa359f5b4b67adedeba5dc313415e2923f8055e72c172a6ce"
+dependencies = [
+ "async-trait",
+ "futures",
+ "merlin",
+ "parity-scale-codec",
+ "parking_lot",
+ "schnorrkel",
+ "sp-core 18.0.0",
+ "sp-externalities 0.18.0",
  "thiserror",
 ]
 
@@ -3669,6 +3848,17 @@ name = "sp-panic-handler"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abed79c3d5b3622f65ab065676addd9923b9b122cd257df23e2757ce487c6d2"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "sp-panic-handler"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75986cc917d897e0f6d0c848088064df4c74ccbb8f1c1848700b725f5ca7fe04"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3690,12 +3880,35 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "serde",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-std",
- "sp-weights",
+ "sp-application-crypto 17.0.0",
+ "sp-arithmetic 12.0.0",
+ "sp-core 16.0.0",
+ "sp-io 17.0.0",
+ "sp-std 6.0.0",
+ "sp-weights 14.0.0",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a2c26cbd47407e0a1c425ac18f4955cc1cf6b9675d1cffba3620d4d1c4cdaf"
+dependencies = [
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "paste",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "sp-application-crypto 20.0.0",
+ "sp-arithmetic 14.0.0",
+ "sp-core 18.0.0",
+ "sp-io 20.0.0",
+ "sp-std 7.0.0",
+ "sp-weights 17.0.0",
 ]
 
 [[package]]
@@ -3708,12 +3921,31 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities",
- "sp-runtime-interface-proc-macro",
- "sp-std",
- "sp-storage",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-externalities 0.17.0",
+ "sp-runtime-interface-proc-macro 9.0.0",
+ "sp-std 6.0.0",
+ "sp-storage 11.0.0",
+ "sp-tracing 8.0.0",
+ "sp-wasm-interface 10.0.0",
+ "static_assertions",
+]
+
+[[package]]
+name = "sp-runtime-interface"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2446ea08a1ae6dac4218b26e01c7aad6dbf47eb506f4f2b1efa821aa418a07d2"
+dependencies = [
+ "bytes",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "primitive-types",
+ "sp-externalities 0.18.0",
+ "sp-runtime-interface-proc-macro 10.0.0",
+ "sp-std 7.0.0",
+ "sp-storage 12.0.0",
+ "sp-tracing 9.0.0",
+ "sp-wasm-interface 12.0.0",
  "static_assertions",
 ]
 
@@ -3722,6 +3954,19 @@ name = "sp-runtime-interface-proc-macro"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2773c90e5765847c5e8b4a24b553d38a9ca52ded47c142cfcfb7948f42827af9"
+dependencies = [
+ "Inflector",
+ "proc-macro-crate 1.3.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sp-runtime-interface-proc-macro"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae5b00aef477127ddb6177b3464ad1e2bdcc12ee913fc5dfc9d065c6cea89b"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.3.0",
@@ -3742,11 +3987,32 @@ dependencies = [
  "parking_lot",
  "rand 0.8.5",
  "smallvec",
- "sp-core",
- "sp-externalities",
- "sp-panic-handler",
- "sp-std",
- "sp-trie",
+ "sp-core 16.0.0",
+ "sp-externalities 0.17.0",
+ "sp-panic-handler 6.0.0",
+ "sp-std 6.0.0",
+ "sp-trie 16.0.0",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22be4db29a769cffc9237a14a99a9a7920f789ab3ecca39df0bc4ee182d6da6a"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "parking_lot",
+ "rand 0.8.5",
+ "smallvec",
+ "sp-core 18.0.0",
+ "sp-externalities 0.18.0",
+ "sp-panic-handler 7.0.0",
+ "sp-std 7.0.0",
+ "sp-trie 19.0.0",
  "thiserror",
  "tracing",
 ]
@@ -3758,6 +4024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af0ee286f98455272f64ac5bb1384ff21ac029fbb669afbaf48477faff12760e"
 
 [[package]]
+name = "sp-std"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de8eef39962b5b97478719c493bed2926cf70cb621005bbf68ebe58252ff986"
+
+[[package]]
 name = "sp-storage"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3767,8 +4039,22 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive",
- "sp-std",
+ "sp-debug-derive 6.0.0",
+ "sp-std 6.0.0",
+]
+
+[[package]]
+name = "sp-storage"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ad1f8c52d4700ac7bc42b3375679a6c6fc1fe876f4b40c6efdf36f933ef0291"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "ref-cast",
+ "serde",
+ "sp-debug-derive 7.0.0",
+ "sp-std 7.0.0",
 ]
 
 [[package]]
@@ -3778,7 +4064,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e46bd547da89a9cda69b4ce4c91a5b7e1f86915190d83cd407b715d0c6bac042"
 dependencies = [
  "parity-scale-codec",
- "sp-std",
+ "sp-std 6.0.0",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "sp-tracing"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00fab60bf3d42255ce3f678903d3a2564662371c75623de4a1ffc7cac46143df"
+dependencies = [
+ "parity-scale-codec",
+ "sp-std 7.0.0",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.2.25",
@@ -3800,11 +4099,35 @@ dependencies = [
  "parking_lot",
  "scale-info",
  "schnellru",
- "sp-core",
- "sp-std",
+ "sp-core 16.0.0",
+ "sp-std 6.0.0",
  "thiserror",
  "tracing",
- "trie-db",
+ "trie-db 0.24.0",
+ "trie-root",
+]
+
+[[package]]
+name = "sp-trie"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbed4ac45ea623c04775aa96149b532114329aac767466c14d464cf37ceb9ac"
+dependencies = [
+ "ahash 0.8.3",
+ "hash-db",
+ "hashbrown 0.12.3",
+ "lazy_static",
+ "memory-db",
+ "nohash-hasher",
+ "parity-scale-codec",
+ "parking_lot",
+ "scale-info",
+ "schnellru",
+ "sp-core 18.0.0",
+ "sp-std 7.0.0",
+ "thiserror",
+ "tracing",
+ "trie-db 0.26.0",
  "trie-root",
 ]
 
@@ -3818,9 +4141,24 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "sp-std",
+ "sp-std 6.0.0",
  "wasmi",
- "wasmtime",
+ "wasmtime 5.0.1",
+]
+
+[[package]]
+name = "sp-wasm-interface"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510bdd9ade55508e5aa05b99ab79aaa4b74a1f7476351b6ce0f3aab3b1cb2524"
+dependencies = [
+ "anyhow",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "sp-std 7.0.0",
+ "wasmi",
+ "wasmtime 6.0.1",
 ]
 
 [[package]]
@@ -3833,10 +4171,26 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic",
- "sp-core",
- "sp-debug-derive",
- "sp-std",
+ "sp-arithmetic 12.0.0",
+ "sp-core 16.0.0",
+ "sp-debug-derive 6.0.0",
+ "sp-std 6.0.0",
+]
+
+[[package]]
+name = "sp-weights"
+version = "17.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e770e01f5e922a84206b483a838a9c581c72f006f2a8a371eb28bb21624bab91"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "smallvec",
+ "sp-arithmetic 14.0.0",
+ "sp-core 18.0.0",
+ "sp-debug-derive 7.0.0",
+ "sp-std 7.0.0",
 ]
 
 [[package]]
@@ -3883,6 +4237,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -3949,9 +4306,9 @@ dependencies = [
  "scale-value",
  "serde",
  "serde_json",
- "sp-core",
- "sp-core-hashing",
- "sp-runtime",
+ "sp-core 16.0.0",
+ "sp-core-hashing 6.0.0",
+ "sp-runtime 18.0.0",
  "subxt-macro",
  "subxt-metadata",
  "thiserror",
@@ -4000,7 +4357,7 @@ dependencies = [
  "frame-metadata",
  "parity-scale-codec",
  "scale-info",
- "sp-core-hashing",
+ "sp-core-hashing 6.0.0",
 ]
 
 [[package]]
@@ -4068,18 +4425,18 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4353,6 +4710,19 @@ checksum = "004e1e8f92535694b4cb1444dc5a8073ecf0815e3357f729638b9f8fc4062908"
 dependencies = [
  "hash-db",
  "hashbrown 0.12.3",
+ "log",
+ "rustc-hex",
+ "smallvec",
+]
+
+[[package]]
+name = "trie-db"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879380c0061b165ba1f036325b7f3478bc1a947814d9fc36d22c5d8e960b11bd"
+dependencies = [
+ "hash-db",
+ "hashbrown 0.13.2",
  "log",
  "rustc-hex",
  "smallvec",
@@ -4698,6 +5068,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b20236ab624147dfbb62cf12a19aaf66af0e41b8398838b66e997d07d269d4"
+dependencies = [
+ "indexmap",
+ "url",
+]
+
+[[package]]
 name = "wasmtime"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4715,10 +5095,35 @@ dependencies = [
  "psm",
  "serde",
  "target-lexicon",
- "wasmparser",
- "wasmtime-environ",
- "wasmtime-jit",
- "wasmtime-runtime",
+ "wasmparser 0.96.0",
+ "wasmtime-environ 5.0.1",
+ "wasmtime-jit 5.0.1",
+ "wasmtime-runtime 5.0.1",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e89f9819523447330ffd70367ef4a18d8c832e24e8150fe054d1d912841632"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.29.0",
+ "once_cell",
+ "paste",
+ "psm",
+ "serde",
+ "target-lexicon",
+ "wasmparser 0.100.0",
+ "wasmtime-environ 6.0.1",
+ "wasmtime-jit 6.0.1",
+ "wasmtime-runtime 6.0.1",
  "windows-sys 0.42.0",
 ]
 
@@ -4732,13 +5137,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-asm-macros"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd3a5e46c198032da934469f3a6e48649d1f9142438e4fd4617b68a35644b8a"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "wasmtime-environ"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9350c919553cddf14f78f9452119c8004d7ef6bfebb79a41a21819ed0c5604d8"
 dependencies = [
  "anyhow",
- "cranelift-entity",
+ "cranelift-entity 0.92.1",
  "gimli 0.26.2",
  "indexmap",
  "log",
@@ -4746,8 +5160,27 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasmparser",
- "wasmtime-types",
+ "wasmparser 0.96.0",
+ "wasmtime-types 5.0.1",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a6db9fc52985ba06ca601f2ff0ff1f526c5d724c7ac267b47326304b0c97883"
+dependencies = [
+ "anyhow",
+ "cranelift-entity 0.93.1",
+ "gimli 0.26.2",
+ "indexmap",
+ "log",
+ "object 0.29.0",
+ "serde",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.100.0",
+ "wasmtime-types 6.0.1",
 ]
 
 [[package]]
@@ -4767,9 +5200,32 @@ dependencies = [
  "rustc-demangle",
  "serde",
  "target-lexicon",
- "wasmtime-environ",
- "wasmtime-jit-icache-coherence",
- "wasmtime-runtime",
+ "wasmtime-environ 5.0.1",
+ "wasmtime-jit-icache-coherence 5.0.1",
+ "wasmtime-runtime 5.0.1",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "wasmtime-jit"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b77e3a52cd84d0f7f18554afa8060cfe564ccac61e3b0802d3fd4084772fa5f6"
+dependencies = [
+ "addr2line 0.17.0",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "cpp_demangle",
+ "gimli 0.26.2",
+ "log",
+ "object 0.29.0",
+ "rustc-demangle",
+ "serde",
+ "target-lexicon",
+ "wasmtime-environ 6.0.1",
+ "wasmtime-jit-icache-coherence 6.0.1",
+ "wasmtime-runtime 6.0.1",
  "windows-sys 0.42.0",
 ]
 
@@ -4783,10 +5239,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-jit-debug"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0245e8a9347017c7185a72e215218a802ff561545c242953c11ba00fccc930f"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd4356c2493002da3b111d470c2ecea65a3017009afce8adc46eaa5758739891"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d412e9340ab1c83867051d8d1d7c90aa8c9afc91da086088068e2734e25064"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4811,9 +5287,33 @@ dependencies = [
  "paste",
  "rand 0.8.5",
  "rustix",
- "wasmtime-asm-macros",
- "wasmtime-environ",
- "wasmtime-jit-debug",
+ "wasmtime-asm-macros 5.0.1",
+ "wasmtime-environ 5.0.1",
+ "wasmtime-jit-debug 5.0.1",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "wasmtime-runtime"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d594e791b5fdd4dbaf8cf7ae62f2e4ff85018ce90f483ca6f42947688e48827d"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "indexmap",
+ "libc",
+ "log",
+ "mach",
+ "memfd",
+ "memoffset",
+ "paste",
+ "rand 0.8.5",
+ "rustix",
+ "wasmtime-asm-macros 6.0.1",
+ "wasmtime-environ 6.0.1",
+ "wasmtime-jit-debug 6.0.1",
  "windows-sys 0.42.0",
 ]
 
@@ -4823,10 +5323,22 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86e1e4f66a2b9a114f9def450ab9971828c968db6ea6fccd613724b771fa4913"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.92.1",
  "serde",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.96.0",
+]
+
+[[package]]
+name = "wasmtime-types"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6688d6f96d4dbc1f89fab626c56c1778936d122b5f4ae7a57c2eb42b8d982e2"
+dependencies = [
+ "cranelift-entity 0.93.1",
+ "serde",
+ "thiserror",
+ "wasmparser 0.100.0",
 ]
 
 [[package]]

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -18,6 +18,8 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0.69"
+base58 = { version = "0.2.0" }
+blake2 = { version = "0.10.4", default-features = false }
 contract-metadata = { version = "2.0.2", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
@@ -28,16 +30,18 @@ itertools = "0.10.5"
 tracing = "0.1.37"
 nom = "7.1.3"
 nom-supreme = { version = "0.7.0", features = ["error"] }
+primitive-types = "0.12.1"
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.154", default-features = false, features = ["derive"] }
 serde_json = "1.0.94"
-sp-core = "16.0.0"
-sp-runtime = "18.0.0"
+thiserror = "1.0.39"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 ink = "4.0.1"
+sp-core = { version = "18.0.0", default-features = false }
+sp-keyring = "21.0.0"
 
 [features]
 # This `std` feature is required for testing using an inline contract's metadata, because `ink!` annotates the metadata

--- a/crates/transcode/src/account_id.rs
+++ b/crates/transcode/src/account_id.rs
@@ -26,6 +26,14 @@ use serde::{
 /// A 32-byte cryptographic identifier. This is a simplified version of Substrate's
 /// `sp_core::crypto::AccountId32`.
 ///
+/// It replaces the usage of this type from the `sp-core` crate directly. Direct
+/// dependencies on substrate crates can cause linking issues if the dependant
+/// package itself has substrate dependencies which depend on an incompatible version
+/// of `wasmtime`.
+///
+/// This is the only type that was used from `sp-core`, and it is unlikely to change,
+/// so it made sense to make a copy and reduce the dependency burden.
+///
 /// # Note
 ///
 /// This has been copied from `subxt::utils::AccountId32`, with some modifications:

--- a/crates/transcode/src/account_id.rs
+++ b/crates/transcode/src/account_id.rs
@@ -1,0 +1,236 @@
+// Copyright 2018-2020 Parity Technologies (UK) Ltd.
+// This file is part of cargo-contract.
+//
+// cargo-contract is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// cargo-contract is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
+
+use scale::{
+    Decode,
+    Encode,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+/// A 32-byte cryptographic identifier. This is a simplified version of Substrate's
+/// `sp_core::crypto::AccountId32`.
+///
+/// # Note
+///
+/// This has been copied from `subxt::utils::AccountId32`, with some modifications:
+///
+/// - Custom [`scale_info::TypeInfo`] implementation to match original substrate type.
+/// - Made `to_ss58check` public.
+/// - Implemented `TryFrom<&'a [u8]>`.
+///
+/// We can consider modifying the type upstream if appropriate.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, Debug)]
+pub struct AccountId32(pub [u8; 32]);
+
+/// Custom `TypeInfo` impl with path matching original `sp_core::crypto::AccountId32`
+impl scale_info::TypeInfo for AccountId32 {
+    type Identity = Self;
+
+    fn type_info() -> scale_info::Type {
+        scale_info::Type::builder()
+            .path(::scale_info::Path::new("AccountId32", "sp_core::crypto"))
+            .composite(
+                scale_info::build::Fields::unnamed()
+                    .field(|f| f.ty::<[u8; 32]>().type_name("[u8; 32]").docs(&[])),
+            )
+    }
+}
+
+impl AsRef<[u8]> for AccountId32 {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl AsRef<[u8; 32]> for AccountId32 {
+    fn as_ref(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for AccountId32 {
+    fn from(x: [u8; 32]) -> Self {
+        AccountId32(x)
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for AccountId32 {
+    type Error = ();
+    fn try_from(x: &'a [u8]) -> Result<AccountId32, ()> {
+        if x.len() == 32 {
+            let mut data = [0; 32];
+            data.copy_from_slice(x);
+            Ok(AccountId32(data))
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl AccountId32 {
+    // Return the ss58-check string for this key. Adapted from `sp_core::crypto`. We need this to
+    // serialize our account appropriately but otherwise don't care.
+    pub fn to_ss58check(&self) -> String {
+        // For serializing to a string to obtain the account nonce, we use the default substrate
+        // prefix (since we have no way to otherwise pick one). It doesn't really matter, since when
+        // it's deserialized back in system_accountNextIndex, we ignore this (so long as it's valid).
+        const SUBSTRATE_SS58_PREFIX: u8 = 42;
+        // prefix <= 63 just take up one byte at the start:
+        let mut v = vec![SUBSTRATE_SS58_PREFIX];
+        // then push the account ID bytes.
+        v.extend(self.0);
+        // then push a 2 byte checksum of what we have so far.
+        let r = ss58hash(&v);
+        v.extend(&r[0..2]);
+        // then encode to base58.
+        use base58::ToBase58;
+        v.to_base58()
+    }
+
+    // This isn't strictly needed, but to give our AccountId32 a little more usefulness, we also
+    // implement the logic needed to decode an AccountId32 from an SS58 encoded string. This is exposed
+    // via a `FromStr` impl.
+    fn from_ss58check(s: &str) -> Result<Self, FromSs58Error> {
+        const CHECKSUM_LEN: usize = 2;
+        let body_len = 32;
+
+        use base58::FromBase58;
+        let data = s.from_base58().map_err(|_| FromSs58Error::BadBase58)?;
+        if data.len() < 2 {
+            return Err(FromSs58Error::BadLength)
+        }
+        let prefix_len = match data[0] {
+            0..=63 => 1,
+            64..=127 => 2,
+            _ => return Err(FromSs58Error::InvalidPrefix),
+        };
+        if data.len() != prefix_len + body_len + CHECKSUM_LEN {
+            return Err(FromSs58Error::BadLength)
+        }
+        let hash = ss58hash(&data[0..body_len + prefix_len]);
+        let checksum = &hash[0..CHECKSUM_LEN];
+        if data[body_len + prefix_len..body_len + prefix_len + CHECKSUM_LEN] != *checksum
+        {
+            // Invalid checksum.
+            return Err(FromSs58Error::InvalidChecksum)
+        }
+
+        let result = data[prefix_len..body_len + prefix_len]
+            .try_into()
+            .map_err(|_| FromSs58Error::BadLength)?;
+        Ok(AccountId32(result))
+    }
+}
+
+/// An error obtained from trying to interpret an SS58 encoded string into an AccountId32
+#[derive(thiserror::Error, Clone, Copy, Eq, PartialEq, Debug)]
+#[allow(missing_docs)]
+pub enum FromSs58Error {
+    #[error("Base 58 requirement is violated")]
+    BadBase58,
+    #[error("Length is bad")]
+    BadLength,
+    #[error("Invalid checksum")]
+    InvalidChecksum,
+    #[error("Invalid SS58 prefix byte.")]
+    InvalidPrefix,
+}
+
+// We do this just to get a checksum to help verify the validity of the address in to_ss58check
+fn ss58hash(data: &[u8]) -> Vec<u8> {
+    use blake2::{
+        Blake2b512,
+        Digest,
+    };
+    const PREFIX: &[u8] = b"SS58PRE";
+    let mut ctx = Blake2b512::new();
+    ctx.update(PREFIX);
+    ctx.update(data);
+    ctx.finalize().to_vec()
+}
+
+impl Serialize for AccountId32 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_ss58check())
+    }
+}
+
+impl<'de> Deserialize<'de> for AccountId32 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        AccountId32::from_ss58check(&String::deserialize(deserializer)?)
+            .map_err(|e| serde::de::Error::custom(format!("{e:?}")))
+    }
+}
+
+impl std::fmt::Display for AccountId32 {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.to_ss58check())
+    }
+}
+
+impl std::str::FromStr for AccountId32 {
+    type Err = FromSs58Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        AccountId32::from_ss58check(s)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use sp_core::crypto::Ss58Codec;
+    use sp_keyring::AccountKeyring;
+
+    #[test]
+    fn ss58_is_compatible_with_substrate_impl() {
+        let keyrings = vec![
+            AccountKeyring::Alice,
+            AccountKeyring::Bob,
+            AccountKeyring::Charlie,
+        ];
+
+        for keyring in keyrings {
+            let substrate_account = keyring.to_account_id();
+            // Avoid "From" impl hidden behind "substrate-compat" feature so that this test
+            // can work either way:
+            let local_account = AccountId32(substrate_account.clone().into());
+
+            // Both should encode to ss58 the same way:
+            let substrate_ss58 = substrate_account.to_ss58check();
+            assert_eq!(substrate_ss58, local_account.to_ss58check());
+
+            // Both should decode from ss58 back to the same:
+            assert_eq!(
+                sp_core::crypto::AccountId32::from_ss58check(&substrate_ss58).unwrap(),
+                substrate_account
+            );
+            assert_eq!(
+                AccountId32::from_ss58check(&substrate_ss58).unwrap(),
+                local_account
+            );
+        }
+    }
+}

--- a/crates/transcode/src/env_types.rs
+++ b/crates/transcode/src/env_types.rs
@@ -14,8 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::scon::Value;
-use crate::scon::Hex;
+use crate::{
+    AccountId32,
+    Hex,
+    Value,
+};
 use anyhow::{
     Context,
     Result,
@@ -30,10 +33,6 @@ use scale_info::{
     IntoPortable,
     Path,
     TypeInfo,
-};
-use sp_core::crypto::{
-    AccountId32,
-    Ss58Codec,
 };
 use std::{
     boxed::Box,
@@ -202,7 +201,7 @@ pub struct Hash;
 
 impl CustomTypeDecoder for Hash {
     fn decode_value(&self, input: &mut &[u8]) -> Result<Value> {
-        let hash = sp_core::H256::decode(input)?;
+        let hash = primitive_types::H256::decode(input)?;
         Ok(Value::Hex(Hex::from_str(&format!("{hash:?}"))?))
     }
 }

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -96,6 +96,7 @@
 //! println!("Encoded constructor data {:?}", data);
 //! ```
 
+mod account_id;
 mod decode;
 mod encode;
 pub mod env_types;
@@ -104,6 +105,7 @@ mod transcoder;
 mod util;
 
 pub use self::{
+    account_id::AccountId32,
     scon::{
         Hex,
         Map,
@@ -569,10 +571,9 @@ mod tests {
         // encoded args follow the 4 byte selector
         let encoded_args = &encoded[4..];
 
-        let expected = sp_core::crypto::AccountId32::from_str(
-            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-        )
-        .unwrap();
+        let expected =
+            AccountId32::from_str("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+                .unwrap();
         assert_eq!(expected.encode(), encoded_args);
         Ok(())
     }
@@ -591,14 +592,10 @@ mod tests {
         let encoded_args = &encoded[4..];
 
         let expected = vec![
-            sp_core::crypto::AccountId32::from_str(
-                "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-            )
-            .unwrap(),
-            sp_core::crypto::AccountId32::from_str(
-                "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-            )
-            .unwrap(),
+            AccountId32::from_str("5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
+                .unwrap(),
+            AccountId32::from_str("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty")
+                .unwrap(),
         ];
         assert_eq!(expected.encode(), encoded_args);
         Ok(())

--- a/crates/transcode/src/transcoder.rs
+++ b/crates/transcode/src/transcoder.rs
@@ -26,6 +26,7 @@ use super::{
         TypesByPath,
     },
     scon::Value,
+    AccountId32,
 };
 
 use anyhow::Result;
@@ -97,10 +98,8 @@ impl TranscoderBuilder {
     }
 
     pub fn with_default_custom_type_transcoders(self) -> Self {
-        self.register_custom_type_transcoder::<sp_runtime::AccountId32, _>(
-            env_types::AccountId,
-        )
-        .register_custom_type_decoder::<sp_core::H256, _>(env_types::Hash)
+        self.register_custom_type_transcoder::<AccountId32, _>(env_types::AccountId)
+            .register_custom_type_decoder::<primitive_types::H256, _>(env_types::Hash)
     }
 
     pub fn register_custom_type_transcoder<T, U>(self, transcoder: U) -> Self
@@ -685,12 +684,12 @@ mod tests {
 
     #[test]
     fn transcode_account_id_custom_ss58_encoding() -> Result<()> {
-        type AccountId = sp_runtime::AccountId32;
+        type AccountId = AccountId32;
 
         #[allow(dead_code)]
         #[derive(TypeInfo)]
         struct S {
-            no_alias: sp_runtime::AccountId32,
+            no_alias: AccountId32,
             aliased: AccountId,
         }
 
@@ -729,7 +728,7 @@ mod tests {
             Ok(Value::Seq(Seq::new(values.collect())))
         };
 
-        transcode_roundtrip::<Vec<sp_runtime::AccountId32>>(
+        transcode_roundtrip::<Vec<AccountId32>>(
             r#"[
                 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY,
                 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty,
@@ -760,7 +759,7 @@ mod tests {
         #[allow(dead_code)]
         #[derive(TypeInfo)]
         struct S {
-            hash: sp_core::H256,
+            hash: primitive_types::H256,
         }
 
         transcode_roundtrip::<S>(


### PR DESCRIPTION
Removes the substrate dependencies from `contract-transcode`.

We copy the `AccountId32` type from `subxt`: https://github.com/paritytech/subxt/blob/ce0a82e3227efb0eae131f025da5f839d9623e15/subxt/src/utils/account_id.rs, with a few modifications so that it can work in place of `sp_core::crypto::AccountId32`