### PR TITLE
Show Gas consumption by default for dry-runs

### DIFF
--- a/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
@@ -467,6 +467,11 @@ impl InstantiateDryRunResult {
             DEFAULT_KEY_COL_WIDTH
         );
         name_value_println!("Data", format!("{:?}", self.data), DEFAULT_KEY_COL_WIDTH);
+        name_value_println!(
+            "Gas limit",
+            self.gas_consumed.to_string(),
+            DEFAULT_KEY_COL_WIDTH
+        );
     }
 }
 

--- a/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
@@ -468,7 +468,7 @@ impl InstantiateDryRunResult {
         );
         name_value_println!("Data", format!("{:?}", self.data), DEFAULT_KEY_COL_WIDTH);
         name_value_println!(
-            "Gas limit",
+            "Gas consumed",
             self.gas_consumed.to_string(),
             DEFAULT_KEY_COL_WIDTH
         );


### PR DESCRIPTION
Modify the output in `cargo contract instantiate ` to show the gas consumed estimated when dry-run.
Fix the issue https://github.com/paritytech/cargo-contract/issues/1021

Output:
<img width="470" alt="Screenshot 2023-05-19 at 15 57 17" src="https://github.com/paritytech/cargo-contract/assets/15804380/55c7af5b-9b9f-42e1-83c1-e80f4243575e">

