### PR TITLE
Release `v3.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0]
+
 ### Added
 - Experimental support for RISC-V contracts - [#1076](https://github.com/paritytech/cargo-contract/pull/1076)
 
@@ -13,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contracts are build as `bin` crate now (we used `cdylib` before) - [#1076](https://github.com/paritytech/cargo-contract/pull/1076)
   - BREAKING CHANGE: Make sure that your contract is `no_main` by having this on top of your contract:
     - `#![cfg_attr(not(feature = "std"), no_std, no_main)]`
+- Update contracts node metadata (#1105)
+  - Compatible with `substrate-contracts-node 0.25.0-a2b09462c7c`
 
 ## [2.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Contracts are build as `bin` crate now (we used `cdylib` before) - [#1076](https://github.com/paritytech/cargo-contract/pull/1076)
   - BREAKING CHANGE: Make sure that your contract is `no_main` by having this on top of your contract:
     - `#![cfg_attr(not(feature = "std"), no_std, no_main)]`
+    - This will be detected and suggested for `error[E0601]`  [#1113](https://github.com/paritytech/cargo-contract/pull/1113)
 - Update contracts node metadata (#1105)
   - Compatible with `substrate-contracts-node 0.25.0-a2b09462c7c`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update contracts node metadata (#1105)
   - Compatible with `substrate-contracts-node 0.25.0-a2b09462c7c`
 
+### Fixed
+- Fix original Wasm artifact path [#1116](https://github.com/paritytech/cargo-contract/pull/1116)
+
 ## [2.2.1]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "2.2.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -806,7 +806,7 @@ checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "contract-build"
-version = "2.2.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "2.2.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "2.2.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-build"
-version = "2.3.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -37,7 +37,7 @@ which = "4.4.0"
 zip = { version = "0.6.5", default-features = false }
 strum = { version = "0.24", features = ["derive"] }
 
-contract-metadata = { version = "2.3.0", path = "../metadata" }
+contract-metadata = { version = "3.0.0", path = "../metadata" }
 
 [build-dependencies]
 anyhow = "1.0.71"

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-build"
-version = "2.2.1"
+version = "2.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -37,7 +37,7 @@ which = "4.4.0"
 zip = { version = "0.6.5", default-features = false }
 strum = { version = "0.24", features = ["derive"] }
 
-contract-metadata = { version = "2.2.1", path = "../metadata" }
+contract-metadata = { version = "2.3.0", path = "../metadata" }
 
 [build-dependencies]
 anyhow = "1.0.71"

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/contract-metadata"
 homepage = "https://www.substrate.io/"
 description = "Library for building ink! smart contracts"
 keywords = ["wasm", "parity", "webassembly", "blockchain", "edsl"]
-include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE", "build.rs", "templates",]
+include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE", "build.rs", "templates", "riscv_memory_layout.ld"]
 
 [dependencies]
 anyhow = "1.0.71"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "2.3.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-contract-build = { version = "2.3.0", path = "../build" }
-contract-metadata = { version = "2.3.0", path = "../metadata" }
-contract-transcode = { version = "2.3.0", path = "../transcode" }
+contract-build = { version = "3.0.0", path = "../build" }
+contract-metadata = { version = "3.0.0", path = "../metadata" }
+contract-transcode = { version = "3.0.0", path = "../transcode" }
 
 anyhow = "1.0.71"
 clap = { version = "4.2.7", features = ["derive", "env"] }

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "2.2.1"
+version = "2.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-contract-build = { version = "2.2.1", path = "../build" }
-contract-metadata = { version = "2.2.1", path = "../metadata" }
-contract-transcode = { version = "2.2.1", path = "../transcode" }
+contract-build = { version = "2.3.0", path = "../build" }
+contract-metadata = { version = "2.3.0", path = "../metadata" }
+contract-transcode = { version = "2.3.0", path = "../transcode" }
 
 anyhow = "1.0.71"
 clap = { version = "4.2.7", features = ["derive", "env"] }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "2.2.1"
+version = "2.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "2.3.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "2.3.0"
+version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 anyhow = "1.0.71"
 base58 = { version = "0.2.0" }
 blake2 = { version = "0.10.4", default-features = false }
-contract-metadata = { version = "2.3.0", path = "../metadata" }
+contract-metadata = { version = "3.0.0", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "1.9.3"

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "2.2.1"
+version = "2.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 anyhow = "1.0.71"
 base58 = { version = "0.2.0" }
 blake2 = { version = "0.10.4", default-features = false }
-contract-metadata = { version = "2.2.1", path = "../metadata" }
+contract-metadata = { version = "2.3.0", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "1.9.3"


### PR DESCRIPTION
### Added
- Experimental support for RISC-V contracts - [#1076](https://github.com/paritytech/cargo-contract/pull/1076)

### Changed
- Contracts are build as `bin` crate now (we used `cdylib` before) - [#1076](https://github.com/paritytech/cargo-contract/pull/1076)
  - BREAKING CHANGE: Make sure that your contract is `no_main` by having this on top of your contract:
    - `#![cfg_attr(not(feature = "std"), no_std, no_main)]`
    - This will be detected and suggested for `error[E0601]`  [#1113](https://github.com/paritytech/cargo-contract/pull/1113)
- Update contracts node metadata (#1105)
  - Compatible with `substrate-contracts-node 0.25.0-a2b09462c7c`

### Fixed
- Fix original Wasm artifact path [#1116](https://github.com/paritytech/cargo-contract/pull/1116)