### PR TITLE
Configure tty output correctly

### DIFF
--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -104,9 +104,9 @@ pub fn cargo_tty_output(cmd: Expression) -> Expression {
         .map(|(width, _)| width.to_string())
         .unwrap_or_else(|| "100".to_string());
 
-    cmd.env("CARGO_TERM_COLOR", "always")
+    cmd.env("CARGO_TERM_COLOR", "auto")
         .env("CARGO_TERM_PROGRESS_WIDTH", term_size)
-        .env("CARGO_TERM_PROGRESS_WHEN", "always")
+        .env("CARGO_TERM_PROGRESS_WHEN", "auto")
 }
 
 /// Returns the base name of the path.


### PR DESCRIPTION
Previously `--output-json` and `--quiet` flag still produced some compilation status output due to misconfigured tty output. This PR provides a fix.