### PR TITLE
Relates to #674. Add `suri_path` and `password_path` options to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.2]
+
+### Added
+- Add `suri-path` and `password-path` options for `cargo contract` commands including `upload`, `instantiate`, `call`, and `remove` - [#998](TBC)
+
 ## [3.0.1]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -806,7 +806,7 @@ checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "contract-build"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-build"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -39,7 +39,7 @@ which = "4.4.0"
 zip = { version = "0.6.6", default-features = false }
 strum = { version = "0.24", features = ["derive"] }
 
-contract-metadata = { version = "3.0.1", path = "../metadata" }
+contract-metadata = { version = "3.0.2", path = "../metadata" }
 
 [build-dependencies]
 anyhow = "1.0.71"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-contract-build = { version = "3.0.1", path = "../build" }
-contract-metadata = { version = "3.0.1", path = "../metadata" }
-contract-transcode = { version = "3.0.1", path = "../transcode" }
+contract-build = { version = "3.0.2", path = "../build" }
+contract-metadata = { version = "3.0.2", path = "../metadata" }
+contract-transcode = { version = "3.0.2", path = "../transcode" }
 
 anyhow = "1.0.71"
 clap = { version = "4.3.0", features = ["derive", "env"] }

--- a/crates/cargo-contract/src/cmd/extrinsics/integration_tests.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/integration_tests.rs
@@ -336,6 +336,8 @@ async fn build_upload_instantiate_info() {
     let stderr = str::from_utf8(&output.stderr).unwrap();
     assert!(output.status.success(), "upload code failed: {stderr}");
 
+    // TODO - add tests for `suri-path` and `password-path`
+
     let output = cargo_contract(project_path.as_path())
         .arg("instantiate")
         .args(["--constructor", "new"])

--- a/crates/cargo-contract/src/cmd/extrinsics/mod.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/mod.rs
@@ -171,38 +171,18 @@ impl ExtrinsicOpts {
             // TODO - replace with `Ok` from `anyhow` throughout if possible
             // instead of using `std::result::Result`
             std::result::Result::Ok(d) => {
-                println!("d is {:#?}", d);
-                // // get suri_path
-                // let sp = match &d.suri_path {
-                //     // TODO - figure out how to avoid using `.clone`
-                //     Some(sp) => sp.as_path().display().to_string(),
-                //     None => anyhow::bail!("suri path not provided"),
-                // };
-                // println!("sp is {:#?}", sp);
-
-                // // get password_path
-                // let pp = match &d.password_path {
-                //     // TODO - figure out how to avoid using `.clone`
-                //     Some(pp) => Some(pp.as_path().display().to_string()),
-                //     None => anyhow::bail!("password path not provided"),
-                // };
-                // println!("pp is {:#?}", pp);
-
                 // get suri
                 let suri = match &d.suri {
                     // remove newline characters
                     Some(s) => s.trim().to_string(),
                     None => anyhow::bail!("suri not provided"),
                 };
-                println!("suri is {:#?}", suri);
-
                 // get password
                 let password = match &d.password {
                     // remove newline characters
                     Some(p) => Some(p.trim().to_string()),
                     None => anyhow::bail!("password not provided"),
                 };
-                println!("password is {:#?}", password);
                 return Pair::from_string(&suri, password.as_ref().map(String::as_ref))
                     .map_err(|_| anyhow::anyhow!("Secret string error"))
             },
@@ -321,7 +301,7 @@ impl SuriData {
                                 }
                             };
                         } else {
-                            println!("suri file does not exist");
+                            anyhow::bail!("suri file does not exist")
                         }
                         suri = match s.suri() {
                             std::result::Result::Ok(s) => s.to_string(),
@@ -365,7 +345,6 @@ impl SuriData {
                             }
                         };
                         let p = Password(Some(_p));
-
                         let dir = pp.parent().map_or_else(PathBuf::new, PathBuf::from);
                         let metadata_path = dir.join(format!("{file_name}.txt"));
                         if metadata_path.exists() {
@@ -376,7 +355,7 @@ impl SuriData {
                                 }
                             };
                         } else {
-                            println!("password file does not exist");
+                            anyhow::bail!("password file does not exist")
                         }
                         password = match p.password() {
                             std::result::Result::Ok(p) => p.to_string(),

--- a/crates/cargo-contract/src/cmd/extrinsics/mod.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/mod.rs
@@ -186,7 +186,7 @@ impl ExtrinsicOpts {
                 return Pair::from_string(&suri, password.as_ref().map(String::as_ref))
                     .map_err(|_| anyhow::anyhow!("Secret string error"))
             },
-            std::result::Result::Err(_e) => anyhow::bail!("suri data not provided {}", _e),
+            std::result::Result::Err(_e) => anyhow::bail!("suri data not provided. {}", _e),
         };
     }
 
