### PR TITLE
feat: use `CARGO_ENCODED_RUSTFLAGS` instead of `RUSTFLAGS`

### DIFF
--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -190,10 +190,10 @@ impl Target {
         }
     }
 
-    /// Target specific flags to be set to `RUSTFLAGS` while building.
+    /// Target specific flags to be set to `CARGO_ENCODED_RUSTFLAGS` while building.
     pub fn rustflags(&self) -> &'static str {
         match self {
-            Self::Wasm => "-C link-arg=-zstack-size=65536 -C link-arg=--import-memory -Clinker-plugin-lto -C target-cpu=mvp",
+            Self::Wasm => "-C\x1flink-arg=-zstack-size=65536\x1f-C\x1flink-arg=--import-memory\x1f-Clinker-plugin-lto\x1f-C\x1ftarget-cpu=mvp",
             Self::RiscV => "-Clinker-plugin-lto",
         }
     }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -282,12 +282,12 @@ fn exec_cargo_for_onchain_target(
             fs::write(&path, include_bytes!("../riscv_memory_layout.ld"))?;
             let path = path.display();
             env.push((
-                "RUSTFLAGS",
+                "CARGO_ENCODED_RUSTFLAGS",
                 Some(format!("{rustflags} -Clink-arg=-T{path}",)),
             ));
             Some(path)
         } else {
-            env.push(("RUSTFLAGS", Some(rustflags.to_string())));
+            env.push(("CARGO_ENCODED_RUSTFLAGS", Some(rustflags.to_string())));
             None
         };
 


### PR DESCRIPTION
## Summary
Use `CARGO_ENCODED_RUSTFLAGS` instead of `RUSTFLAGS` in `contract-build` crate. This does not affect/break anything.

## Why?
I wanted to use `contract-build` inside cargo build script for compiling ink! contract fixtures for testing, here is a example build script - https://github.com/AstarNetwork/Astar/blob/e148ddf271577b4e36662afe4b9ec820c235a384/tests/xcm-simulator/build.rs. But with the current use of `RUSTFLAGS` it's not possible.

Since with Rust 1.55.0, `RUSTFLAGS` is not set for build scripts - https://github.com/rust-lang/cargo/issues/10111.  On top of that when [cross-compiling (in our case `wasm32-unknown-unknown`), cargo does not apply `RUSTFLAGS` for build scripts _by design_](https://github.com/rust-lang/cargo/issues/4423). That means `RUSTFLAGS` will totally be ignored in build script environment, that includes setting env from inside build script.

## Solution
Simply use `CARGO_ENCODED_RUSTFLAGS` instead - https://github.com/rust-lang/cargo/issues/10111#issuecomment-976892083