### PR TITLE
Add flag -y as a shortcut for --skip-confirm

### DIFF
--- a/crates/cargo-contract/src/cmd/extrinsics/integration_tests.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/integration_tests.rs
@@ -201,8 +201,6 @@ async fn build_upload_instantiate_call() {
         .expect("failed to execute process");
     let stdout = str::from_utf8(&output.stdout).unwrap();
     let stderr = str::from_utf8(&output.stderr).unwrap();
-    println!("{:?}", stdout);
-    println!("{:?}", stderr);
     assert!(output.status.success(), "instantiate failed: {stderr}");
 
     let contract_account = extract_contract_address(stdout);


### PR DESCRIPTION
PR for this issue: Add flag -y that says Yes to every prompt (https://github.com/paritytech/cargo-contract/issues/1062)

It adds `-y` as a shortcut for `--skip-confirm`. 
Examplo of use:
`cargo contract instantiate --suri //Alice --constructor new  --args true -x -y` instead of `cargo contract instantiate --suri //Alice --constructor new  --args true -x --skip-confirm`