### PR TITLE
Configurable max memory pages

### DIFF
--- a/crates/build/README.md
+++ b/crates/build/README.md
@@ -35,6 +35,7 @@ let args = contract_build::ExecuteArgs {
     output_type: OutputType::Json,
     skip_wasm_validation: false,
     target: Target::Wasm,
+    max_memory_pages: 16,
 };
 
 contract_build::execute(args);

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -95,14 +95,14 @@ use std::{
 };
 use strum::IntoEnumIterator;
 
-/// This is the maximum number of pages available for a contract to allocate.
-const MAX_MEMORY_PAGES: u32 = 16;
+/// This is the default maximum number of pages available for a contract to allocate.
+pub const DEFAULT_MAX_MEMORY_PAGES: u32 = 16;
 
 /// Version of the currently executing `cargo-contract` binary.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Arguments to use when executing `build` or `check` commands.
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct ExecuteArgs {
     /// The location of the Cargo manifest (`Cargo.toml`) file to use.
     pub manifest_path: ManifestPath,
@@ -118,6 +118,28 @@ pub struct ExecuteArgs {
     pub output_type: OutputType,
     pub skip_wasm_validation: bool,
     pub target: Target,
+    pub max_memory_pages: u32,
+}
+
+impl Default for ExecuteArgs {
+    fn default() -> Self {
+        Self {
+            manifest_path: Default::default(),
+            verbosity: Default::default(),
+            build_mode: Default::default(),
+            features: Default::default(),
+            network: Default::default(),
+            build_artifact: Default::default(),
+            unstable_flags: Default::default(),
+            optimization_passes: Default::default(),
+            keep_debug_symbols: Default::default(),
+            lint: Default::default(),
+            output_type: Default::default(),
+            skip_wasm_validation: Default::default(),
+            target: Default::default(),
+            max_memory_pages: DEFAULT_MAX_MEMORY_PAGES,
+        }
+    }
 }
 
 /// Result of the build process.
@@ -512,7 +534,7 @@ fn ensure_maximum_memory_pages(
         }
     } else {
         let initial = mem_ty.limits().initial();
-        *mem_ty = MemoryType::new(initial, Some(MAX_MEMORY_PAGES));
+        *mem_ty = MemoryType::new(initial, Some(maximum_allowed_pages));
     }
 
     Ok(())
@@ -559,13 +581,14 @@ fn post_process_wasm(
     crate_metadata: &CrateMetadata,
     skip_wasm_validation: bool,
     verbosity: &Verbosity,
+    max_memory_pages: u32,
 ) -> Result<()> {
     // Deserialize Wasm module from a file.
     let mut module = load_module(&crate_metadata.original_code)
         .context("Loading of original wasm failed")?;
 
     strip_exports(&mut module);
-    ensure_maximum_memory_pages(&mut module, MAX_MEMORY_PAGES)?;
+    ensure_maximum_memory_pages(&mut module, max_memory_pages)?;
     strip_custom_sections(&mut module);
 
     if !skip_wasm_validation {
@@ -654,6 +677,7 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
         output_type,
         skip_wasm_validation,
         target,
+        max_memory_pages,
     } = args;
 
     // The CLI flag `optimization-passes` overwrites optimization passes which are
@@ -793,7 +817,12 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
 
             match target {
                 Target::Wasm => {
-                    post_process_wasm(&crate_metadata, skip_wasm_validation, &verbosity)?;
+                    post_process_wasm(
+                        &crate_metadata,
+                        skip_wasm_validation,
+                        &verbosity,
+                        max_memory_pages,
+                    )?;
                     let handler =
                         WasmOptHandler::new(optimization_passes, keep_debug_symbols)?;
                     handler.optimize(

--- a/crates/build/src/tests.rs
+++ b/crates/build/src/tests.rs
@@ -168,6 +168,7 @@ fn optimization_passes_from_cli_must_take_precedence_over_profile(
         output_type: OutputType::Json,
         skip_wasm_validation: false,
         target: Default::default(),
+        ..Default::default()
     };
 
     // when
@@ -210,6 +211,7 @@ fn optimization_passes_from_profile_must_be_used(
         output_type: OutputType::Json,
         skip_wasm_validation: false,
         target: Default::default(),
+        ..Default::default()
     };
 
     // when

--- a/crates/cargo-contract/src/cmd/build.rs
+++ b/crates/cargo-contract/src/cmd/build.rs
@@ -118,6 +118,9 @@ pub struct BuildCommand {
     /// Which bytecode to build the contract into.
     #[clap(long, default_value = "wasm")]
     target: Target,
+    /// The maximum number of pages available for a wasm contract to allocate.
+    #[clap(long, default_value_t = contract_build::DEFAULT_MAX_MEMORY_PAGES)]
+    max_memory_pages: u32,
 }
 
 impl BuildCommand {
@@ -161,6 +164,7 @@ impl BuildCommand {
             output_type,
             skip_wasm_validation: self.skip_wasm_validation,
             target: self.target,
+            max_memory_pages: self.max_memory_pages,
         };
 
         contract_build::execute(args)
@@ -204,6 +208,7 @@ impl CheckCommand {
             output_type: OutputType::default(),
             skip_wasm_validation: false,
             target: self.target,
+            max_memory_pages: 0,
         };
 
         contract_build::execute(args)


### PR DESCRIPTION
This PR adds and command line argument `--max-memory-pages` to `cargo contract build`.

## Background
Contracts on Phala Networks are allowed to use up to 4MB of memory. `cargo-contract` did enforce the wasm to set max pages to 16. That would cause a build error when our contracts use larger memory:
```
 [3/5] Optimizing wasm file
[wasm-validator error in module] unexpected true: memory max >= initial, on 
memory
ERROR: Failed to validate wasm: error validating input
```