### PR TITLE
Relates to #530. Detect network status and allow running `cargo contract build` when offline.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "heck",
  "hex",
  "impl-serde",
+ "online",
  "parity-scale-codec",
  "parity-wasm",
  "pretty_assertions",
@@ -2676,6 +2677,12 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "online"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b1fb38eaf6c33f63feced1355536f223bc2e849cfe50c91ca79ee706f968e1"
 
 [[package]]
 name = "opaque-debug"

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -27,6 +27,7 @@ rustc_version = "0.4.0"
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 toml = "0.7.4"
 tracing = "0.1.37"
+online = "4.0.1"
 parity-wasm = "0.45.0"
 semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -16,6 +16,7 @@
 
 use anyhow::Result;
 use clap::Args;
+use online::check;
 use std::{
     convert::TryFrom,
     fmt,
@@ -78,9 +79,17 @@ pub enum Network {
 }
 
 impl Network {
+    /// Returns the current network status
+    pub fn network_status(&self) -> Self {
+        match check(None) {
+            Ok(_) => Self::Online,
+            _ => Self::Offline
+        }
+    }
+
     /// If `Network::Offline` append the `--offline` flag for cargo invocations.
     pub fn append_to_args(&self, args: &mut Vec<String>) {
-        match self {
+        match self.network_status() {
             Self::Online => (),
             Self::Offline => args.push("--offline".to_owned()),
         }


### PR DESCRIPTION
**Proposed changes**
This PR relates to issue https://github.com/paritytech/cargo-contract/issues/530.
Previously when it determined whether to append the `--network` option it never would because `Network::Online` was set as default state, so whenever it'd check `match self` in `Network::append_to_args` function it would always return https://github.com/paritytech/cargo-contract/blob/master/crates/build/src/args.rs#L84.
The new functionality checks the internet status using the Rust library https://docs.rs/online/latest/online/

**Usage**
* Run a [substrate-contracts-node](https://github.com/paritytech/substrate-contracts-node/) on ws://127.0.0.1:9944 (e.g. this codebase allows you to run it in a Docker container https://github.com/ltfschoen/InkTemplate, and if necessary delete the chain db and restart the node by running `docker exec -it ink /app/docker/reset.sh`)

* Run the following to build a Flipper contract after running `https://github.com/paritytech/cargo-contract && cd cargo-contract`:
```bash
cargo build
cargo run -p cargo-contract contract new flipper
```
* Move the ./flipper folder out of the workspace
```
mv ./flipper ../
cargo run -p cargo-contract contract build --manifest-path /path_to_flipper/Cargo.toml
```

**Important note**: the PR doesn't include updating the CI stage as mentioned here https://github.com/paritytech/cargo-contract/issues/530#issuecomment-1114439665. Would that just require adding an extra line `cargo run --profile debug-ci -- contract build --offline --manifest-path=${{ runner.temp }}/foobar/Cargo.toml &&` [here](https://github.com/paritytech/cargo-contract/blob/master/.github/workflows/ci.yml#L196)?

**Verify it works**
* Turn off internet connection and run `cargo run -p cargo-contract contract build --manifest-path ./flipper/Cargo.toml` and it should output `The contract was built`
* Turn on internet connection and run the same thing and it should still output `The contract was built`