### PR TITLE
Release `v3.0.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1]
+
+### Fixed
+- `[contract-build]` flush the remaining buffered bytes [1118](https://github.com/paritytech/cargo-contract/pull/1118)
+
 ## [3.0.0]
 
 ### Added

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-build"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -39,7 +39,7 @@ which = "4.4.0"
 zip = { version = "0.6.6", default-features = false }
 strum = { version = "0.24", features = ["derive"] }
 
-contract-metadata = { version = "3.0.0", path = "../metadata" }
+contract-metadata = { version = "3.0.1", path = "../metadata" }
 
 [build-dependencies]
 anyhow = "1.0.71"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-contract-build = { version = "3.0.0", path = "../build" }
-contract-metadata = { version = "3.0.0", path = "../metadata" }
-contract-transcode = { version = "3.0.0", path = "../transcode" }
+contract-build = { version = "3.0.1", path = "../build" }
+contract-metadata = { version = "3.0.1", path = "../metadata" }
+contract-transcode = { version = "3.0.1", path = "../transcode" }
 
 anyhow = "1.0.71"
 clap = { version = "4.2.7", features = ["derive", "env"] }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 anyhow = "1.0.71"
 base58 = { version = "0.2.0" }
 blake2 = { version = "0.10.4", default-features = false }
-contract-metadata = { version = "3.0.0", path = "../metadata" }
+contract-metadata = { version = "3.0.1", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "1.9.3"


### PR DESCRIPTION
### Fixed
- `[contract-build]` flush the remaining buffered bytes [1118](https://github.com/paritytech/cargo-contract/pull/1118)