### PR TITLE
Only copy and rewrite target contract manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
 dependencies = [
- "anstyle 1.0.0",
+ "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
@@ -131,7 +131,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
 dependencies = [
- "anstyle 1.0.0",
+ "anstyle",
  "windows-sys 0.48.0",
 ]
 
@@ -729,7 +729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14a1a858f532119338887a4b8e1af9c60de8249cd7bafd68036a489e261e37b6"
 dependencies = [
  "anstream",
- "anstyle 1.0.0",
+ "anstyle",
  "bitflags",
  "clap_lex",
  "strsim",

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -329,9 +329,7 @@ fn exec_cargo_dylint(crate_metadata: &CrateMetadata, verbosity: Verbosity) -> Re
 
     Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
         .with_root_package_manifest(|manifest| {
-            manifest
-                .delete_workspace_table()
-                .with_dylint()?;
+            manifest.delete_workspace_table().with_dylint()?;
             Ok(())
         })?
         .using_temp(|manifest_path| {

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -284,9 +284,10 @@ fn exec_cargo_for_wasm_target(
         Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
             .with_root_package_manifest(|manifest| {
                 manifest
+                    .delete_workspace_table()
                     .with_crate_types(["cdylib"])?
                     .with_profile_release_defaults(Profile::default_contract_release())?
-                    .with_workspace()?;
+                    .with_workspace()?; // todo: combine with delete_workspace_table?
                 Ok(())
             })?
             .using_temp(cargo_build)?;

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -284,10 +284,9 @@ fn exec_cargo_for_wasm_target(
         Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
             .with_root_package_manifest(|manifest| {
                 manifest
-                    .delete_workspace_table()
                     .with_crate_types(["cdylib"])?
                     .with_profile_release_defaults(Profile::default_contract_release())?
-                    .with_workspace()?; // todo: combine with delete_workspace_table?
+                    .with_empty_workspace();
                 Ok(())
             })?
             .using_temp(cargo_build)?;
@@ -329,7 +328,9 @@ fn exec_cargo_dylint(crate_metadata: &CrateMetadata, verbosity: Verbosity) -> Re
 
     Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
         .with_root_package_manifest(|manifest| {
-            manifest.delete_workspace_table().with_dylint()?;
+            manifest
+                .with_dylint()?
+                .with_empty_workspace();
             Ok(())
         })?
         .using_temp(|manifest_path| {

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -660,6 +660,12 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
                 )
             })?;
 
+            tracing::debug!(
+                "Fingerprint before build: {:?}, after build: {:?}",
+                pre_fingerprint,
+                post_fingerprint
+            );
+
             let dest_wasm_path = crate_metadata.dest_wasm.clone();
 
             if pre_fingerprint == Some(post_fingerprint)

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -328,7 +328,9 @@ fn exec_cargo_dylint(crate_metadata: &CrateMetadata, verbosity: Verbosity) -> Re
 
     Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
         .with_root_package_manifest(|manifest| {
-            manifest.with_dylint()?;
+            manifest
+                .delete_workspace_table()
+                .with_dylint()?;
             Ok(())
         })?
         .using_temp(|manifest_path| {

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -328,9 +328,7 @@ fn exec_cargo_dylint(crate_metadata: &CrateMetadata, verbosity: Verbosity) -> Re
 
     Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
         .with_root_package_manifest(|manifest| {
-            manifest
-                .with_dylint()?
-                .with_empty_workspace();
+            manifest.with_dylint()?.with_empty_workspace();
             Ok(())
         })?
         .using_temp(|manifest_path| {

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -186,9 +186,9 @@ pub(crate) fn execute(
         Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
             .with_root_package_manifest(|manifest| {
                 manifest
-                    .delete_workspace_table()
                     .with_added_crate_type("rlib")?
-                    .with_profile_release_lto(false)?;
+                    .with_profile_release_lto(false)?
+                    .with_empty_workspace();
                 Ok(())
             })?
             .with_metadata_gen_package()?

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -186,13 +186,12 @@ pub(crate) fn execute(
         Workspace::new(&crate_metadata.cargo_meta, &crate_metadata.root_package.id)?
             .with_root_package_manifest(|manifest| {
                 manifest
+                    .delete_workspace_table()
                     .with_added_crate_type("rlib")?
                     .with_profile_release_lto(false)?;
                 Ok(())
             })?
-            .with_metadata_gen_package(
-                crate_metadata.manifest_path.absolute_directory()?,
-            )?
+            .with_metadata_gen_package()?
             .using_temp(generate_metadata)?;
     }
 

--- a/crates/build/src/workspace/manifest.rs
+++ b/crates/build/src/workspace/manifest.rs
@@ -225,15 +225,14 @@ impl Manifest {
         Ok(self)
     }
 
-    /// Set empty `[workspace]` section if it does not exist.
+    /// Set `[workspace]` section to an empty table. When building a contract project any workspace
+    /// members are not copied to the temporary workspace, so need to be removed.
     ///
-    /// Ignores the `workspace` from the parent `Cargo.toml`.
-    /// This can reduce the size of the contract in some cases.
-    pub fn with_workspace(&mut self) -> Result<&mut Self> {
-        if let toml::map::Entry::Vacant(value) = self.toml.entry("workspace") {
-            value.insert(value::Value::Table(Default::default()));
-        }
-        Ok(self)
+    /// Additionally, where no workspace is already specified, this can in some cases reduce the
+    /// size of the contract.
+    pub fn with_empty_workspace(&mut self) -> &mut Self {
+        self.toml.insert("workspace".into(), value::Value::Table(Default::default()));
+        self
     }
 
     /// Get mutable reference to `[profile.release]` section
@@ -342,12 +341,6 @@ impl Manifest {
         let manifest_dir = self.path.absolute_directory()?;
         let path_rewrite = PathRewrite { manifest_dir };
         path_rewrite.rewrite_relative_paths(&mut self.toml)
-    }
-
-    /// Remove the `[workspace]` section from the manifest.
-    pub fn delete_workspace_table(&mut self) -> &mut Self {
-        self.toml.remove("workspace");
-        self
     }
 
     /// Writes the amended manifest to the given path.

--- a/crates/build/src/workspace/manifest.rs
+++ b/crates/build/src/workspace/manifest.rs
@@ -231,7 +231,8 @@ impl Manifest {
     /// Additionally, where no workspace is already specified, this can in some cases reduce the
     /// size of the contract.
     pub fn with_empty_workspace(&mut self) -> &mut Self {
-        self.toml.insert("workspace".into(), value::Value::Table(Default::default()));
+        self.toml
+            .insert("workspace".into(), value::Value::Table(Default::default()));
         self
     }
 

--- a/crates/build/src/workspace/manifest.rs
+++ b/crates/build/src/workspace/manifest.rs
@@ -336,8 +336,6 @@ impl Manifest {
     ///
     /// - `[lib]/path`
     /// - `[dependencies]`
-    ///
-    /// Dependencies with package names specified in `exclude_deps` will not be rewritten.
     pub fn rewrite_relative_paths(&mut self) -> Result<()> {
         let manifest_dir = self.path.absolute_directory()?;
         let path_rewrite = PathRewrite { manifest_dir };

--- a/crates/build/src/workspace/manifest.rs
+++ b/crates/build/src/workspace/manifest.rs
@@ -340,9 +340,7 @@ impl Manifest {
     /// Dependencies with package names specified in `exclude_deps` will not be rewritten.
     pub fn rewrite_relative_paths(&mut self) -> Result<()> {
         let manifest_dir = self.path.absolute_directory()?;
-        let path_rewrite = PathRewrite {
-            manifest_dir,
-        };
+        let path_rewrite = PathRewrite { manifest_dir };
         path_rewrite.rewrite_relative_paths(&mut self.toml)
     }
 

--- a/crates/build/src/workspace/mod.rs
+++ b/crates/build/src/workspace/mod.rs
@@ -34,11 +34,9 @@ use cargo_metadata::{
     PackageId,
 };
 
-use std::{
-    path::{
-        Path,
-        PathBuf,
-    },
+use std::path::{
+    Path,
+    PathBuf,
 };
 
 /// Make a copy of a cargo workspace, maintaining only the directory structure and manifest
@@ -60,7 +58,9 @@ impl Workspace {
             .packages
             .iter()
             .find(|p| p.id == *root_package)
-            .ok_or_else(|| anyhow::anyhow!("The root package should be a workspace member"))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!("The root package should be a workspace member")
+            })?;
 
         let manifest_path = ManifestPath::new(&root_package.manifest_path)?;
         let root_manifest = Manifest::new(manifest_path)?;
@@ -101,13 +101,14 @@ impl Workspace {
     /// intra-workspace relative dependency paths which will be preserved.
     ///
     /// Returns the paths of the new manifests.
-    pub fn write<P: AsRef<Path>>(
-        &mut self,
-        target: P,
-    ) -> Result<ManifestPath> {
+    pub fn write<P: AsRef<Path>>(&mut self, target: P) -> Result<ManifestPath> {
         // replace the original workspace root with the temporary directory
         let mut new_path: PathBuf = target.as_ref().into();
-        new_path.push(self.root_package.manifest_path.strip_prefix(&self.workspace_root)?);
+        new_path.push(
+            self.root_package
+                .manifest_path
+                .strip_prefix(&self.workspace_root)?,
+        );
         let new_manifest = ManifestPath::new(new_path)?;
 
         // tracing::info!("Rewriting manifest {} to {}", self.root_manifest.manifest_path, new_manifest.display());
@@ -132,9 +133,7 @@ impl Workspace {
 
         // copy the `Cargo.lock` file
         let src_lockfile = self.workspace_root.clone().join("Cargo.lock");
-        let dest_lockfile = tmp_dir
-            .path()
-            .join("Cargo.lock");
+        let dest_lockfile = tmp_dir.path().join("Cargo.lock");
         if src_lockfile.exists() {
             tracing::debug!(
                 "Copying '{}' to ' '{}'",

--- a/crates/build/src/workspace/mod.rs
+++ b/crates/build/src/workspace/mod.rs
@@ -213,8 +213,8 @@ impl Workspace {
 
         // copy the `Cargo.lock` file
         let src_lockfile = self.workspace_root.clone().join("Cargo.lock");
-        let dest_lockfile = tmp_root_manifest_path
-            .absolute_directory()?
+        let dest_lockfile = tmp_dir
+            .path()
             .join("Cargo.lock");
         if src_lockfile.exists() {
             tracing::debug!(


### PR DESCRIPTION
Previously the whole workspace was copied to the temp dir. However we were only ever modifying and utilizing the target contracts manifest. This was causing unnecessary rebuilds of workspace contracts as experienced here: https://github.com/paritytech/ink/issues/1734.

## todo

- [x] confirm fix of https://github.com/paritytech/ink/issues/1734
- [x] update all comments of modified methods.