### PR TITLE
Display build progress with `--output-json`, print to `stderr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Dry-run result output improvements [1123](https://github.com/paritytech/cargo-contract/pull/1123)
+- Display build progress with --output-json, print to stderr [1211](https://github.com/paritytech/cargo-contract/pull/1211)
 
 ### Fixed
 - Configure tty output correctly - [#1209]((https://github.com/paritytech/cargo-contract/pull/1209))

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -299,7 +299,7 @@ fn exec_cargo_for_onchain_target(
 
         // newer rustc versions might emit unsupported instructions
         if rustc_version::version_meta()?.semver >= Version::new(1, 70, 0) {
-            maybe_println!(
+            verbose_println!(
                 verbosity,
                 "{} {}",
                 "warning:".yellow().bold(),
@@ -334,7 +334,7 @@ fn exec_cargo_for_onchain_target(
     };
 
     if unstable_flags.original_manifest {
-        maybe_println!(
+        verbose_println!(
             verbosity,
             "{} {}",
             "warning:".yellow().bold(),
@@ -606,7 +606,7 @@ fn post_process_wasm(
     if !skip_wasm_validation {
         validate_wasm::validate_import_section(&module)?;
     } else {
-        maybe_println!(
+        verbose_println!(
             verbosity,
             " {}",
             "Skipping wasm validation! Contract code may be invalid."
@@ -718,7 +718,7 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
         let total_steps = build_artifact.steps();
         if lint {
             steps.set_total_steps(total_steps + 1);
-            maybe_println!(
+            verbose_println!(
                 verbosity,
                 " {} {}",
                 format!("{steps}").bold(),
@@ -738,7 +738,7 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
             let mut build_steps = BuildSteps::new();
             let pre_fingerprint = Fingerprint::new(&crate_metadata)?;
 
-            maybe_println!(
+            verbose_println!(
                 verbosity,
                 " {} {}",
                 format!("{build_steps}").bold(),
@@ -808,7 +808,7 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
 
             maybe_lint(&mut build_steps)?;
 
-            maybe_println!(
+            verbose_println!(
                 verbosity,
                 " {} {}",
                 format!("{build_steps}").bold(),
@@ -873,7 +873,7 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
             let mut build_steps = BuildSteps::new();
             maybe_lint(&mut build_steps)?;
 
-            maybe_println!(
+            verbose_println!(
                 verbosity,
                 " {} {}",
                 format!("{build_steps}").bold(),

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -299,8 +299,7 @@ fn exec_cargo_for_onchain_target(
 
         // newer rustc versions might emit unsupported instructions
         if rustc_version::version_meta()?.semver >= Version::new(1, 70, 0) {
-            verbose_println!(
-                verbosity,
+            eprintln!(
                 "{} {}",
                 "warning:".yellow().bold(),
                 "You are using a rustc version that might emit unsupported wasm instructions. Build using a version lower than 1.70.0 to make sure your contract will deploy."
@@ -334,7 +333,7 @@ fn exec_cargo_for_onchain_target(
     };
 
     if unstable_flags.original_manifest {
-        verbose_println!(
+        verbose_eprintln!(
             verbosity,
             "{} {}",
             "warning:".yellow().bold(),
@@ -606,7 +605,7 @@ fn post_process_wasm(
     if !skip_wasm_validation {
         validate_wasm::validate_import_section(&module)?;
     } else {
-        verbose_println!(
+        verbose_eprintln!(
             verbosity,
             " {}",
             "Skipping wasm validation! Contract code may be invalid."
@@ -718,7 +717,7 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
         let total_steps = build_artifact.steps();
         if lint {
             steps.set_total_steps(total_steps + 1);
-            verbose_println!(
+            verbose_eprintln!(
                 verbosity,
                 " {} {}",
                 format!("{steps}").bold(),
@@ -738,7 +737,7 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
             let mut build_steps = BuildSteps::new();
             let pre_fingerprint = Fingerprint::new(&crate_metadata)?;
 
-            verbose_println!(
+            verbose_eprintln!(
                 verbosity,
                 " {} {}",
                 format!("{build_steps}").bold(),
@@ -808,7 +807,7 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
 
             maybe_lint(&mut build_steps)?;
 
-            verbose_println!(
+            verbose_eprintln!(
                 verbosity,
                 " {} {}",
                 format!("{build_steps}").bold(),
@@ -873,7 +872,7 @@ pub fn execute(args: ExecuteArgs) -> Result<BuildResult> {
             let mut build_steps = BuildSteps::new();
             maybe_lint(&mut build_steps)?;
 
-            verbose_println!(
+            verbose_eprintln!(
                 verbosity,
                 " {} {}",
                 format!("{build_steps}").bold(),

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -17,8 +17,8 @@
 use crate::{
     code_hash,
     crate_metadata::CrateMetadata,
-    verbose_println,
     util,
+    verbose_eprintln,
     workspace::{
         ManifestPath,
         Workspace,
@@ -128,7 +128,7 @@ pub(crate) fn execute(
     } = extended_metadata(crate_metadata, final_contract_wasm, build_info)?;
 
     let generate_metadata = |manifest_path: &ManifestPath| -> Result<()> {
-        verbose_println!(
+        verbose_eprintln!(
             verbosity,
             " {} {}",
             format!("{build_steps}").bold(),
@@ -169,7 +169,7 @@ pub(crate) fn execute(
             build_steps.increment_current();
         }
 
-        verbose_println!(
+        verbose_eprintln!(
             verbosity,
             " {} {}",
             format!("{build_steps}").bold(),

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -17,7 +17,7 @@
 use crate::{
     code_hash,
     crate_metadata::CrateMetadata,
-    maybe_println,
+    verbose_println,
     util,
     workspace::{
         ManifestPath,
@@ -128,7 +128,7 @@ pub(crate) fn execute(
     } = extended_metadata(crate_metadata, final_contract_wasm, build_info)?;
 
     let generate_metadata = |manifest_path: &ManifestPath| -> Result<()> {
-        maybe_println!(
+        verbose_println!(
             verbosity,
             " {} {}",
             format!("{build_steps}").bold(),
@@ -169,7 +169,7 @@ pub(crate) fn execute(
             build_steps.increment_current();
         }
 
-        maybe_println!(
+        verbose_println!(
             verbosity,
             " {} {}",
             format!("{build_steps}").bold(),

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -122,12 +122,13 @@ pub fn decode_hex(input: &str) -> Result<Vec<u8>, hex::FromHexError> {
     hex::decode(input.trim_start_matches("0x"))
 }
 
-/// Prints to stdout if `verbosity.is_verbose()` is `true`.
+/// Prints to stderr if `verbosity.is_verbose()` is `true`.
+/// Like `cargo`, we use stderr for verbose output.
 #[macro_export]
 macro_rules! maybe_println {
     ($verbosity:expr, $($msg:tt)*) => {
         if $verbosity.is_verbose() {
-            ::std::println!($($msg)*);
+            ::std::eprintln!($($msg)*);
         }
     };
 }

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -125,7 +125,7 @@ pub fn decode_hex(input: &str) -> Result<Vec<u8>, hex::FromHexError> {
 /// Prints to stderr if `verbosity.is_verbose()` is `true`.
 /// Like `cargo`, we use stderr for verbose output.
 #[macro_export]
-macro_rules! maybe_println {
+macro_rules! verbose_println {
     ($verbosity:expr, $($msg:tt)*) => {
         if $verbosity.is_verbose() {
             ::std::eprintln!($($msg)*);

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -125,7 +125,7 @@ pub fn decode_hex(input: &str) -> Result<Vec<u8>, hex::FromHexError> {
 /// Prints to stderr if `verbosity.is_verbose()` is `true`.
 /// Like `cargo`, we use stderr for verbose output.
 #[macro_export]
-macro_rules! verbose_println {
+macro_rules! verbose_eprintln {
     ($verbosity:expr, $($msg:tt)*) => {
         if $verbosity.is_verbose() {
             ::std::eprintln!($($msg)*);

--- a/crates/cargo-contract/src/cmd/build.rs
+++ b/crates/cargo-contract/src/cmd/build.rs
@@ -128,7 +128,7 @@ impl BuildCommand {
         let manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
         let unstable_flags: UnstableFlags =
             TryFrom::<&UnstableOptions>::try_from(&self.unstable_options)?;
-        let mut verbosity = TryFrom::<&VerbosityFlags>::try_from(&self.verbosity)?;
+        let verbosity = TryFrom::<&VerbosityFlags>::try_from(&self.verbosity)?;
 
         let build_mode = match self.build_release {
             true => BuildMode::Release,

--- a/crates/cargo-contract/src/cmd/build.rs
+++ b/crates/cargo-contract/src/cmd/build.rs
@@ -145,11 +145,6 @@ impl BuildCommand {
             false => OutputType::HumanReadable,
         };
 
-        // We want to ensure that the only thing in `STDOUT` is our JSON formatted string.
-        if matches!(output_type, OutputType::Json) {
-            verbosity = Verbosity::Quiet;
-        }
-
         let args = ExecuteArgs {
             manifest_path,
             verbosity,


### PR DESCRIPTION
Extracted from https://github.com/paritytech/cargo-contract/pull/1210.

Adding as standalone PR to ensure there is an entry in the changelog for it.

Currently the verbose progress output goes to `stdout`, it should go to `stderr` as `cargo` does, which allows displaying of progress to the user and still be able to pipe `stdout` to a file or another program, as is required for `--output-json`