### PR TITLE
Initial RISC-V support

### DIFF
--- a/crates/build/riscv_memory_layout.ld
+++ b/crates/build/riscv_memory_layout.ld
@@ -1,0 +1,17 @@
+MEMORY {
+    RAM : ORIGIN = 0x00000000, LENGTH =  2M
+}
+
+SECTIONS {
+    . = ORIGIN(RAM);
+    .text : { *(.init) *(.text .text.*) } > REGION_TEXT
+    .rodata : { *(.rodata) *(.rodata.*) } > REGION_RODATA
+    .bss : { *(.sbss) *(.bss) *(.bss.*) } > REGION_DATA
+    .data : { *(.data) } > REGION_DATA
+    /DISCARD/ : { *(.eh_frame) }
+    . = ALIGN(4);
+}
+
+REGION_ALIAS("REGION_TEXT", RAM);
+REGION_ALIAS("REGION_RODATA", RAM);
+REGION_ALIAS("REGION_DATA", RAM);

--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -111,8 +111,8 @@ impl BuildArtifacts {
     /// Used as output on the cli.
     pub fn steps(&self) -> usize {
         match self {
-            BuildArtifacts::All => 5,
-            BuildArtifacts::CodeOnly => 4,
+            BuildArtifacts::All => 4,
+            BuildArtifacts::CodeOnly => 3,
             BuildArtifacts::CheckOnly => 1,
         }
     }
@@ -154,6 +154,54 @@ impl fmt::Display for BuildSteps {
             .total_steps
             .map_or("*".to_string(), |steps| steps.to_string());
         write!(f, "[{}/{}]", self.current_step, total_steps)
+    }
+}
+
+/// The list of targets that ink! supports.
+#[derive(
+    Eq,
+    PartialEq,
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub enum Target {
+    /// WebAssembly
+    #[clap(name = "wasm")]
+    #[default]
+    Wasm,
+    /// RISC-V: Experimental
+    #[clap(name = "riscv")]
+    RiscV,
+}
+
+impl Target {
+    /// The target string to be passed to rustc in order to build for this target.
+    pub fn llvm_target(&self) -> &'static str {
+        match self {
+            Self::Wasm => "wasm32-unknown-unknown",
+            Self::RiscV => "riscv32i-unknown-none-elf",
+        }
+    }
+
+    /// Target specific flags to be set to `RUSTFLAGS` while building.
+    pub fn rustflags(&self) -> &'static str {
+        match self {
+            Self::Wasm => "-C link-arg=-zstack-size=65536 -C link-arg=--import-memory -Clinker-plugin-lto -C target-cpu=mvp",
+            Self::RiscV => "-Clinker-plugin-lto",
+        }
+    }
+
+    /// The file extension that is used by rustc when outputing the binary.
+    pub fn source_extension(&self) -> &'static str {
+        match self {
+            Self::Wasm => "wasm",
+            Self::RiscV => "",
+        }
     }
 }
 

