### PR TITLE
Suggest adding `no_main` for `error[E0601]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
  "clap",
  "colored",
  "contract-metadata",
+ "duct",
  "heck",
  "hex",
  "impl-serde",
@@ -1170,6 +1171,18 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "duct"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ae3fc31835f74c2a7ceda3aeede378b0ae2e74c8f1c36559fcc9ae2a4e7d3e"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
 
 [[package]]
 name = "dyn-clonable"
@@ -2682,6 +2695,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "os_pipe"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,6 +3740,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shared_child"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0d94659ad3c2137fef23ae75b03d5241d633f8acded53d672decfa0e6e0caef"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
  "serde_json",
  "strum",
  "tempfile",
+ "term_size",
  "toml 0.7.3",
  "tracing",
  "url",
@@ -4383,6 +4384,16 @@ dependencies = [
  "redox_syscall 0.3.5",
  "rustix 0.37.4",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -19,6 +19,7 @@ blake2 = "0.10.6"
 cargo_metadata = "0.15.4"
 colored = "2.0.0"
 clap = { version = "4.2.7", features = ["derive", "env"] }
+duct = "0.13.6"
 heck = "0.4.0"
 hex = "0.4.3"
 impl-serde = "0.4.0"

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -32,6 +32,7 @@ semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1.0.96"
 tempfile = "3.5.0"
+term_size = "0.3.2"
 url = { version = "2.3.1", features = ["serde"] }
 wasm-opt = "0.112.0"
 which = "4.4.0"

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -346,7 +346,7 @@ fn invoke_cargo_and_scan_for_error(cargo: duct::Expression) -> Result<()> {
         if missing_main_err == err_buf.make_contiguous() {
             eprintln!(
                 "\n\n{}",
-                "Ensure the contract is annotated with `no_main` e.g.:"
+                "Ensure the contract is annotated with `no_main`, e.g.:"
                     .bright_yellow()
                     .bold()
             );

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -343,16 +343,17 @@ fn invoke_cargo_and_scan_for_error(cargo: duct::Expression) -> Result<()> {
 
     loop {
         let bytes_read = io::Read::read(&mut reader, &mut buffer)?;
-        io::Write::write(&mut io::stderr(), &buffer[0..bytes_read])?;
         for byte in buffer[0..bytes_read].iter() {
             err_buf.push_back(*byte);
             if err_buf.len() > missing_main_err.len() {
-                err_buf.pop_front();
+                let byte = err_buf.pop_front().expect("buffer is not empty");
+                io::Write::write(&mut io::stderr(), &[byte])?;
             }
         }
         if missing_main_err == err_buf.make_contiguous() {
+            eprintln!("\nExited with error: [E0601]");
             eprintln_red!(
-                ": Your contract must be annotated with the `no_main` attribute."
+                "Your contract must be annotated with the `no_main` attribute.\n"
             );
             eprintln_red!("Examples how to do this:");
             eprintln_red!("   - `#![cfg_attr(not(feature = \"std\"), no_std, no_main)]`");

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -565,6 +565,7 @@ fn assert_compatible_ink_dependencies(
         let args = ["-i", dependency, "--duplicates"];
         let cargo = util::cargo_cmd("tree", args, manifest_path.directory(), verbosity, vec![]);
         cargo
+            .stdout_null()
             .run()
             .with_context(|| {
                 format!(

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -351,7 +351,7 @@ fn invoke_cargo_and_scan_for_error(cargo: duct::Expression) -> Result<()> {
             }
         }
         if missing_main_err == err_buf.make_contiguous() {
-            eprintln!("\nExited with error: [E0601]");
+            eprintln_red!("\nExited with error: [E0601]");
             eprintln_red!(
                 "Your contract must be annotated with the `no_main` attribute.\n"
             );

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -149,16 +149,17 @@ pub(crate) fn execute(
         network.append_to_args(&mut args);
         features.append_to_args(&mut args);
 
-        let stdout = util::invoke_cargo(
+        let cmd = util::cargo_cmd(
             "run",
             args,
             crate_metadata.manifest_path.directory(),
             verbosity,
             vec![],
-        )?;
+        );
+        let output = cmd.stdout_capture().run()?;
 
         let ink_meta: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_slice(&stdout)?;
+            serde_json::from_slice(&output.stdout)?;
         let metadata = ContractMetadata::new(source, contract, user, ink_meta);
         {
             let mut metadata = metadata.clone();

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -93,11 +93,14 @@ where
 
 /// Configures the cargo command to output colour and the progress bar.
 pub fn cargo_tty_output(cmd: Expression) -> Expression {
-    // let term_size = term_size::dimensions_stderr()
-    //     .map(|(width, _)| width.to_string())
-    //     .unwrap_or_else(|| "100".to_string());
-    use term_size::dimensions_stderr;
+    #[cfg(windows)]
     let term_size = "100";
+
+    #[cfg(not(windows))]
+    let term_size = term_size::dimensions_stderr()
+        .map(|(width, _)| width.to_string())
+        .unwrap_or_else(|| "100".to_string());
+
     cmd.env("CARGO_TERM_COLOR", "always")
         .env("CARGO_TERM_PROGRESS_WIDTH", term_size)
         .env("CARGO_TERM_PROGRESS_WHEN", "always")

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -94,6 +94,7 @@ where
 /// Configures the cargo command to output colour and the progress bar.
 pub fn cargo_tty_output(cmd: Expression) -> Expression {
     #[cfg(windows)]
+    use term_size as _;
     let term_size = "100";
 
     #[cfg(not(windows))]

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -24,6 +24,7 @@ use std::{
     ffi::OsString,
     path::Path,
 };
+use term_size as _;
 
 // Returns the current Rust toolchain formatted by `<channel>-<target-triple>`.
 pub(crate) fn rust_toolchain() -> Result<String> {
@@ -94,7 +95,6 @@ where
 /// Configures the cargo command to output colour and the progress bar.
 pub fn cargo_tty_output(cmd: Expression) -> Expression {
     #[cfg(windows)]
-    use term_size as _;
     let term_size = "100";
 
     #[cfg(not(windows))]

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -56,6 +56,7 @@ where
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let mut cmd_args = Vec::new();
 
+    cmd_args.push(command);
     cmd_args.push("--color=always");
 
     match verbosity {

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -96,6 +96,7 @@ pub fn cargo_tty_output(cmd: Expression) -> Expression {
     // let term_size = term_size::dimensions_stderr()
     //     .map(|(width, _)| width.to_string())
     //     .unwrap_or_else(|| "100".to_string());
+    use term_size::dimensions_stderr;
     let term_size = "100";
     cmd.env("CARGO_TERM_COLOR", "always")
         .env("CARGO_TERM_PROGRESS_WIDTH", term_size)

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -91,6 +91,13 @@ where
     cmd
 }
 
+/// Configures the cargo command to output colour and the progress bar.
+pub fn cargo_tty_output(cmd: Expression) -> Expression {
+    cmd.env("CARGO_TERM_COLOR", "always")
+        .env("CARGO_TERM_PROGRESS_WIDTH", "100")
+        .env("CARGO_TERM_PROGRESS_WHEN", "always")
+}
+
 /// Returns the base name of the path.
 pub(crate) fn base_name(path: &Path) -> &str {
     path.file_name()

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -96,8 +96,7 @@ pub fn cargo_tty_output(cmd: Expression) -> Expression {
     let term_size = term_size::dimensions_stderr()
         .map(|(width, _)| width.to_string())
         .unwrap_or_else(|| "100".to_string());
-    cmd
-        .env("CARGO_TERM_COLOR", "always")
+    cmd.env("CARGO_TERM_COLOR", "always")
         .env("CARGO_TERM_PROGRESS_WIDTH", term_size)
         .env("CARGO_TERM_PROGRESS_WHEN", "always")
 }

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -93,9 +93,10 @@ where
 
 /// Configures the cargo command to output colour and the progress bar.
 pub fn cargo_tty_output(cmd: Expression) -> Expression {
-    let term_size = term_size::dimensions_stderr()
-        .map(|(width, _)| width.to_string())
-        .unwrap_or_else(|| "100".to_string());
+    // let term_size = term_size::dimensions_stderr()
+    //     .map(|(width, _)| width.to_string())
+    //     .unwrap_or_else(|| "100".to_string());
+    let term_size = "100";
     cmd.env("CARGO_TERM_COLOR", "always")
         .env("CARGO_TERM_PROGRESS_WIDTH", term_size)
         .env("CARGO_TERM_PROGRESS_WHEN", "always")

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -93,8 +93,12 @@ where
 
 /// Configures the cargo command to output colour and the progress bar.
 pub fn cargo_tty_output(cmd: Expression) -> Expression {
-    cmd.env("CARGO_TERM_COLOR", "always")
-        .env("CARGO_TERM_PROGRESS_WIDTH", "100")
+    let term_size = term_size::dimensions_stderr()
+        .map(|(width, _)| width.to_string())
+        .unwrap_or_else(|| "100".to_string());
+    cmd
+        .env("CARGO_TERM_COLOR", "always")
+        .env("CARGO_TERM_PROGRESS_WIDTH", term_size)
         .env("CARGO_TERM_PROGRESS_WHEN", "always")
 }
 


### PR DESCRIPTION
Since https://github.com/paritytech/cargo-contract/pull/1076, `no_main` is now required. This PR adds a suggestion in case of the error `error[E0601]: `main` function not found in crate...

This is the result:
![image](https://github.com/paritytech/cargo-contract/assets/75586/0b1d2b70-2150-4c01-a746-c46b40227f1c)

Note that the suggestion must appear *before* the compiler error because we can't know for sure how many lines the error message will encompass, so we just print it first.

Introduces [duct](https://docs.rs/duct/latest/duct/) which allows for easily building command expressions and working with capturing the `stdout` and `stderr`.

## Maintaing the progress bar

An earlier iteration was using `BufReader::lines` to read the captured `stderr` and check for the error code for the missing main function. However this came with the downside of the familiar progress bar (see below) not being displayed.

![image](https://github.com/paritytech/cargo-contract/assets/75586/8dfdf27d-bde3-4ca5-a45a-78ce7a23192f)

I have been able to get that to work again with some hacking. The result involves reading the reader one byte at a time and redirecting that straight to `stderr`, while maintaining a small buffer to check for the known error. I am aware that this is not the most efficient way, but it was the only way to get the progress bar displaying as it does when not capturing `stderr`.