### PR TITLE
Fix original Wasm artifact path

### DIFF
--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -105,7 +105,7 @@ impl CrateMetadata {
         let mut original_code = target_directory.clone();
         original_code.push(target.llvm_target());
         original_code.push("release");
-        original_code.push(package_name.clone());
+        original_code.push(root_package.name.clone());
         original_code.set_extension(target.source_extension());
 
         // {target_dir}/{package_name}.code


### PR DESCRIPTION
The original code `.wasm` file is the same as the unmodified package name, e.g. `basic-contract-caller`. It was using the normalized one with underscores `basic_contract_caller`