### PR TITLE
Display status of pulling docker image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,19 +696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "unicode-width",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,7 +716,6 @@ dependencies = [
  "heck",
  "hex",
  "impl-serde",
- "indicatif",
  "parity-scale-codec",
  "parity-wasm",
  "pretty_assertions",
@@ -741,6 +727,7 @@ dependencies = [
  "strum 0.25.0",
  "tempfile",
  "term_size",
+ "termion",
  "tokio",
  "tokio-stream",
  "toml 0.7.6",
@@ -1215,12 +1202,6 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
@@ -1816,19 +1797,6 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff8cc23a7393a397ed1d7f56e6365cba772aba9f9912ab968b03043c395d057"
-dependencies = [
- "console",
- "instant",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
 ]
 
 [[package]]
@@ -2562,10 +2530,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
+name = "numtoa"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
@@ -2693,7 +2661,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets 0.48.1",
 ]
@@ -2765,12 +2733,6 @@ name = "platforms"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
-
-[[package]]
-name = "portable-atomic"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
 name = "ppv-lite86"
@@ -3001,11 +2963,29 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall 0.2.16",
 ]
 
 [[package]]
@@ -4391,7 +4371,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix 0.37.23",
  "windows-sys 0.48.0",
 ]
@@ -4413,6 +4393,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termion"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659c1f379f3408c7e5e84c7d0da6d93404e3800b6b9d063ba24436419302ec90"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall 0.2.16",
+ "redox_termios",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,7 @@ dependencies = [
  "clap",
  "colored",
  "contract-metadata",
+ "crossterm",
  "duct",
  "heck",
  "hex",
@@ -727,7 +728,6 @@ dependencies = [
  "strum 0.25.0",
  "tempfile",
  "term_size",
- "termion",
  "tokio",
  "tokio-stream",
  "toml 0.7.6",
@@ -870,6 +870,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2451,6 +2476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -2528,12 +2554,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
@@ -2661,7 +2681,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.1",
 ]
@@ -2963,29 +2983,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_termios"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
-dependencies = [
- "redox_syscall 0.2.16",
 ]
 
 [[package]]
@@ -3736,6 +3738,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4371,7 +4403,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix 0.37.23",
  "windows-sys 0.48.0",
 ]
