### PR TITLE
Revert "Bump tracing from 0.1.37 to 0.1.38"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,10 +4821,11 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.38"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4832,13 +4833,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -25,7 +25,7 @@ impl-serde = "0.4.0"
 rustc_version = "0.4.0"
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 toml = "0.7.3"
-tracing = "0.1.38"
+tracing = "0.1.37"
 parity-wasm = "0.45.0"
 semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -24,7 +24,7 @@ contract-transcode = { version = "2.2.0", path = "../transcode" }
 
 anyhow = "1.0.70"
 clap = { version = "4.2.5", features = ["derive", "env"] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 which = "4.4.0"

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -27,7 +27,7 @@ indexmap = "1.9.3"
 ink_env = "4.2.0"
 ink_metadata = "4.2.0"
 itertools = "0.10.5"
-tracing = "0.1.38"
+tracing = "0.1.37"
 nom = "7.1.3"
 nom-supreme = { version = "0.7.0", features = ["error"] }
 primitive-types = { version = "0.12.1", default-features = false, features = ["codec", "scale-info", "serde"] }


### PR DESCRIPTION
This reverts commit 0420cb828c131e68b385e5291327270ec75aa75c.

Unfortunately, tracing 0.1.38 has yanked which blocks people install the crate, could you make a release after this revert PR merged?

About the yank: https://github.com/tokio-rs/tracing/issues/2578