### PR TITLE
Suggest valid message or constructor name, when misspelled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,7 @@ dependencies = [
  "serde_json",
  "sp-core 18.0.0",
  "sp-keyring",
+ "strsim",
  "thiserror",
  "tracing",
 ]

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -36,6 +36,7 @@ scale-info = { version = "2.4.0", default-features = false, features = ["derive"
 serde = { version = "1.0.159", default-features = false, features = ["derive"] }
 serde_json = "1.0.95"
 thiserror = "1.0.40"
+strsim = "0.10.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -225,7 +225,7 @@ impl ContractMessageTranscoder {
                 let possible_values: Vec<_> = constructors.chain(messages).collect();
                 let help_txt = did_you_mean(name, possible_values.clone())
                     .first()
-                    .map(|suggestion| format!("Did you mean '{}'", suggestion))
+                    .map(|suggestion| format!("Did you mean '{}'?", suggestion))
                     .unwrap_or_else(|| {
                         format!("Should be one of: {}", possible_values.iter().join(", "))
                     });
@@ -573,7 +573,7 @@ mod tests {
         let transcoder = ContractMessageTranscoder::new(metadata);
         assert_eq!(
             transcoder.encode("fip", ["true"]).unwrap_err().to_string(),
-            "No constructor or message with the name 'fip' found.\nDid you mean 'flip'"
+            "No constructor or message with the name 'fip' found.\nDid you mean 'flip'?"
         );
     }
 

--- a/crates/transcode/src/lib.rs
+++ b/crates/transcode/src/lib.rs
@@ -157,7 +157,7 @@ pub struct ContractMessageTranscoder {
 /// Returns a Vec of all possible values that exceed a similarity threshold
 /// sorted by ascending similarity, most similar comes last
 /// Extracted from https://github.com/clap-rs/clap/blob/v4.3.4/clap_builder/src/parser/features/suggestions.rs#L11-L26
-pub(crate) fn did_you_mean<T, I>(v: &str, possible_values: I) -> Vec<String>
+fn did_you_mean<T, I>(v: &str, possible_values: I) -> Vec<String>
 where
     T: AsRef<str>,
     I: IntoIterator<Item = T>,


### PR DESCRIPTION
Suggest a valid message or constructor name when the user misspell it. 
If there are no close match, it will display the full list of available messages / constructors. 
This can be helpful when messages are namespaced and the user input it with the correct case


![Screenshot 2023-06-14 at 21 10 44](https://github.com/paritytech/cargo-contract/assets/521091/8dc1b9f1-f30f-428f-86a2-b2b7eaaf0104)

