### PR TITLE
fix(build): An error when running with `--lint`

### DIFF
--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -58,7 +58,9 @@ where
     let mut cmd_args = Vec::new();
 
     cmd_args.push(command);
-    cmd_args.push("--color=always");
+    if command != "dylint" {
+        cmd_args.push("--color=always");
+    }
 
     match verbosity {
         Verbosity::Quiet => cmd_args.push("--quiet"),


### PR DESCRIPTION
After this fix it is possible to run `dylint` with the linting library.

For example, to run the linter on the flipper contract we can use the following in the `ink` directory:
```
cd integration-tests/flipper/
DYLINT_LIBRARY_PATH="$(realpath ../../linting/target/debug)" cargo contract build --lint
```

It works, and we can test new lints using this.

Closes #1166