### PR TITLE
Rewrites build file path in manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
 dependencies = [
- "anstyle 1.0.0",
+ "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
@@ -131,7 +131,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
 dependencies = [
- "anstyle 1.0.0",
+ "anstyle",
  "windows-sys 0.48.0",
 ]
 
@@ -729,7 +729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14a1a858f532119338887a4b8e1af9c60de8249cd7bafd68036a489e261e37b6"
 dependencies = [
  "anstream",
- "anstyle 1.0.0",
+ "anstyle",
  "bitflags",
  "clap_lex",
  "strsim",

--- a/crates/build/src/tests.rs
+++ b/crates/build/src/tests.rs
@@ -293,12 +293,10 @@ fn building_contract_with_source_file_in_subfolder_must_work(
     Ok(())
 }
 
-fn building_contract_with_build_rs_must_work(
-    manifest_path: &ManifestPath,
-) -> Result<()> {
+fn building_contract_with_build_rs_must_work(manifest_path: &ManifestPath) -> Result<()> {
     // given
     let mut test_manifest = TestContractManifest::new(manifest_path.clone())?;
-    test_manifest.add_package_value("build","build.rs".to_string().into())?;
+    test_manifest.add_package_value("build", "build.rs".to_string().into())?;
     test_manifest.write()?;
 
     let path = manifest_path.directory().expect("dir must exist");

--- a/crates/build/src/workspace/manifest.rs
+++ b/crates/build/src/workspace/manifest.rs
@@ -421,6 +421,16 @@ struct PathRewrite<'a> {
 impl<'a> PathRewrite<'a> {
     /// Replace relative paths with absolute paths with the working directory.
     fn rewrite_relative_paths(&self, toml: &mut value::Table) -> Result<()> {
+        // Rewrite `[package.build]` path to an absolute path.
+        if let Some(package) = toml.get_mut("package") {
+            let package = package
+                .as_table_mut()
+                .ok_or_else(|| anyhow::anyhow!("`[package]` should be a table"))?;
+            if let Some(build) = package.get_mut("build") {
+                self.to_absolute_path(format!("[package.build]"), build)?
+            }
+        }
+
         // Rewrite `[lib] path = /path/to/lib.rs`
         if let Some(lib) = toml.get_mut("lib") {
             self.rewrite_path(lib, "lib", "src/lib.rs")?;

--- a/crates/build/src/workspace/manifest.rs
+++ b/crates/build/src/workspace/manifest.rs
@@ -427,7 +427,7 @@ impl<'a> PathRewrite<'a> {
                 .as_table_mut()
                 .ok_or_else(|| anyhow::anyhow!("`[package]` should be a table"))?;
             if let Some(build) = package.get_mut("build") {
-                self.to_absolute_path(format!("[package.build]"), build)?
+                self.to_absolute_path("[package.build]".to_string(), build)?
             }
         }
 


### PR DESCRIPTION
Currently contract projects with a build file fail to compile.

This PR fixes this by rewriting the path of the specified `build` file in the temp manifest.

Fixes #1060.

