### PR TITLE
Make output format of cargo contract info consistent with other subcommands

### DIFF
--- a/crates/cargo-contract/src/cmd/info.rs
+++ b/crates/cargo-contract/src/cmd/info.rs
@@ -21,11 +21,11 @@ use super::{
 };
 use crate::{
     cmd::{
+        extrinsics::MAX_KEY_COL_WIDTH,
         runtime_api::api::runtime_types::pallet_contracts::storage::ContractInfo,
         Balance,
         CodeHash,
         ErrorVariant,
-        extrinsics::{MAX_KEY_COL_WIDTH}
     },
     name_value_println,
 };
@@ -130,8 +130,16 @@ impl InfoToJson {
     /// Display contract information in a formatted way
     pub fn basic_display_format_contract_info(&self) {
         name_value_println!("TrieId", format!("{}", self.trie_id), MAX_KEY_COL_WIDTH);
-        name_value_println!("Code Hash", format!("{:?}", self.code_hash), MAX_KEY_COL_WIDTH);
-        name_value_println!("Storage Items", format!("{:?}", self.storage_items), MAX_KEY_COL_WIDTH);
+        name_value_println!(
+            "Code Hash",
+            format!("{:?}", self.code_hash),
+            MAX_KEY_COL_WIDTH
+        );
+        name_value_println!(
+            "Storage Items",
+            format!("{:?}", self.storage_items),
+            MAX_KEY_COL_WIDTH
+        );
         name_value_println!(
             "Storage Deposit",
             format!("{:?}", self.storage_item_deposit),

--- a/crates/cargo-contract/src/cmd/info.rs
+++ b/crates/cargo-contract/src/cmd/info.rs
@@ -25,6 +25,7 @@ use crate::{
         Balance,
         CodeHash,
         ErrorVariant,
+        extrinsics::{MAX_KEY_COL_WIDTH}
     },
     name_value_println,
 };
@@ -128,12 +129,13 @@ impl InfoToJson {
 
     /// Display contract information in a formatted way
     pub fn basic_display_format_contract_info(&self) {
-        name_value_println!("TrieId:", format!("{}", self.trie_id));
-        name_value_println!("Code hash:", format!("{:?}", self.code_hash));
-        name_value_println!("Storage items:", format!("{:?}", self.storage_items));
+        name_value_println!("TrieId", format!("{}", self.trie_id), MAX_KEY_COL_WIDTH);
+        name_value_println!("Code Hash", format!("{:?}", self.code_hash), MAX_KEY_COL_WIDTH);
+        name_value_println!("Storage Items", format!("{:?}", self.storage_items), MAX_KEY_COL_WIDTH);
         name_value_println!(
-            "Storage deposit:",
-            format!("{:?}", self.storage_item_deposit)
+            "Storage Deposit",
+            format!("{:?}", self.storage_item_deposit),
+            MAX_KEY_COL_WIDTH
         );
     }
 }


### PR DESCRIPTION
Change in the function basic_display_format_contract_info() to make the command `cargo contract info` use the same output format with other subcommands.
Fix of the Issue: https://github.com/paritytech/cargo-contract/issues/1112

Output:
<img width="610" alt="Screenshot 2023-05-19 at 11 26 27" src="https://github.com/paritytech/cargo-contract/assets/15804380/8aeff594-afda-46ed-bafa-6b7fc6f459ea">

