### PR TITLE
Upgrade `scale-info` to `2.5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61471dff9096de1d8b2319efed7162081e96793f5ebb147e50db10d50d648a4d"
+checksum = "0cfdffd972d76b22f3d7f81c8be34b2296afd3a25e0a547bd9abe340a4dbbe97"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3198,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219580e803a66b3f05761fd06f1f879a872444e49ce23f73694d26e5a954c7e6"
+checksum = "61fa974aea2d63dd18a4ec3a49d59af9f34178c73a4f56d2f18205628d00681e"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",

--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 ink = { version = "4.1.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
 ink_e2e = "4.1.0"

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -32,7 +32,7 @@ nom = "7.1.3"
 nom-supreme = { version = "0.7.0", features = ["error"] }
 primitive-types = { version = "0.12.1", default-features = false, features = ["codec", "scale-info", "serde"] }
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
-scale-info = { version = "2.4.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.159", default-features = false, features = ["derive"] }
 serde_json = "1.0.95"
 thiserror = "1.0.40"

--- a/crates/transcode/src/env_types.rs
+++ b/crates/transcode/src/env_types.rs
@@ -116,17 +116,14 @@ impl PathKey {
         T: TypeInfo,
     {
         let type_info = T::type_info();
-        let path = type_info
-            .path()
-            .clone()
-            .into_portable(&mut Default::default());
+        let path = type_info.path.into_portable(&mut Default::default());
         PathKey::from(&path)
     }
 }
 
 impl From<&Path<PortableForm>> for PathKey {
     fn from(path: &Path<PortableForm>) -> Self {
-        PathKey(path.segments().to_vec())
+        PathKey(path.segments.to_vec())
     }
 }
 

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -221,7 +221,7 @@ impl ContractMessageTranscoder {
             let value = scon::parse_value(arg.as_ref())?;
             self.transcoder.encode(
                 self.metadata.registry(),
-                spec.ty().ty().id(),
+                spec.ty().ty().id,
                 &value,
                 &mut encoded,
             )?;
@@ -275,7 +275,7 @@ impl ContractMessageTranscoder {
         let mut args = Vec::new();
         for arg in event_spec.args() {
             let name = arg.label().to_string();
-            let value = self.decode(arg.ty().ty().id(), data)?;
+            let value = self.decode(arg.ty().ty().id, data)?;
             args.push((Value::String(name), value));
         }
 
@@ -304,7 +304,7 @@ impl ContractMessageTranscoder {
         let mut args = Vec::new();
         for arg in msg_spec.args() {
             let name = arg.label().to_string();
-            let value = self.decode(arg.ty().ty().id(), data)?;
+            let value = self.decode(arg.ty().ty().id, data)?;
             args.push((Value::String(name), value));
         }
 
@@ -333,7 +333,7 @@ impl ContractMessageTranscoder {
         let mut args = Vec::new();
         for arg in msg_spec.args() {
             let name = arg.label().to_string();
-            let value = self.decode(arg.ty().ty().id(), data)?;
+            let value = self.decode(arg.ty().ty().id, data)?;
             args.push((Value::String(name), value));
         }
 
@@ -350,7 +350,7 @@ impl ContractMessageTranscoder {
             anyhow::anyhow!("Failed to find message spec with name '{}'", name)
         })?;
         if let Some(return_ty) = msg_spec.return_type().opt_type() {
-            self.decode(return_ty.ty().id(), data)
+            self.decode(return_ty.ty().id, data)
         } else {
             Ok(Value::Unit)
         }
@@ -414,13 +414,14 @@ impl CompositeTypeFields {
     pub fn from_fields(fields: &[Field<PortableForm>]) -> Result<Self> {
         if fields.iter().next().is_none() {
             Ok(Self::NoFields)
-        } else if fields.iter().all(|f| f.name().is_some()) {
+        } else if fields.iter().all(|f| f.name.is_some()) {
             let fields = fields
                 .iter()
                 .map(|field| {
                     CompositeTypeNamedField {
                         name: field
-                            .name()
+                            .name
+                            .as_ref()
                             .expect("All fields have a name; qed")
                             .to_owned(),
                         field: field.clone(),
@@ -428,7 +429,7 @@ impl CompositeTypeFields {
                 })
                 .collect();
             Ok(Self::Named(fields))
-        } else if fields.iter().all(|f| f.name().is_none()) {
+        } else if fields.iter().all(|f| f.name.is_none()) {
             Ok(Self::Unnamed(fields.to_vec()))
         } else {
             Err(anyhow::anyhow!(

--- a/crates/transcode/src/transcoder.rs
+++ b/crates/transcode/src/transcoder.rs
@@ -86,9 +86,9 @@ pub struct TranscoderBuilder {
 impl TranscoderBuilder {
     pub fn new(registry: &PortableRegistry) -> Self {
         let types_by_path = registry
-            .types()
+            .types
             .iter()
-            .map(|ty| (PathKey::from(ty.ty().path()), ty.id()))
+            .map(|ty| (PathKey::from(&ty.ty.path), ty.id))
             .collect::<TypesByPath>();
         Self {
             types_by_path,
@@ -202,7 +202,7 @@ mod tests {
         let type_id = registry.register_type(&MetaType::new::<T>());
         let registry: PortableRegistry = registry.into();
 
-        Ok((registry, type_id.id()))
+        Ok((registry, type_id.id))
     }
 
     fn transcode_roundtrip<T>(input: &str, expected_output: Value) -> Result<()>


### PR DESCRIPTION
Accessors are deprecated and fields are made public, see https://github.com/paritytech/scale-info/pull/176