### PR TITLE
Fix integration tests and CI tests :t-rex:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download?job=build-linux' && \
           unzip substrate-contracts-node.zip && \
           chmod +x artifacts/substrate-contracts-node-linux/substrate-contracts-node &&
-          cargo test --profile debug-ci --all-features -- --test-threads=1 &
+          cargo test --profile debug-ci --all-features -- --test-threads=1
 
       - name: Install latest `substrate-contracts-node` binary and run tests
         if: runner.os == 'macOS'
@@ -120,7 +120,7 @@ jobs:
           curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download?job=build-mac' && \
           unzip substrate-contracts-node.zip && \
           chmod +x artifacts/substrate-contracts-node-mac/substrate-contracts-node &&
-          cargo test --profile debug-ci --all-features -- --test-threads=1 &    
+          cargo test --profile debug-ci --all-features -- --test-threads=1
 
 
   template:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,10 +124,11 @@ jobs:
       fail-fast: false
       matrix:
         # We want newer versions than 'latest' here to have current wasm-opt
-        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
+        os: ["ubuntu-22.04", "macos-12"]
     runs-on: ${{ matrix.os }}
     env:
       RUST_BACKTRACE: full
+      CONTRACTS_NODE_URL: https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -144,22 +145,24 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Install latest `substrate-contracts-node` binary and run tests
+      - name: Install latest `substrate-contracts-node` binary
         if: runner.os == 'Linux'
         run: |
-          curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download?job=build-linux' && \
+          curl -L -o substrate-contracts-node.zip "$CONTRACTS_NODE_URL?job=build-linux" && \
           unzip substrate-contracts-node.zip && \
           chmod +x artifacts/substrate-contracts-node-linux/substrate-contracts-node &&
-          cargo test --profile debug-ci --all-features -- --test-threads=1
+          echo "Linux: $PATH"
 
-      - name: Install latest `substrate-contracts-node` binary and run tests
+      - name: Install latest `substrate-contracts-node` binary
         if: runner.os == 'macOS'
         run: |
-          curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download?job=build-mac' && \
+          curl -L -o substrate-contracts-node.zip "$CONTRACTS_NODE_URL?job=build-mac" && \
           unzip substrate-contracts-node.zip && \
           chmod +x artifacts/substrate-contracts-node-mac/substrate-contracts-node &&
-          cargo test --profile debug-ci --all-features -- --test-threads=1
+          echo "MacOS: $PATH"
 
+      - name: Run tests
+        run: cargo test --profile debug-ci --all-features -- --test-threads=1
 
   template:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,21 +145,21 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Install latest `substrate-contracts-node` binary (Linux)
-        if: runner.os == 'Linux'
+      - name: Install latest `substrate-contracts-node` binary
         run: |
-          curl -L -o substrate-contracts-node.zip "$CONTRACTS_NODE_URL?job=build-linux" && \
-          unzip substrate-contracts-node.zip && \
-          chmod +x artifacts/substrate-contracts-node-linux/substrate-contracts-node &&
-          mv artifacts/substrate-contracts-node-linux/substrate-contracts-node /usr/local/bin
-
-      - name: Install latest `substrate-contracts-node` binary (Mac)
-        if: runner.os == 'macOS'
-        run: |
-          curl -L -o substrate-contracts-node.zip "$CONTRACTS_NODE_URL?job=build-mac" && \
-          unzip substrate-contracts-node.zip && \
-          chmod +x artifacts/substrate-contracts-node-mac/substrate-contracts-node &&
-          mv artifacts/substrate-contracts-node-mac/substrate-contracts-node /usr/local/bin
+          if [ "$RUNNER_OS" == "Linux" ]; then
+              CONTRACTS_NODE_OS=linux
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+              CONTRACTS_NODE_OS=mac
+          else
+              echo "$RUNNER_OS not supported"
+              exit 1
+          fi
+          curl -L -o substrate-contracts-node.zip "$CONTRACTS_NODE_URL?job=build-$CONTRACTS_NODE_OS"
+          unzip substrate-contracts-node.zip
+          chmod +x artifacts/substrate-contracts-node-$CONTRACTS_NODE_OS/substrate-contracts-node &&
+          mv artifacts/substrate-contracts-node-$CONTRACTS_NODE_OS/substrate-contracts-node /usr/local/bin
+        shell: bash
 
       - name: Run tests
         run: cargo test --profile debug-ci --all-features -- --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       RUST_BACKTRACE: full
-      CONTRACTS_NODE_URL: https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -146,6 +145,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install latest `substrate-contracts-node` binary
+        env:
+          CONTRACTS_NODE_URL: https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
               CONTRACTS_NODE_OS=linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,21 +145,21 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Install latest `substrate-contracts-node` binary
+      - name: Install latest `substrate-contracts-node` binary (Linux)
         if: runner.os == 'Linux'
         run: |
           curl -L -o substrate-contracts-node.zip "$CONTRACTS_NODE_URL?job=build-linux" && \
           unzip substrate-contracts-node.zip && \
           chmod +x artifacts/substrate-contracts-node-linux/substrate-contracts-node &&
-          echo "Linux: $PATH"
+          mv artifacts/substrate-contracts-node-linux/substrate-contracts-node /usr/local/bin
 
-      - name: Install latest `substrate-contracts-node` binary
+      - name: Install latest `substrate-contracts-node` binary (Mac)
         if: runner.os == 'macOS'
         run: |
           curl -L -o substrate-contracts-node.zip "$CONTRACTS_NODE_URL?job=build-mac" && \
           unzip substrate-contracts-node.zip && \
           chmod +x artifacts/substrate-contracts-node-mac/substrate-contracts-node &&
-          echo "MacOS: $PATH"
+          mv artifacts/substrate-contracts-node-mac/substrate-contracts-node /usr/local/bin
 
       - name: Run tests
         run: cargo test --profile debug-ci --all-features -- --test-threads=1

--- a/crates/cargo-contract/src/cmd/extrinsics/integration_tests.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/integration_tests.rs
@@ -212,7 +212,6 @@ async fn build_upload_instantiate_call() {
             .args(["--message", "get"])
             .args(["--contract", contract_account])
             .args(["--suri", "//Alice"])
-            .arg("-x")
             .assert()
             .stdout(predicate::str::contains(expected.to_string()));
     };
@@ -224,6 +223,7 @@ async fn build_upload_instantiate_call() {
         .args(["--message", "flip"])
         .args(["--contract", contract_account])
         .args(["--suri", "//Alice"])
+        .arg("-x")
         .assert()
         .stdout(predicate::str::contains("ExtrinsicSuccess"));
 


### PR DESCRIPTION
Since https://github.com/paritytech/cargo-contract/pull/928, the tests have not been running at all on CI, due to a trailing ampersand on the `run` command (or at least executing async and not reporting back).

This PR makes the tests run again, and fixes the broken  `build_upload_instantiate_call` test.

It also combines the download and install `substrate-contracts-node` into a single step.