--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::ManifestPath;
+use crate::{
+    ManifestPath,
+    Target,
+};
 use anyhow::{
     Context,
     Result,
@@ -43,8 +46,8 @@ pub struct CrateMetadata {
     pub cargo_meta: cargo_metadata::Metadata,
     pub contract_artifact_name: String,
     pub root_package: Package,
-    pub original_wasm: PathBuf,
-    pub dest_wasm: PathBuf,
+    pub original_code: PathBuf,
+    pub dest_code: PathBuf,
     pub ink_version: Version,
     pub documentation: Option<Url>,
     pub homepage: Option<Url>,
@@ -54,13 +57,16 @@ pub struct CrateMetadata {
 
 impl CrateMetadata {
     /// Attempt to construct [`CrateMetadata`] from the given manifest path.
-    pub fn from_manifest_path(manifest_path: Option<&PathBuf>) -> Result<Self> {
+    pub fn from_manifest_path(
+        manifest_path: Option<&PathBuf>,
+        target: Target,
+    ) -> Result<Self> {
         let manifest_path = ManifestPath::try_from(manifest_path)?;
-        Self::collect(&manifest_path)
+        Self::collect(&manifest_path, target)
     }
 
     /// Parses the contract manifest and returns relevant metadata.
-    pub fn collect(manifest_path: &ManifestPath) -> Result<Self> {
+    pub fn collect(manifest_path: &ManifestPath, target: Target) -> Result<Self> {
         let (metadata, root_package) = get_cargo_metadata(manifest_path)?;
         let mut target_directory = metadata.target_directory.as_path().join("ink");
 
@@ -94,17 +100,17 @@ impl CrateMetadata {
             target_directory = target_directory.join(package_name.clone());
         }
 
-        // {target_dir}/wasm32-unknown-unknown/release/{package_name}.wasm
-        let mut original_wasm = target_directory.clone();
-        original_wasm.push("wasm32-unknown-unknown");
-        original_wasm.push("release");
-        original_wasm.push(package_name.clone());
-        original_wasm.set_extension("wasm");
+        // {target_dir}/{target}/release/{package_name}.{extension}
+        let mut original_code = target_directory.clone();
+        original_code.push(target.llvm_target());
+        original_code.push("release");
+        original_code.push(package_name.clone());
+        original_code.set_extension(target.source_extension());
 
-        // {target_dir}/{package_name}.wasm
-        let mut dest_wasm = target_directory.clone();
-        dest_wasm.push(package_name.clone());
-        dest_wasm.set_extension("wasm");
+        // {target_dir}/{package_name}.code
+        let mut dest_code = target_directory.clone();
+        dest_code.push(package_name.clone());
+        dest_code.set_extension("code");
 
         let ink_version = metadata
             .packages
@@ -132,8 +138,8 @@ impl CrateMetadata {
             cargo_meta: metadata,
             root_package,
             contract_artifact_name: package_name,
-            original_wasm: original_wasm.into(),
-            dest_wasm: dest_wasm.into(),
+            original_code: original_code.into(),
+            dest_code: dest_code.into(),
             ink_version,
             documentation,
             homepage,

--- a/crates/build/src/tests.rs
+++ b/crates/build/src/tests.rs
@@ -24,6 +24,7 @@ use crate::{
     ManifestPath,
     OptimizationPasses,
     OutputType,
+    Target,
     Verbosity,
 };
 use anyhow::Result;
@@ -165,6 +166,7 @@ fn optimization_passes_from_cli_must_take_precedence_over_profile(
         lint: false,
         output_type: OutputType::Json,
         skip_wasm_validation: false,
+        target: Default::default(),
     };
 
     // when
@@ -206,6 +208,7 @@ fn optimization_passes_from_profile_must_be_used(
         lint: false,
         output_type: OutputType::Json,
         skip_wasm_validation: false,
+        target: Default::default(),
     };
 
     // when
@@ -398,10 +401,10 @@ fn generates_metadata(manifest_path: &ManifestPath) -> Result<()> {
     )?;
     test_manifest.write()?;
 
-    let crate_metadata = CrateMetadata::collect(manifest_path)?;
+    let crate_metadata = CrateMetadata::collect(manifest_path, Target::Wasm)?;
 
     // usually this file will be produced by a previous build step
-    let final_contract_wasm_path = &crate_metadata.dest_wasm;
+    let final_contract_wasm_path = &crate_metadata.dest_code;
     fs::create_dir_all(final_contract_wasm_path.parent().unwrap()).unwrap();
     fs::write(final_contract_wasm_path, "TEST FINAL WASM BLOB").unwrap();
 
@@ -460,7 +463,7 @@ fn generates_metadata(manifest_path: &ManifestPath) -> Result<()> {
     let user = metadata_json.get("user").expect("user section not found");
 
     // calculate wasm hash
-    let fs_wasm = fs::read(&crate_metadata.dest_wasm)?;
+    let fs_wasm = fs::read(&crate_metadata.dest_code)?;
     let expected_hash = crate::code_hash(&fs_wasm[..]);
     let expected_wasm = build_byte_str(&fs_wasm);
 
@@ -671,7 +674,7 @@ impl BuildTestContext {
     ) -> Result<()> {
         println!("Running {name}");
         let manifest_path = ManifestPath::new(self.working_dir.join("Cargo.toml"))?;
-        let crate_metadata = CrateMetadata::collect(&manifest_path)?;
+        let crate_metadata = CrateMetadata::collect(&manifest_path, Target::Wasm)?;
         match test(&manifest_path) {
             Ok(()) => (),
             Err(err) => {
@@ -682,8 +685,8 @@ impl BuildTestContext {
         self.remove_all_except_target_dir()?;
         copy_dir_all(&self.template_dir, &self.working_dir)?;
         // remove the original wasm artifact to force it to be rebuilt
-        if crate_metadata.original_wasm.exists() {
-            fs::remove_file(&crate_metadata.original_wasm)?;
+        if crate_metadata.original_code.exists() {
+            fs::remove_file(&crate_metadata.original_code)?;
         }
         Ok(())
     }

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -53,7 +53,7 @@ pub fn invoke_cargo<I, S, P>(
     args: I,
     working_dir: Option<P>,
     verbosity: Verbosity,
-    env: Vec<(&str, Option<&str>)>,
+    env: Vec<(&str, Option<String>)>,
 ) -> Result<Vec<u8>>
 where
     I: IntoIterator<Item = S> + std::fmt::Debug,

--- a/crates/build/src/wasm_opt.rs
+++ b/crates/build/src/wasm_opt.rs
@@ -19,7 +19,6 @@ use wasm_opt::OptimizationOptions;
 
 use std::{
     fmt,
-    fs::metadata,
     path::PathBuf,
     str,
 };
@@ -54,7 +53,7 @@ impl WasmOptHandler {
         &self,
         dest_wasm: &PathBuf,
         contract_artifact_name: &String,
-    ) -> Result<OptimizationResult> {
+    ) -> Result<()> {
         // We'll create a temporary file for our optimized Wasm binary. Note that we'll later
         // overwrite this with the original path of the Wasm binary.
         let mut dest_optimized = dest_wasm.clone();
@@ -84,16 +83,9 @@ impl WasmOptHandler {
             ))
         }
 
-        let original_size = metadata(dest_wasm)?.len() as f64 / 1000.0;
-        let optimized_size = metadata(&dest_optimized)?.len() as f64 / 1000.0;
-
         // Overwrite existing destination wasm file with the optimised version
         std::fs::rename(&dest_optimized, dest_wasm)?;
-        Ok(OptimizationResult {
-            dest_wasm: dest_wasm.clone(),
-            original_size,
-            optimized_size,
-        })
+        Ok(())
     }
 }
 

--- a/crates/build/src/workspace/manifest.rs
+++ b/crates/build/src/workspace/manifest.rs
@@ -147,16 +147,32 @@ impl Manifest {
         &self.path
     }
 
-    /// Get mutable reference to `[lib] crate-types = []` section
-    fn get_crate_types_mut(&mut self) -> Result<&mut value::Array> {
-        let lib = self
-            .toml
-            .get_mut("lib")
-            .ok_or_else(|| anyhow::anyhow!("lib section not found"))?;
+    /// Get the name of the package.
+    fn name(&self) -> Result<&str> {
+        self.toml
+            .get("package")
+            .ok_or_else(|| anyhow::anyhow!("package section not found"))?
+            .as_table()
+            .ok_or_else(|| anyhow::anyhow!("package section should be a table"))?
+            .get("name")
+            .ok_or_else(|| anyhow::anyhow!("package must have a name"))?
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("package name must be a string"))
+    }
 
-        let crate_types = lib
+    /// Get a mutable reference to the `[lib]` section.
+    fn lib_target_mut(&mut self) -> Result<&mut value::Table> {
+        self.toml
+            .get_mut("lib")
+            .ok_or_else(|| anyhow::anyhow!("lib section not found"))?
             .as_table_mut()
-            .ok_or_else(|| anyhow::anyhow!("lib section should be a table"))?
+            .ok_or_else(|| anyhow::anyhow!("lib section should be a table"))
+    }
+
+    /// Get mutable reference to `[lib] crate-types = []` section.
+    fn crate_types_mut(&mut self) -> Result<&mut value::Array> {
+        let crate_types = self
+            .lib_target_mut()?
             .entry("crate-type")
             .or_insert(value::Value::Array(Default::default()));
 
@@ -165,18 +181,15 @@ impl Manifest {
             .ok_or_else(|| anyhow::anyhow!("crate-types should be an Array"))
     }
 
-    /// Set the contents of the `[lib] crate-types = []` section.
-    ///
-    /// Overwrites any existing crate types.
-    pub fn with_crate_types<'a, I>(&mut self, new_crate_types: I) -> Result<&mut Self>
-    where
-        I: IntoIterator<Item = &'a str>,
-    {
-        let existing_crate_types = self.get_crate_types_mut()?;
-        existing_crate_types.clear();
-        for crate_type in new_crate_types.into_iter() {
-            existing_crate_types.push(crate_type.into())
+    /// Replaces the `[lib]` target by a single `[bin]` target using the same file and name.
+    pub fn with_replaced_lib_to_bin(&mut self) -> Result<&mut Self> {
+        let mut lib = self.lib_target_mut()?.clone();
+        self.toml.remove("lib");
+        if !lib.contains_key("name") {
+            lib.insert("name".into(), self.name()?.into());
         }
+        lib.remove("crate-types");
+        self.toml.insert("bin".into(), vec![lib].into());
         Ok(self)
     }
 
@@ -184,7 +197,7 @@ impl Manifest {
     ///
     /// If the value already exists, does nothing.
     pub fn with_added_crate_type(&mut self, crate_type: &str) -> Result<&mut Self> {
-        let crate_types = self.get_crate_types_mut()?;
+        let crate_types = self.crate_types_mut()?;
         if !crate_type_exists(crate_type, crate_types) {
             crate_types.push(crate_type.into());
         }
@@ -192,7 +205,7 @@ impl Manifest {
     }
 
     /// Extract `optimization-passes` from `[package.metadata.contract]`
-    pub fn get_profile_optimization_passes(&mut self) -> Option<OptimizationPasses> {
+    pub fn profile_optimization_passes(&mut self) -> Option<OptimizationPasses> {
         self.toml
             .get("package")?
             .as_table()?
@@ -208,7 +221,7 @@ impl Manifest {
     /// Set `[profile.release]` lto flag
     pub fn with_profile_release_lto(&mut self, enabled: bool) -> Result<&mut Self> {
         let lto = self
-            .get_profile_release_table_mut()?
+            .profile_release_table_mut()?
             .entry("lto")
             .or_insert(enabled.into());
         *lto = enabled.into();
@@ -225,7 +238,7 @@ impl Manifest {
         &mut self,
         defaults: Profile,
     ) -> Result<&mut Self> {
-        let profile_release = self.get_profile_release_table_mut()?;
+        let profile_release = self.profile_release_table_mut()?;
         defaults.merge(profile_release);
         Ok(self)
     }
@@ -242,7 +255,7 @@ impl Manifest {
     }
 
     /// Get mutable reference to `[profile.release]` section
-    fn get_profile_release_table_mut(&mut self) -> Result<&mut value::Table> {
+    fn profile_release_table_mut(&mut self) -> Result<&mut value::Table> {
         let profile = self
             .toml
             .entry("profile")
@@ -261,7 +274,7 @@ impl Manifest {
     ///
     /// If the value does not exist, does nothing.
     pub fn with_removed_crate_type(&mut self, crate_type: &str) -> Result<&mut Self> {
-        let crate_types = self.get_crate_types_mut()?;
+        let crate_types = self.crate_types_mut()?;
         if crate_type_exists(crate_type, crate_types) {
             crate_types.retain(|v| v.as_str().map_or(true, |s| s != crate_type));
         }

--- a/crates/cargo-contract/src/cmd/build.rs
+++ b/crates/cargo-contract/src/cmd/build.rs
@@ -25,6 +25,7 @@ use contract_build::{
     Network,
     OptimizationPasses,
     OutputType,
+    Target,
     UnstableFlags,
     UnstableOptions,
     Verbosity,
@@ -110,6 +111,9 @@ pub struct BuildCommand {
     /// Don't perform wasm validation checks e.g. for permitted imports.
     #[clap(long)]
     skip_wasm_validation: bool,
+    /// Which bytecode to build the contract into.
+    #[clap(long, default_value = "wasm")]
+    target: Target,
 }
 
 impl BuildCommand {
@@ -152,6 +156,7 @@ impl BuildCommand {
             lint: self.lint,
             output_type,
             skip_wasm_validation: self.skip_wasm_validation,
+            target: self.target,
         };
 
         contract_build::execute(args)
@@ -170,6 +175,8 @@ pub struct CheckCommand {
     features: Features,
     #[clap(flatten)]
     unstable_options: UnstableOptions,
+    #[clap(long, default_value = "wasm")]
+    target: Target,
 }
 
 impl CheckCommand {
@@ -192,6 +199,7 @@ impl CheckCommand {
             lint: false,
             output_type: OutputType::default(),
             skip_wasm_validation: false,
+            target: self.target,
         };
 
         contract_build::execute(args)

--- a/crates/cargo-contract/src/cmd/decode.rs
+++ b/crates/cargo-contract/src/cmd/decode.rs
@@ -49,7 +49,8 @@ enum DataType {
 
 impl DecodeCommand {
     pub fn run(&self) -> Result<()> {
-        let crate_metadata = CrateMetadata::from_manifest_path(None)?;
+        let crate_metadata =
+            CrateMetadata::from_manifest_path(None, contract_build::Target::Wasm)?;
         let transcoder = ContractMessageTranscoder::load(crate_metadata.metadata_path())?;
 
         const ERR_MSG: &str = "Failed to decode specified data as a hex value";

--- a/crates/cargo-contract/src/cmd/extrinsics/mod.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/mod.rs
@@ -207,7 +207,10 @@ impl ContractArtifacts {
     ) -> Result<ContractArtifacts> {
         let artifact_path = match (manifest_path, file) {
             (manifest_path, None) => {
-                let crate_metadata = CrateMetadata::from_manifest_path(manifest_path)?;
+                let crate_metadata = CrateMetadata::from_manifest_path(
+                    manifest_path,
+                    contract_build::Target::Wasm,
+                )?;
 
                 if crate_metadata.contract_bundle_path().exists() {
                     crate_metadata.contract_bundle_path()


### PR DESCRIPTION
This PR adds initial support for RISC-V. It allows the user to supply `--target riscv` which then will build a contract into `riscv32i`. The feature is more or less complete in that it produces a contract bundle containing RISC-V bytecode. However, there is no executor where to run those contracts on, yet. Additionally, there is no post processing done on the resulting file. This will come later in order to bring the file size down.

## Changes

- Add `--target` command line flag. Defaults to `wasm`.
- Build contracts as `bin` target rather than `cdylib`. This is required for RISC-V but changes nothing for wasm.
- Change the `wasm` file extension for the contract code to `code` so that it is agnostic to the bytecode. We added a symlink from the `.wasm` file when building for wasm to have backwards compat.
- Add a preliminary linker script for RISC-V that links the code according to our current VM implementation. This is of course subject to change,
- Unify optimization and post processing steps. The differentiation seems arbitrary and makes no sense for RISC-V. Post processing encapsulates both now.
- 
## Caveats

- Some tests are failing because they use the latest released version of ink! which doesn't include https://github.com/paritytech/ink/pull/1718
- When building without `--release` the linking fails. This is an old bug we know from wasm which appears with `-Zbuild-std + lto + overflow-checks`. The idea is to get rid of overflow checks and ban unchecked arithmetic from contracts. I will present a solution for this soon.