### PR TITLE
Enable Wasm sign_ext

### DIFF
--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -27,7 +27,7 @@ rustc_version = "0.4.0"
 scale = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 toml = "0.7.5"
 tracing = "0.1.37"
-parity-wasm = "0.45.0"
+parity-wasm = { version = "0.45.0", features = ["sign_ext"] }
 semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = "1.0.99"

--- a/crates/build/src/wasm_opt.rs
+++ b/crates/build/src/wasm_opt.rs
@@ -15,7 +15,10 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use anyhow::Result;
-use wasm_opt::OptimizationOptions;
+use wasm_opt::{
+    Feature,
+    OptimizationOptions,
+};
 
 use std::{
     fmt,
@@ -65,10 +68,9 @@ impl WasmOptHandler {
         );
 
         OptimizationOptions::from(self.optimization_level)
-            // Binaryen (and wasm-opt) now enables the `SignExt` and `MutableGlobals`
-            // features by default, so we want to disable those for now since
-            // `pallet-contracts` still needs to enable these.
+            // Since rustc 1.70 `SignExt` can't be disabled anymore. Hence we have to allow it.
             .mvp_features_only()
+            .enable_feature(Feature::SignExt)
             // the memory in our module is imported, `wasm-opt` needs to be told that
             // the memory is initialized to zeroes, otherwise it won't run the
             // memory-packing pre-pass.


### PR DESCRIPTION
Since Rustc 1.70 we can't disable signed extension anymore. Hence we have to allow it in order to keep functioning. Eventually, we want to remove the `parity-wasm` dependency but for now we can just enable the `sign_ext` feature.

Please note that those contracts will not deploy on `pallet-contracts`, yet. Support is coming soon.