### PR TITLE
Add CI check for all individual crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,28 @@ jobs:
           command: fmt
           args: --check
 
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check each crate
+        run: |
+          for crate in crates/*/; do
+            cargo check --manifest-path ${crate}/Cargo.toml --all-targets;
+            cargo check --manifest-path ${crate}/Cargo.toml --all-features --all-targets;
+          done
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Check each crate
         run: |
-          for crate in crates/*/; do
+          for crate in ./crates/*/; do
             cargo check --manifest-path ${crate}/Cargo.toml --all-targets;
             cargo check --manifest-path ${crate}/Cargo.toml --all-features --all-targets;
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,7 @@ jobs:
         run: |
           for crate in ./crates/*/; do
             echo "Checking $crate";
-            cargo check --manifest-path ${crate}/Cargo.toml --all-targets;
-            cargo check --manifest-path ${crate}/Cargo.toml --all-features --all-targets;
+            cargo check --manifest-path ${crate}/Cargo.toml;
           done
 
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Check each crate
         run: |
           for crate in ./crates/*/; do
+            echo "Checking $crate";
             cargo check --manifest-path ${crate}/Cargo.toml --all-targets;
             cargo check --manifest-path ${crate}/Cargo.toml --all-features --all-targets;
           done

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -30,7 +30,9 @@ itertools = "0.10.5"
 tracing = "0.1.37"
 nom = "7.1.3"
 nom-supreme = { version = "0.7.0", features = ["error"] }
-primitive-types = { version = "0.12.1", default-features = false, features = ["codec", "scale-info", "serde"] }
+#TEMP comment this out to check CI failure
+#primitive-types = { version = "0.12.1", default-features = false, features = ["codec", "scale-info", "serde"] }
+primitive-types = "0.12.1"
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.154", default-features = false, features = ["derive"] }

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -30,9 +30,7 @@ itertools = "0.10.5"
 tracing = "0.1.37"
 nom = "7.1.3"
 nom-supreme = { version = "0.7.0", features = ["error"] }
-#TEMP comment this out to check CI failure
-#primitive-types = { version = "0.12.1", default-features = false, features = ["codec", "scale-info", "serde"] }
-primitive-types = "0.12.1"
+primitive-types = { version = "0.12.1", default-features = false, features = ["codec", "scale-info", "serde"] }
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
 serde = { version = "1.0.154", default-features = false, features = ["derive"] }


### PR DESCRIPTION
Currently the CI only runs workspace level `build` and `test` commands. However it is possible that these will succeed but when building an individual crate it will fail. e.g the CI for https://github.com/paritytech/cargo-contract/pull/1010 succeeded, but when it came to releasing it, it didn't work because of [missing features](https://github.com/paritytech/cargo-contract/pull/1016/commits/d89ca994b84f4b519bca1a11b6c3b5fec220b603).

My guess is that there is another crate which depends on `primitive-types` at the workspace level, which pulls in the required features via feature unification.

This PR iterates over the crates in the `crates` dir and runs `check` on each one. When performing a release on an individual crate, `cargo publish` will run `cargo check` before publishing, so we want to catch any errors which would arise there in the CI.