@@ -4393,18 +4425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "termion"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659c1f379f3408c7e5e84c7d0da6d93404e3800b6b9d063ba24436419302ec90"
-dependencies = [
- "libc",
- "numtoa",
- "redox_syscall 0.2.16",
- "redox_termios",
 ]
 
 [[package]]

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -42,7 +42,7 @@ strum = { version = "0.25", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 bollard = "0.14"
-termion = "2.0.1"
+crossterm = "0.26.1"
 
 contract-metadata = { version = "3.0.1", path = "../metadata" }
 

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -42,7 +42,7 @@ strum = { version = "0.25", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 bollard = "0.14"
-indicatif = "0.17"
+termion = "2.0.1"
 
 contract-metadata = { version = "3.0.1", path = "../metadata" }
 

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -34,6 +34,7 @@
 //! and overwrite those paths relative to the host machine.
 
 use std::{
+    cmp::Ordering,
     collections::{
         hash_map::DefaultHasher,
         HashMap,
@@ -46,8 +47,8 @@ use std::{
         BufReader,
         Write,
     },
+    marker::Unpin,
     path::Path,
-    time::Duration,
 };
 
 use anyhow::{
@@ -63,10 +64,12 @@ use bollard::{
         ListContainersOptions,
         LogOutput,
     },
+    errors::Error,
     image::{
         CreateImageOptions,
         ListImagesOptions,
     },
+    models::CreateImageInfo,
     service::{
         HostConfig,
         ImageSummary,
@@ -76,11 +79,10 @@ use bollard::{
     Docker,
 };
 use contract_metadata::ContractMetadata;
-use indicatif::{
-    ProgressBar,
-    ProgressStyle,
+use tokio_stream::{
+    Stream,
+    StreamExt,
 };
-use tokio_stream::StreamExt;
 
 use crate::{
     verbose_eprintln,
@@ -511,35 +513,68 @@ async fn pull_image(
     build_steps.increment_current();
 
     if verbosity.is_verbose() {
-        let spinner_style = ProgressStyle::with_template(
-            " {spinner:.cyan} [{wide_bar:.cyan/blue}]\n {wide_msg}",
-        )?
-        .progress_chars("#>-")
-        .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ ");
-        let pb = ProgressBar::new(1000);
-        pb.set_style(spinner_style);
-        pb.enable_steady_tick(Duration::from_millis(100));
-
-        while let Some(summary_result) = pull_image_stream.next().await {
-            let summary = summary_result?;
-
-            if let Some(progress_detail) = summary.progress_detail {
-                let total = progress_detail.total.map_or(1000, |v| v) as u64;
-                let current_step = progress_detail.current.map_or(1000, |v| v) as u64;
-                pb.set_length(total);
-                pb.set_position(current_step);
-
-                if let Some(msg) = summary.status {
-                    pb.set_message(msg);
-                }
-            }
-        }
-
-        pb.finish();
+        show_pull_progress(pull_image_stream).await?
     } else {
         while pull_image_stream.next().await.is_some() {}
     }
 
+    Ok(())
+}
+
+/// Display the progress of the pulling of each image layer.
+async fn show_pull_progress(
+    mut pull_image_stream: impl Stream<Item = Result<CreateImageInfo, Error>> + Sized + Unpin,
+) -> Result<()> {
+    let mut layers = Vec::new();
+    let mut curr_index = 0i16;
+    while let Some(result) = pull_image_stream.next().await {
+        let info = result?;
+
+        let status = info.status.unwrap_or_default();
+        if status.starts_with("Digest:") || status.starts_with("Status:") {
+            eprintln!("{}", status);
+            continue
+        }
+
+        if let Some(id) = info.id {
+            let mut move_cursor = String::new();
+            if let Some(index) = layers.iter().position(|l| l == &id) {
+                let diff = index as i16 - curr_index;
+                curr_index = index as i16;
+                match diff.cmp(&1) {
+                    Ordering::Greater => {
+                        let down = diff - 1;
+                        move_cursor = format!("{}", termion::cursor::Down(down as u16))
+                    }
+                    Ordering::Less => {
+                        let up = diff.abs() + 1;
+                        move_cursor = format!("{}", termion::cursor::Up(up as u16))
+                    }
+                    Ordering::Equal => {}
+                }
+            } else {
+                layers.push(id.clone());
+                let len = layers.len() as i16;
+                let diff = len - curr_index;
+                curr_index = len;
+                if diff > 1 {
+                    move_cursor = format!("{}", termion::cursor::Down(diff as u16))
+                }
+            };
+
+            let clear_line = termion::clear::CurrentLine;
+
+            if status == "Pull complete" {
+                println!("{}{}{}: {}", move_cursor, clear_line, id, status)
+            } else {
+                let progress = info.progress.unwrap_or_default();
+                println!(
+                    "{}{}{}: {} {}",
+                    move_cursor, clear_line, id, status, progress
+                )
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -525,6 +525,14 @@ async fn pull_image(
 async fn show_pull_progress(
     mut pull_image_stream: impl Stream<Item = Result<CreateImageInfo, Error>> + Sized + Unpin,
 ) -> Result<()> {
+    use crossterm::{
+        cursor,
+        terminal::{
+            self,
+            ClearType,
+        },
+    };
+
     let mut layers = Vec::new();
     let mut curr_index = 0i16;
     while let Some(result) = pull_image_stream.next().await {
@@ -544,11 +552,11 @@ async fn show_pull_progress(
                 match diff.cmp(&1) {
                     Ordering::Greater => {
                         let down = diff - 1;
-                        move_cursor = format!("{}", termion::cursor::Down(down as u16))
+                        move_cursor = format!("{}", cursor::MoveDown(down as u16))
                     }
                     Ordering::Less => {
                         let up = diff.abs() + 1;
-                        move_cursor = format!("{}", termion::cursor::Up(up as u16))
+                        move_cursor = format!("{}", cursor::MoveUp(up as u16))
                     }
                     Ordering::Equal => {}
                 }
@@ -558,11 +566,11 @@ async fn show_pull_progress(
                 let diff = len - curr_index;
                 curr_index = len;
                 if diff > 1 {
-                    move_cursor = format!("{}", termion::cursor::Down(diff as u16))
+                    move_cursor = format!("{}", cursor::MoveDown(diff as u16))
                 }
             };
 
-            let clear_line = termion::clear::CurrentLine;
+            let clear_line = terminal::Clear(ClearType::CurrentLine);
 
             if status == "Pull complete" {
                 println!("{}{}{}: {}", move_cursor, clear_line, id, status)

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -527,7 +527,6 @@ async fn show_pull_progress(
 ) -> Result<()> {
     use crossterm::{
         cursor,
-        execute,
         terminal::{
             self,
             ClearType,

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -527,6 +527,7 @@ async fn show_pull_progress(
 ) -> Result<()> {
     use crossterm::{
         cursor,
+        execute,
         terminal::{
             self,
             ClearType,
@@ -573,10 +574,10 @@ async fn show_pull_progress(
             let clear_line = terminal::Clear(ClearType::CurrentLine);
 
             if status == "Pull complete" {
-                println!("{}{}{}: {}", move_cursor, clear_line, id, status)
+                eprintln!("{}{}{}: {}", move_cursor, clear_line, id, status)
             } else {
                 let progress = info.progress.unwrap_or_default();
-                println!(
+                eprintln!(
                     "{}{}{}: {} {}",
                     move_cursor, clear_line, id, status, progress
                 )

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -547,6 +547,7 @@ async fn show_pull_progress(
         if let Some(id) = info.id {
             let mut move_cursor = String::new();
             if let Some(index) = layers.iter().position(|l| l == &id) {
+                let index = index + 1;
                 let diff = index as i16 - curr_index;
                 curr_index = index as i16;
                 match diff.cmp(&1) {


### PR DESCRIPTION
The current progress display for pulling images jumps around because there are progress updates for the different layers. 

This PR uses the `CreateImageResult::progress` which shows the "native" docker progress, and moves the cursor to the relevant line which displays the progress for that layer.

![image](https://github.com/paritytech/cargo-contract/assets/75586/8dd0e4a3-b5dd-4fd7-a679-f5ef074ff671)

![image](https://github.com/paritytech/cargo-contract/assets/75586/d96e6ae8-73fe-4f73-9d7e-45fb97c5c406)


