### PR TITLE
Suggestions for PR #1148: verifiable build docker interaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,19 +708,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "unicode-width",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,7 +728,6 @@ dependencies = [
  "heck",
  "hex",
  "impl-serde",
- "indicatif",
  "parity-scale-codec",
  "parity-wasm",
  "pretty_assertions",
@@ -1237,12 +1223,6 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
@@ -1847,19 +1827,6 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff8cc23a7393a397ed1d7f56e6365cba772aba9f9912ab968b03043c395d057"
-dependencies = [
- "console",
- "instant",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
 ]
 
 [[package]]
@@ -2593,12 +2560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2805,12 +2766,6 @@ name = "platforms"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
-
-[[package]]
-name = "portable-atomic"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,9 +1223,9 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -2025,7 +2025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.3",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -2992,7 +2992,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata 0.3.2",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -3012,7 +3012,7 @@ checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -3023,9 +3023,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rend"
@@ -3160,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -3185,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.3"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
@@ -4333,9 +4333,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
+checksum = "df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0"
 
 [[package]]
 name = "tempfile"
@@ -4513,7 +4513,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.3",
+ "rustls 0.21.5",
  "tokio",
 ]
 

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -108,4 +108,4 @@ COPY --from=cc-builder /usr/local/cargo/bin/cargo-contract /usr/local/bin/cargo-
 WORKDIR /contract
 
 # default entry point
-ENTRYPOINT ["cargo", "contract", "build", "--release"]
+ENTRYPOINT ["cargo", "contract"]

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -42,7 +42,6 @@ strum = { version = "0.25", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 bollard = "0.14"
-indicatif = "0.17"
 
 contract-metadata = { version = "3.0.1", path = "../metadata" }
 

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -132,7 +132,14 @@ pub fn docker_build(args: ExecuteArgs) -> Result<BuildResult> {
                 }
             };
 
