### PR TITLE
Upgrade wasm-opt to 0.112.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4615,9 +4615,9 @@ checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-opt"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a303793cbc01fb96551badfc7367db6007396bba6bac97936b3c8b6f7fdb41"
+checksum = "87fef6d0d508f08334e0ab0e6877feb4c0ecb3956bcf2cb950699b22fedf3e9c"
 dependencies = [
  "anyhow",
  "libc",
@@ -4631,9 +4631,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c9deb56f8a9f2ec177b3bd642a8205621835944ed5da55f2388ef216aca5a4"
+checksum = "bc816bbc1596c8f2e8127e137a760c798023ef3d378f2ae51f0f1840e2dfa445"
 dependencies = [
  "anyhow",
  "cxx",
@@ -4643,15 +4643,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.111.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4432e28b542738a9776cedf92e8a99d8991c7b4667ee2c7ccddfb479dd2856a7"
+checksum = "40199e4f68ef1071b3c6d0bd8026a12b481865d4b9e49c156932ea9a6234dd14"
 dependencies = [
  "anyhow",
  "cc",
  "cxx",
  "cxx-build",
- "regex",
 ]
 
 [[package]]

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -32,7 +32,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1.0.94"
 tempfile = "3.4.0"
 url = { version = "2.3.1", features = ["serde"] }
-wasm-opt = "0.111.0"
+wasm-opt = "0.112.0"
 which = "4.4.0"
 zip = { version = "0.6.4", default-features = false }
 


### PR DESCRIPTION
Just keeping the crate up to date.

There don't appear to be significant changes in binaryen 112:

https://github.com/WebAssembly/binaryen/blob/main/CHANGELOG.md#v112