### PR TITLE
Dry-run result output improvements

### DIFF
--- a/crates/cargo-contract/src/cmd/extrinsics/call.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/call.rs
@@ -119,7 +119,7 @@ impl CallCommand {
                 match result.result {
                     Ok(ref ret_val) => {
                         let value = transcoder
-                            .decode_return(&self.message, &mut &ret_val.data[..])
+                            .decode_message_return(&self.message, &mut &ret_val.data[..])
                             .context(format!(
                                 "Failed to decode return value {:?}",
                                 &ret_val
@@ -329,6 +329,6 @@ impl CallDryRunResult {
             format!("{:?}", self.reverted),
             DEFAULT_KEY_COL_WIDTH
         );
-        name_value_println!("Data", format!("{}", self.data), DEFAULT_KEY_COL_WIDTH);
+        name_value_println!("Returned", format!("{}", self.data), DEFAULT_KEY_COL_WIDTH);
     }
 }

--- a/crates/cargo-contract/src/cmd/extrinsics/call.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/call.rs
@@ -125,7 +125,6 @@ impl CallCommand {
                                 &ret_val
                             ))?;
                         let dry_run_result = CallDryRunResult {
-                            result: String::from("Success!"),
                             reverted: ret_val.did_revert(),
                             data: value,
                             gas_consumed: result.gas_consumed,
@@ -305,8 +304,6 @@ pub struct CallRequest {
 /// Result of the contract call
 #[derive(serde::Serialize)]
 pub struct CallDryRunResult {
-    /// Result of a dry run
-    pub result: String,
     /// Was the operation reverted
     pub reverted: bool,
     pub data: Value,
@@ -323,12 +320,11 @@ impl CallDryRunResult {
     }
 
     pub fn print(&self) {
-        name_value_println!("Result", self.result, DEFAULT_KEY_COL_WIDTH);
+        name_value_println!("Result", format!("{}", self.data), DEFAULT_KEY_COL_WIDTH);
         name_value_println!(
             "Reverted",
             format!("{:?}", self.reverted),
             DEFAULT_KEY_COL_WIDTH
         );
-        name_value_println!("Returned", format!("{}", self.data), DEFAULT_KEY_COL_WIDTH);
     }
 }

--- a/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/instantiate.rs
@@ -212,10 +212,9 @@ impl Exec {
                             &ret_val
                         ))?;
                     let dry_run_result = InstantiateDryRunResult {
-                        result: String::from("Success!"),
+                        result: value,
                         contract: ret_val.account_id.to_string(),
                         reverted: ret_val.result.did_revert(),
-                        data: value,
                         gas_consumed: result.gas_consumed,
                         gas_required: result.gas_required,
                         storage_deposit: StorageDeposit::from(&result.storage_deposit),
@@ -451,13 +450,12 @@ impl InstantiateResult {
 /// Result of the contract call
 #[derive(serde::Serialize)]
 pub struct InstantiateDryRunResult {
-    /// Result of a dry run
-    pub result: String,
+    /// The decoded result returned from the constructor
+    pub result: Value,
     /// contract address
     pub contract: String,
     /// Was the operation reverted
     pub reverted: bool,
-    pub data: Value,
     pub gas_consumed: Weight,
     pub gas_required: Weight,
     /// Storage deposit after the operation
@@ -471,14 +469,13 @@ impl InstantiateDryRunResult {
     }
 
     pub fn print(&self) {
-        name_value_println!("Result", self.result, DEFAULT_KEY_COL_WIDTH);
-        name_value_println!("Contract", self.contract, DEFAULT_KEY_COL_WIDTH);
+        name_value_println!("Result", format!("{}", self.result), DEFAULT_KEY_COL_WIDTH);
         name_value_println!(
             "Reverted",
             format!("{:?}", self.reverted),
             DEFAULT_KEY_COL_WIDTH
         );
-        name_value_println!("Returned", format!("{}", self.data), DEFAULT_KEY_COL_WIDTH);
+        name_value_println!("Contract", self.contract, DEFAULT_KEY_COL_WIDTH);
     }
 }
 


### PR DESCRIPTION
## Instantiate

- Replace useless "`Success!`" field with actual decoded data (it will be the decoded `Result<Result<(), _>>`).

Before:
![image](https://github.com/paritytech/cargo-contract/assets/75586/875833a2-859d-45df-ab10-ee1d46fd63d7)

After (The `Bytes` has now been decoded into `Ok()`)
![image](https://github.com/paritytech/cargo-contract/assets/75586/ffec5e36-51dd-436a-992e-0d93ff2d2509)

## Call

Similarly, replaced the useless `"Success!"` with the decoded data.

Before:
![image](https://github.com/paritytech/cargo-contract/assets/75586/1671a1a1-e605-480d-acbd-2db4e8c01c1f)

After:
![image](https://github.com/paritytech/cargo-contract/assets/75586/f45e7d0f-059e-48b1-933d-50b02ac50dab)

