### PR TITLE
`2.0.3` Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [2.0.3]
+
 ### Changed
 - Dry-run `instantiate`, `call` and `upload` commands by default - [#999](https://github.com/paritytech/cargo-contract/pull/999)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "contract-build"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "blake2",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-build"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -36,7 +36,7 @@ wasm-opt = "0.112.0"
 which = "4.4.0"
 zip = { version = "0.6.4", default-features = false }
 
-contract-metadata = { version = "2.0.2", path = "../metadata" }
+contract-metadata = { version = "2.0.3", path = "../metadata" }
 
 [build-dependencies]
 anyhow = "1.0.69"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-contract-build = { version = "2.0.2", path = "../build" }
-contract-metadata = { version = "2.0.2", path = "../metadata" }
-contract-transcode = { version = "2.0.2", path = "../transcode" }
+contract-build = { version = "2.0.3", path = "../build" }
+contract-metadata = { version = "2.0.3", path = "../metadata" }
+contract-transcode = { version = "2.0.3", path = "../transcode" }
 
 anyhow = "1.0.69"
 clap = { version = "4.1.8", features = ["derive", "env"] }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 anyhow = "1.0.69"
 base58 = { version = "0.2.0" }
 blake2 = { version = "0.10.4", default-features = false }
-contract-metadata = { version = "2.0.2", path = "../metadata" }
+contract-metadata = { version = "2.0.3", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "1.9.2"


### PR DESCRIPTION
### [2.0.3]

### Changed
- Dry-run `instantiate`, `call` and `upload` commands by default - [#999](https://github.com/paritytech/cargo-contract/pull/999)

### Added
- Add `cargo contract encode` command - [#998](https://github.com/paritytech/cargo-contract/pull/998)

### Fixed
- Limit input length for `decode` command - [#982](https://github.com/paritytech/cargo-contract/pull/982)
- Pass contract features to metadata gen package - [#1005](https://github.com/paritytech/cargo-contract/pull/1005)
- Custom AccountId32 impl, remove substrate deps - [#1010](https://github.com/paritytech/cargo-contract/pull/1010)
  - Fixes issue with with incompatible `wasmtime` versions when dependant project has old substrate dependencies.