### PR TITLE
:t-rex: pin jobs which build contracts to Rust `1.69`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ on:
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'
-env:
-  # Pinned to 1.69 for building contracts because of https://github.com/paritytech/cargo-contract/issues/1139
-  INK_RUST_TOOLCHAIN: 1.69
 
 jobs:
   fmt:
@@ -140,7 +137,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "$INK_RUST_TOOLCHAIN"
+          # Pinned to 1.69 for building contracts because of https://github.com/paritytech/cargo-contract/issues/1139
+          toolchain: 1.69
           default: true
           target: wasm32-unknown-unknown
           components: rust-src
@@ -184,7 +182,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "$INK_RUST_TOOLCHAIN"
+          # Pinned to 1.69 for building contracts because of https://github.com/paritytech/cargo-contract/issues/1139
+          toolchain: 1.69
           default: true
           target: wasm32-unknown-unknown
           components: rust-src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: $INK_RUST_TOOLCHAIN
+          toolchain: "$INK_RUST_TOOLCHAIN"
           default: true
           target: wasm32-unknown-unknown
           components: rust-src
@@ -184,7 +184,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: $INK_RUST_TOOLCHAIN
+          toolchain: "$INK_RUST_TOOLCHAIN"
           default: true
           target: wasm32-unknown-unknown
           components: rust-src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'
+env:
+  # Pinned to 1.69 for building contracts because of https://github.com/paritytech/cargo-contract/issues/1139
+  INK_RUST_TOOLCHAIN: 1.69
+
 jobs:
   fmt:
     runs-on: ubuntu-latest
@@ -136,7 +140,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: $INK_RUST_TOOLCHAIN
           default: true
           target: wasm32-unknown-unknown
           components: rust-src
@@ -180,7 +184,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: $INK_RUST_TOOLCHAIN
           default: true
           target: wasm32-unknown-unknown
           components: rust-src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'
-
 jobs:
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes CI jobs while https://github.com/paritytech/cargo-contract/issues/1139 is unnresolved