@@ -286,7 +286,7 @@ impl SuriData {
                             std::result::Result::Ok(s) => s,
                             std::result::Result::Err(_e) => {
                                 anyhow::bail!(
-                                    "unable to convert Vec<u8> to String for suri_path {}", _e
+                                    "unable to convert Vec<u8> to String for suri_path. {}", _e
                                 )
                             }
                         };
@@ -297,7 +297,7 @@ impl SuriData {
                             suri = match s.suri() {
                                 std::result::Result::Ok(s) => s.to_string(),
                                 std::result::Result::Err(_e) => {
-                                    anyhow::bail!("unable to get value for Suri {}", _e)
+                                    anyhow::bail!("unable to get value for Suri. {}", _e)
                                 }
                             };
                         } else {
@@ -306,7 +306,7 @@ impl SuriData {
                         suri = match s.suri() {
                             std::result::Result::Ok(s) => s.to_string(),
                             std::result::Result::Err(_e) => {
-                                anyhow::bail!("unable to get value for Suri {}", _e)
+                                anyhow::bail!("unable to get value for Suri. {}", _e)
                             }
                         };
                     }
@@ -340,7 +340,7 @@ impl SuriData {
                             std::result::Result::Ok(p) => p,
                             std::result::Result::Err(_e) => {
                                 anyhow::bail!(
-                                    "unable to convert Vec<u8> to String for password_path {}", _e
+                                    "unable to convert Vec<u8> to String for password_path. {}", _e
                                 )
                             }
                         };
@@ -351,7 +351,7 @@ impl SuriData {
                             password = match p.password() {
                                 std::result::Result::Ok(p) => p.to_string(),
                                 std::result::Result::Err(_e) => {
-                                    anyhow::bail!("unable to get value for Password {}", _e)
+                                    anyhow::bail!("unable to get value for Password. {}", _e)
                                 }
                             };
                         } else {
@@ -360,7 +360,7 @@ impl SuriData {
                         password = match p.password() {
                             std::result::Result::Ok(p) => p.to_string(),
                             std::result::Result::Err(_e) => {
-                                anyhow::bail!("unable to get value for Password {}", _e)
+                                anyhow::bail!("unable to get value for Password. {}", _e)
                             }
                         };
                     }

--- a/crates/cargo-contract/src/cmd/extrinsics/mod.rs
+++ b/crates/cargo-contract/src/cmd/extrinsics/mod.rs
@@ -167,46 +167,47 @@ impl ExtrinsicOpts {
 
     /// Returns the signer for contract extrinsics.
     pub fn signer(&self) -> Result<sr25519::Pair> {
-        let s_binding = "".to_string();
-        let mut suri = match &self.suri {
-            // TODO - figure out how to avoid using `.clone`
-            Some(s) => s.clone(),
-            None => s_binding,
-        };
-        let p_binding = "".to_string();
-        let mut password = match &self.password {
-            // TODO - figure out how to avoid using `.clone`
-            Some(p) => Some(p.clone()),
-            None => Some(p_binding),
-        };
-        // Allow empty string password
-        if !suri.trim().is_empty() {
-            Pair::from_string(&suri, password.as_ref().map(String::as_ref))
-                .map_err(|_| anyhow::anyhow!("Secret string error"))
-        } else {
-            match &self.suri_data() {
-                // TODO - replace with `Ok` from `anyhow` throughout if possible
-                // instead of using `std::result::Result`
-                std::result::Result::Ok(d) => {
-                    // get suri from suri_path
-                    suri = match &d.suri_path {
-                        // TODO - figure out how to avoid using `.clone`
-                        Some(s) => s.as_path().display().to_string(),
-                        None => anyhow::bail!("suri path not provided"),
-                    };
-                    // get password from password_path
-                    password = match &d.password_path {
-                        // TODO - figure out how to avoid using `.clone`
-                        Some(p) => Some(p.as_path().display().to_string()),
-                        None => anyhow::bail!("password path not provided"),
-                    };
-                    return Pair::from_string(&suri, password.as_ref().map(String::as_ref))
-                        .map_err(|_| anyhow::anyhow!("Secret string error"))
-                },
-                std::result::Result::Err(_e) => anyhow::bail!("suri data not provided {}", _e),
-            };
-        }
+        match &self.suri_data() {
+            // TODO - replace with `Ok` from `anyhow` throughout if possible
+            // instead of using `std::result::Result`
+            std::result::Result::Ok(d) => {
+                println!("d is {:#?}", d);
+                // // get suri_path
+                // let sp = match &d.suri_path {
+                //     // TODO - figure out how to avoid using `.clone`
+                //     Some(sp) => sp.as_path().display().to_string(),
+                //     None => anyhow::bail!("suri path not provided"),
+                // };
+                // println!("sp is {:#?}", sp);
 
+                // // get password_path
+                // let pp = match &d.password_path {
+                //     // TODO - figure out how to avoid using `.clone`
+                //     Some(pp) => Some(pp.as_path().display().to_string()),
+                //     None => anyhow::bail!("password path not provided"),
+                // };
+                // println!("pp is {:#?}", pp);
+
+                // get suri
+                let suri = match &d.suri {
+                    // remove newline characters
+                    Some(s) => s.trim().to_string(),
+                    None => anyhow::bail!("suri not provided"),
+                };
+                println!("suri is {:#?}", suri);
+
+                // get password
+                let password = match &d.password {
+                    // remove newline characters
+                    Some(p) => Some(p.trim().to_string()),
+                    None => anyhow::bail!("password not provided"),
+                };
+                println!("password is {:#?}", password);
+                return Pair::from_string(&suri, password.as_ref().map(String::as_ref))
+                    .map_err(|_| anyhow::anyhow!("Secret string error"))
+            },
+            std::result::Result::Err(_e) => anyhow::bail!("suri data not provided {}", _e),
+        };
     }
 
     /// Returns the verbosity

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 anyhow = "1.0.71"
 base58 = { version = "0.2.0" }
 blake2 = { version = "0.10.4", default-features = false }
-contract-metadata = { version = "3.0.1", path = "../metadata" }
+contract-metadata = { version = "3.0.2", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "1.9.3"

--- a/docs/extrinsics.md
+++ b/docs/extrinsics.md
@@ -20,9 +20,19 @@ development and testnets. It is a priority to implement a safer method of signin
 bearing chains.
 
 ```
+--suri-path
+```
+*Optional*. The path to a file containing the secret key URI for the account interacting with the contract.
+
+```
 --password
 ```
 *Optional*. The password for the `--suri`, see https://docs.substrate.io/v3/tools/subkey/#password-protected-keys.
+
+```
+--password-path
+```
+*Optional*. The path to a file containing the password for the secret key URI.
 
 ```
 --manifest-path
@@ -55,6 +65,15 @@ Upload the Wasm code of the contract to the target chain. Invokes the [`upload_c
 dispatchable.
 
 e.g. `cargo contract upload --suri //Alice`
+
+e.g.
+```
+cargo contract upload \
+       --suri-path ../path/to/my-secret-key-uri-file.txt \
+       --password-path ../path/to/my-secret-key-uri-password-file.txt
+```
+- `--suri-path` the path to a file containing the secret key URI for the account interacting with the contract.
+- `--password-path` the path to a file containing the password for the secret key URI.
 
 Assumes that `cargo contract build` has already been run to produce the contract artifacts.
 


### PR DESCRIPTION
 **Proposed changes**
This PR relates to issue #674 and #1106 and updates the CLI options available to allow loading the suri and password from plain text .txt files so users can avoid having to enter values in the terminal. It could be changed so they can read from any file even if it doesn't have an extension.

**Usage**
* Run a [substrate-contracts-node](https://github.com/paritytech/substrate-contracts-node/) on ws://127.0.0.1:9944 (e.g. this codebase allows you to run it in a Docker container https://github.com/ltfschoen/InkTemplate, and if necessary delete the chain db and restart the node by running `docker exec -it ink /app/docker/reset.sh`)

* Run the following to deploy a Flipper contract, where the `contract upload` command reads the suri and password from associated text files with file extension .txt. 
```bash
touch my-suri.txt && echo "//Alice" > my-suri.txt
touch my-password.txt && echo "" > my-password.txt
cargo build
cargo run -p cargo-contract contract new flipper
```
* Move the ./flipper folder out of the workspace
```
mv ./flipper ../
```
```
cargo run -p cargo-contract contract build --manifest-path /path_to_flipper/Cargo.toml
cargo run -p cargo-contract contract upload --suri-path my-suri.txt --password-path my-password.txt --manifest-path /path_to_flipper/Cargo.toml
```
**Important note**: The purpose of this PR is so the user can run CLI commands that read sensitive information from a file, where they'd open a text editor and enter the sensitive information in them that way and then read from the files with CLI commands, and then delete those files after using them. That way they can avoid entering the suri and password in the terminal window where hackers may gain access to it from terminal history logs, but only for demonstration purposes I'm the example suri and password via the terminal with `echo "//Alice" > my-suri.txt` and echo "" > my-password.txt.

**Verified it works with the following functionality**:
* If you you're running a local [substrate-contracts-node](https://github.com/paritytech/substrate-contracts-node/) on ws://127.0.0.1:9944 and then run the following:
```bash
touch my-suri.txt && echo "//Alice" > my-suri.txt
touch my-password.txt && echo "" > my-password.txt
cargo build
cargo run -p cargo-contract contract new flipper
cargo run -p cargo-contract contract build --manifest-path ./flipper/Cargo.toml
cargo run -p cargo-contract contract upload --suri-path my-suri.txt --password-path my-password.txt --manifest-path ./flipper/Cargo.toml
```
then it outputs the following:
```bash
      Result Success!
   Code hash "0x______"
     Deposit ___
Your upload call has not been executed.
To submit the transaction and execute the call on chain, add -x/--execute flag to the command.
```
* If you do the same as in the previous step but you change the contents of my-suri.txt to be `//Alice\n` instead of `//Alice` to simulate what would happen if we weren't applying `.trim()` when reading the file contents, then it outputs the following since it thinks it's dealing with a different account that wouldn't have sufficient funds to upload. Likewise, if you change the my-password.txt file from not having a password (default for Alice's built-in account) to having a password, then it also outputs the following:
```bash
Result ModuleError: Contracts::StorageDepositNotEnoughFunds: ["Origin doesn't have enough balance to pay the required storage deposits."]
```
* If you provide both `--suri` and `--suri-path` it outputs the following since in the code we've set `multiple(false)` to the `ArgGroup` called `"surigroup"`
```bash
error: the argument '--suri <suri>' cannot be used with '--suri-path <suri-path>'

Usage: cargo contract upload --suri <suri> --password-path <password-path> --manifest-path <MANIFEST_PATH> [FILE]
```
* If you provide both `--password` and `--password-path` it outputs the following since in the code we've set `multiple(false)` to the `ArgGroup` called `"passgroup"`
```bash
error: the argument '--password <password>' cannot be used with '--password-path <password-path>'

Usage: cargo contract upload --password <password> --suri-path <suri-path> --manifest-path <MANIFEST_PATH> [FILE]
```
* If you provide a file containing the password for `--password-path` but it doesn't have an extension, then it'll output error:
```bash
ERROR: suri data not provided. password path has no extension, expected `.txt`
```
* If you provide a file containing the suri for `--suri-path` but it doesn't have an extension, then it'll output error:
```bash
ERROR: suri data not provided. suri path has no extension, expected `.txt`
```

**Further considerations:**

* Something worth considering is whether to change it from:
  * `--suri-path` to `--suri-file-path`
  * `--password-path` to `--password-file-path`

* There are numerous `TODO`'s, so any feedback on how to approach those in addition to general review would be appreciated.

* Maybe the `Suri` and `Password` struct types could be used better.