### PR TITLE
Release `v2.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0]
+
 ### Added
 - Add `info` command - [#993](https://github.com/paritytech/cargo-contract/pull/993)
 - Add `--output-json` flag for `info` command - [#1007](https://github.com/paritytech/cargo-contract/pull/1007)
 
 ### Changed
-- Minimum requirements of `ink!` dependencies all updated to `4.1.0` - [#1045](https://github.com/paritytech/cargo-contract/pull/1045)
+- Minimum requirements of `ink!` dependencies all updated to `4.2.0` - [#1084](https://github.com/paritytech/cargo-contract/pull/1084)
+- Upgrade `subxt` to `0.28` [#1039](https://github.com/paritytech/cargo-contract/pull/1039)
+- Upgrade `scale-info` to `2.5` [#1057](https://github.com/paritytech/cargo-contract/pull/1057)
 
-### [2.1.0]
+### Fixed
+- Rewrites build file path in manifest [#1077](https://github.com/paritytech/cargo-contract/pull/1077)
+- Only copy and rewrite target contract manifest [#1079](https://github.com/paritytech/cargo-contract/pull/1079)
+
+
+## [2.1.0]
 
 ### Changed
 - Dry-run `instantiate`, `call` and `upload` commands by default - [#999](https://github.com/paritytech/cargo-contract/pull/999)
@@ -32,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Explicitly enable `std` feature for metadata generation [#977](https://github.com/paritytech/cargo-contract/pull/977)
 - Return artifact paths when contracts unchanged [#992](https://github.com/paritytech/cargo-contract/pull/992)
+- 
 - Minimum requirements of `ink!` dependencies all updated to `4.0.1`
 
 ## [2.0.1]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -806,7 +806,7 @@ checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "contract-build"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -850,7 +850,7 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-build"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -36,7 +36,7 @@ wasm-opt = "0.112.0"
 which = "4.4.0"
 zip = { version = "0.6.4", default-features = false }
 
-contract-metadata = { version = "2.1.0", path = "../metadata" }
+contract-metadata = { version = "2.2.0", path = "../metadata" }
 
 [build-dependencies]
 anyhow = "1.0.70"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-contract-build = { version = "2.1.0", path = "../build" }
-contract-metadata = { version = "2.1.0", path = "../metadata" }
-contract-transcode = { version = "2.1.0", path = "../transcode" }
+contract-build = { version = "2.2.0", path = "../build" }
+contract-metadata = { version = "2.2.0", path = "../metadata" }
+contract-transcode = { version = "2.2.0", path = "../transcode" }
 
 anyhow = "1.0.70"
 clap = { version = "4.2.4", features = ["derive", "env"] }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 anyhow = "1.0.70"
 base58 = { version = "0.2.0" }
 blake2 = { version = "0.10.4", default-features = false }
-contract-metadata = { version = "2.1.0", path = "../metadata" }
+contract-metadata = { version = "2.2.0", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "1.9.3"


### PR DESCRIPTION
### Added
- Add `info` command - [#993](https://github.com/paritytech/cargo-contract/pull/993)
- Add `--output-json` flag for `info` command - [#1007](https://github.com/paritytech/cargo-contract/pull/1007)

### Changed
- Minimum requirements of `ink!` dependencies all updated to `4.2.0` - [#1084](https://github.com/paritytech/cargo-contract/pull/1084)
- Upgrade `subxt` to `0.28` [#1039](https://github.com/paritytech/cargo-contract/pull/1039)
- Upgrade `scale-info` to `2.5` [#1057](https://github.com/paritytech/cargo-contract/pull/1057)

### Fixed
- Rewrites build file path in manifest [#1077](https://github.com/paritytech/cargo-contract/pull/1077)
- Only copy and rewrite target contract manifest [#1079](https://github.com/paritytech/cargo-contract/pull/1079)