### PR TITLE
`[contract-build]` flush the remaining buffered bytes.

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -361,6 +361,8 @@ fn invoke_cargo_and_scan_for_error(cargo: duct::Expression) -> Result<()> {
             return Err(anyhow::anyhow!("missing `no_main` attribute"))
         }
         if bytes_read == 0 {
+            // flush the remaining buffered bytes
+            io::Write::write(&mut io::stderr(), &err_buf.make_contiguous())?;
             break
         }
         buffer = [0u8; 1];


### PR DESCRIPTION
Fixes #1117. Formatting of errors works again:

![image](https://github.com/paritytech/cargo-contract/assets/75586/9e338a3d-04eb-4f97-a36b-82c497d2f912)