-            pull_image(client.clone(), &image, &verbosity, &mut build_steps).await?;
+            if let Err(err) = pull_image(client.clone(), &image, &verbosity, &mut build_steps).await {
+                // If the image could not be pulled, we will still attempt to use a local image of
+                // that name if it exists.
+                eprintln!(
+                    "{}",
+                    format!("Failed to pull the docker image {}: {}", image, err).yellow().bold(),
+                );
+            }
 
             let build_result = run_build(
                 args,

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -171,7 +171,7 @@ fn update_metadata(
 
     metadata.image = Some(build_image.to_owned());
 
-    crate::metadata::write_metadata(&metadata_artifacts, metadata, build_steps, verbosity)
+    crate::metadata::write_metadata(metadata_artifacts, metadata, build_steps, verbosity)
 }
 
 /// Creates the container, returning the container id if successful.
@@ -179,7 +179,7 @@ fn update_metadata(
 /// If the image is not available locally, it will be pulled from the registry.
 async fn create_container(
     client: &Docker,
-    build_args: String,
+    _build_args: String, // todo: add the build args to the cmd
     build_image: &str,
     contract_name: &str,
     host_folder: &Path,
@@ -274,12 +274,12 @@ async fn run_build(
     build_steps: &mut BuildSteps,
 ) -> Result<BuildResult> {
     client
-        .start_container::<String>(&container_id, None)
+        .start_container::<String>(container_id, None)
         .await?;
 
     let AttachContainerResults { mut output, .. } = client
         .attach_container(
-            &container_id,
+            container_id,
             Some(AttachContainerOptions::<String> {
                 stdout: Some(true),
                 stderr: Some(true),
@@ -324,8 +324,8 @@ async fn run_build(
     // remove the container after the run is finished
     // todo: mount a volume with crates.io index to speed up build in new container on the
     // next run.
-    let _ = client
-        .remove_container(&container_id, None)
+    client
+        .remove_container(container_id, None)
         .await
         .context(format!("Error removing container {}", container_id))?;
 

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -53,9 +53,7 @@ use bollard::{
         CreateContainerOptions,
         LogOutput,
     },
-    image::{
-        CreateImageOptions,
-    },
+    image::CreateImageOptions,
     service::{
         HostConfig,
         Mount,
@@ -132,12 +130,16 @@ pub fn docker_build(args: ExecuteArgs) -> Result<BuildResult> {
                 }
             };
 
-            if let Err(err) = pull_image(client.clone(), &image, &verbosity, &mut build_steps).await {
-                // If the image could not be pulled, we will still attempt to use a local image of
-                // that name if it exists.
+            if let Err(err) =
+                pull_image(client.clone(), &image, &verbosity, &mut build_steps).await
+            {
+                // If the image could not be pulled, we will still attempt to use a local
+                // image of that name if it exists.
                 eprintln!(
                     "{}",
-                    format!("Failed to pull the docker image {}: {}", image, err).yellow().bold(),
+                    format!("Failed to pull the docker image {}: {}", image, err)
+                        .yellow()
+                        .bold(),
                 );
             }
 
@@ -156,12 +158,7 @@ pub fn docker_build(args: ExecuteArgs) -> Result<BuildResult> {
                 dest_bundle: crate_metadata.contract_bundle_path(),
             };
 
-            update_metadata(
-                &metadata_artifacts,
-                &verbosity,
-                &mut build_steps,
-                &image,
-            )?;
+            update_metadata(&metadata_artifacts, &verbosity, &mut build_steps, &image)?;
 
             Ok(BuildResult {
                 output_type,
@@ -286,9 +283,10 @@ async fn run_build(
     while let Some(Ok(output)) = output.next().await {
         match output {
             LogOutput::StdOut { message } => {
-                build_result =
-                    Some(serde_json::from_reader(BufReader::new(message.as_ref()))
-                        .context("Error decoding BuildResult"));
+                build_result = Some(
+                    serde_json::from_reader(BufReader::new(message.as_ref()))
+                        .context("Error decoding BuildResult"),
+                );
             }
             LogOutput::StdErr { message } => {
                 stderr.write_all(message.as_ref())?;
@@ -302,8 +300,11 @@ async fn run_build(
     }
 
     // remove the container after the run is finished
-    // todo: mount a volume with crates.io index to speed up build in new container on the next run.
-    let _ = client.remove_container(&container_id, None).await
+    // todo: mount a volume with crates.io index to speed up build in new container on the
+    // next run.
+    let _ = client
+        .remove_container(&container_id, None)
+        .await
         .context(format!("Error removing container {}", container_id))?;
 
     if let Some(build_result) = build_result {

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -35,12 +35,7 @@
 
 use std::{
     collections::{
-        hash_map::DefaultHasher,
         HashMap,
-    },
-    hash::{
-        Hash,
-        Hasher,
     },
     io::{
         BufReader,
@@ -489,19 +484,4 @@ async fn pull_image(
     }
 
     Ok(())
-}
-
-/// Calculates the unique container's code
-fn container_digest(entrypoint: Vec<String>, image_digest: String) -> String {
-    // in order to optimise the container usage
-    // we are hashing the inputted command
-    // in order to reuse the container for the same permutation of arguments
-    let mut s = DefaultHasher::new();
-    // the data is set of commands and args and the image digest
-    let data = (entrypoint, image_digest);
-    data.hash(&mut s);
-    let digest = s.finish();
-    // taking the first 5 digits to be a unique identifier
-    let digest_code: String = digest.to_string().chars().take(5).collect();
-    digest_code
 }

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -294,6 +294,10 @@ async fn run_build(
         }
     }
 
+    // remove the container after the run is finished
+    let _ = client.remove_container(&container_id, None).await
+        .context(format!("Error removing container {}", container_id))?;
+
     if let Some(build_result) = build_result {
         build_result
     } else {

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -295,6 +295,7 @@ async fn run_build(
     }
 
     // remove the container after the run is finished
+    // todo: mount a volume with crates.io index to speed up build in new container on the next run.
     let _ = client.remove_container(&container_id, None).await
         .context(format!("Error removing container {}", container_id))?;
 

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -273,9 +273,7 @@ async fn run_build(
     verbosity: &Verbosity,
     build_steps: &mut BuildSteps,
 ) -> Result<BuildResult> {
-    client
-        .start_container::<String>(container_id, None)
-        .await?;
+    client.start_container::<String>(container_id, None).await?;
 
     let AttachContainerResults { mut output, .. } = client
         .attach_container(

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -150,7 +150,7 @@ impl Default for ExecuteArgs {
 }
 
 /// Result of the build process.
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Default)] // todo: remove
 pub struct BuildResult {
     /// Path to the resulting Wasm file.
     pub dest_wasm: Option<PathBuf>,

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -127,7 +127,7 @@ pub fn decode_hex(input: &str) -> Result<Vec<u8>, hex::FromHexError> {
 macro_rules! maybe_println {
     ($verbosity:expr, $($msg:tt)*) => {
         if $verbosity.is_verbose() {
-            ::std::println!($($msg)*);
+            ::std::eprintln!($($msg)*);
         }
     };
 }

--- a/crates/cargo-contract/src/cmd/build.rs
+++ b/crates/cargo-contract/src/cmd/build.rs
@@ -136,7 +136,7 @@ impl BuildCommand {
         let manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
         let unstable_flags: UnstableFlags =
             TryFrom::<&UnstableOptions>::try_from(&self.unstable_options)?;
-        let mut verbosity = TryFrom::<&VerbosityFlags>::try_from(&self.verbosity)?;
+        let verbosity = TryFrom::<&VerbosityFlags>::try_from(&self.verbosity)?;
 
         let build_mode = if self.verifiable {
             BuildMode::Verifiable
@@ -165,11 +165,6 @@ impl BuildCommand {
             Some(i) => ImageVariant::Custom(i.clone()),
             None => ImageVariant::Default,
         };
-
-        // We want to ensure that the only thing in `STDOUT` is our JSON formatted string.
-        if matches!(output_type, OutputType::Json) {
-            verbosity = Verbosity::Quiet;
-        }
 
         let args = ExecuteArgs {
             manifest_path,


### PR DESCRIPTION
Demonstrating some partially completed suggestions for https://github.com/paritytech/cargo-contract/pull/1148#pullrequestreview-1524627396.

In order to work you need to build a local image with e.g. `docker build . -t local --build-arg CARGO_CONTRACT_GIT=https://github.com/paritytech/cargo-contract --build-arg CARGO_CONTRACT_BRANCH=aj/verifiable-build`. This will install the version of `cargo-contract` from this branch, which is necessary so that the `stdout` and `stderr` are correctly piped.

## todo
- [ ] mount dir with `crates.io` index to avoid downloading index for newly spawned container.
- [ ] display pull image progress bar properly, need to clear previous cursor
- [ ] Sort out build steps.