### PR TITLE
Release `v3.1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.0]
+
+**Notable changes:**
+  - Verifiable builds inside a docker container - [#1148](https://github.com/paritytech/cargo-contract/pull/1148)
+  - Extrinsics extracted to separate crate - [#1181](https://github.com/paritytech/cargo-contract/pull/1181)
+  - Fix building contracts with Rust >= 1.70: enable `sign_ext` Wasm opcode - [#1189](https://github.com/paritytech/cargo-contract/pull/1189)
 
 ### Added
 - Standardised verifiable builds - [#1148](https://github.com/paritytech/cargo-contract/pull/1148)
+- Enable Wasm sign_ext [#1189](https://github.com/paritytech/cargo-contract/pull/1189)
+- Expose extrinsics operations as a library - [#1181](https://github.com/paritytech/cargo-contract/pull/1181)
+- Suggest valid message or constructor name, when misspelled - [#1162](https://github.com/paritytech/cargo-contract/pull/1162)
+- Add flag -y as a shortcut for --skip-confirm - [#1127](https://github.com/paritytech/cargo-contract/pull/1127)
+- Add command line argument --max-memory-pages - [#1128](https://github.com/paritytech/cargo-contract/pull/1128)
+- Show Gas consumption by default for dry-runs - [#1121](https://github.com/paritytech/cargo-contract/pull/1121)
 
 ### Changed
 - Dry-run result output improvements - [1123](https://github.com/paritytech/cargo-contract/pull/1123)
-- Display build progress with --output-json, print to stderr [1211](https://github.com/paritytech/cargo-contract/pull/1211)
+- Display build progress with --output-json, print to stderr - [1211](https://github.com/paritytech/cargo-contract/pull/1211)
+- Update `subxt` to `0.30.1` with new `subxt-signer` crate - [#1236](https://github.com/paritytech/cargo-contract/pull/1236)
+- Upgrade wasm-opt to 0.113 - [#1188](https://github.com/paritytech/cargo-contract/pull/1188)
+- Update substrate dependencies - [#1149](https://github.com/paritytech/cargo-contract/pull/1149)
+- Make output format of cargo contract info consistent with other subcommands - [#1120](https://github.com/paritytech/cargo-contract/pull/1120)
 
 ### Fixed
-- Configure tty output correctly - [#1209]((https://github.com/paritytech/cargo-contract/pull/1209))
-
+- Configure tty output correctly - [#1209](https://github.com/paritytech/cargo-contract/pull/1209)
+- Set `lto = "thin"` for metadata build to fix `linkme` on macOS - [#1200](https://github.com/paritytech/cargo-contract/pull/1200)
+- fix(build): An error when running with `--lint` - [#1174](https://github.com/paritytech/cargo-contract/pull/1174)
+- Dry-run result output improvements - [#1123](https://github.com/paritytech/cargo-contract/pull/1123)
+- feat: use `CARGO_ENCODED_RUSTFLAGS` instead of `RUSTFLAGS` - [#1124](https://github.com/paritytech/cargo-contract/pull/1124)
 
 ## [3.0.1]
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ In order to publish a new version of `cargo-contract`:
 
 -   Bump all crate versions, we move them in lockstep.
 -   Make sure your PR is approved by one or more core developers.
--   Publish `metadata` ➜ `transcode` ➜ `extrinsics` ➜ `build` ➜ `cargo-contract`.
+-   Publish `metadata` ➜ `transcode` ➜ `build` ➜ `extrinsics` ➜ `cargo-contract`.
 -   Merge you PR and push a tag `vX.X` with your version number.
 -   Create a GitHub release with the changelog entries.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ In order to publish a new version of `cargo-contract`:
 
 -   Bump all crate versions, we move them in lockstep.
 -   Make sure your PR is approved by one or more core developers.
--   Publish `metadata` ➜ `transcode` ➜ `build` ➜ `cargo-contract`.
+-   Publish `metadata` ➜ `transcode` ➜ `extrinsics` ➜ `build` ➜ `cargo-contract`.
 -   Merge you PR and push a tag `vX.X` with your version number.
 -   Create a GitHub release with the changelog entries.
 

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,11 +1,9 @@
 FROM docker.io/bitnami/minideb:bullseye-amd64 as slimmed-rust
 
 # The rust version to use
-# The 1.69 toolchain is temporarily required to build ink! contracts because of
-# https://github.com/paritytech/cargo-contract/issues/1139
-ARG RUST_VERSION=1.69
+ARG RUST_VERSION=stable
 # The cargo contract version to use
-ARG CARGO_CONTRACT_VERSION=3.0.1
+ARG CARGO_CONTRACT_VERSION=3.1.0
 # Url to the cargo-contract repository to install from
 ARG CARGO_CONTRACT_GIT
 # Branch to use in git repository

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-build"
-version = "3.0.1"
+version = "3.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -44,7 +44,7 @@ tokio-stream = "0.1"
 bollard = "0.14"
 crossterm = "0.26.1"
 
-contract-metadata = { version = "3.0.1", path = "../metadata" }
+contract-metadata = { version = "3.1.0", path = "../metadata" }
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -14,7 +14,7 @@ description = "Setup and deployment tool for developing Wasm based smart contrac
 keywords = ["wasm", "parity", "webassembly", "blockchain", "edsl"]
 categories = ["command-line-utilities", "development-tools::build-utils", "development-tools::cargo-plugins"]
 include = [
-    "Cargo.toml", "src/**/*.rs", "README.md", "LICENSE", "build.rs", "src/**/*.scale",
+    "Cargo.toml", "src/**/*.rs", "README.md", "LICENSE", "build.rs",
 ]
 
 [dependencies]

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-contract"
-version = "3.0.1"
+version = "3.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-contract-build = { version = "3.0.1", path = "../build" }
-contract-extrinsics = { version = "3.0.1", path = "../extrinsics" }
-contract-transcode = { version = "3.0.1", path = "../transcode" }
+contract-build = { version = "3.1.0", path = "../build" }
+contract-extrinsics = { version = "3.1.0", path = "../extrinsics" }
+contract-transcode = { version = "3.1.0", path = "../transcode" }
 
 anyhow = "1.0.72"
 clap = { version = "4.3.19", features = ["derive", "env"] }

--- a/crates/extrinsics/Cargo.toml
+++ b/crates/extrinsics/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/contract-extrinsics"
 homepage = "https://www.substrate.io/"
 description = "Library defining extrinsics for smart contracts on substrate"
 keywords = ["wasm", "parity", "webassembly", "blockchain", "edsl"]
-include = ["Cargo.toml", "*.rs", "LICENSE"]
+include = ["Cargo.toml", "*.rs", "LICENSE", "src/**/*.scale",]
 
 [dependencies]
 contract-build = { version = "3.1.0", path = "../build" }

--- a/crates/extrinsics/Cargo.toml
+++ b/crates/extrinsics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-extrinsics"
-version = "3.0.1"
+version = "3.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -14,9 +14,9 @@ keywords = ["wasm", "parity", "webassembly", "blockchain", "edsl"]
 include = ["Cargo.toml", "*.rs", "LICENSE"]
 
 [dependencies]
-contract-build = { version = "3.0.1", path = "../build" }
-contract-metadata = { version = "3.0.1", path = "../metadata" }
-contract-transcode = { version = "3.0.1", path = "../transcode" }
+contract-build = { version = "3.1.0", path = "../build" }
+contract-metadata = { version = "3.1.0", path = "../metadata" }
+contract-transcode = { version = "3.1.0", path = "../transcode" }
 
 anyhow = "1.0.72"
 clap = { version = "4.3.19", features = ["derive", "env"] }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-metadata"
-version = "3.0.1"
+version = "3.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-transcode"
-version = "3.0.1"
+version = "3.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 anyhow = "1.0.72"
 base58 = { version = "0.2.0" }
 blake2 = { version = "0.10.4", default-features = false }
-contract-metadata = { version = "3.0.1", path = "../metadata" }
+contract-metadata = { version = "3.1.0", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "2.0.0"


### PR DESCRIPTION
**Notable changes:**
  - Verifiable builds inside a docker container - [#1148](https://github.com/paritytech/cargo-contract/pull/1148)
  - Extrinsics extracted to separate crate - [#1181](https://github.com/paritytech/cargo-contract/pull/1181)
  - Fix building contracts with Rust >= 1.70: enable `sign_ext` Wasm opcode - [#1189](https://github.com/paritytech/cargo-contract/pull/1189)

### Added
- Standardised verifiable builds - [#1148](https://github.com/paritytech/cargo-contract/pull/1148)
- Enable Wasm sign_ext [#1189](https://github.com/paritytech/cargo-contract/pull/1189)
- Expose extrinsics operations as a library - [#1181](https://github.com/paritytech/cargo-contract/pull/1181)
- Suggest valid message or constructor name, when misspelled - [#1162](https://github.com/paritytech/cargo-contract/pull/1162)
- Add flag -y as a shortcut for --skip-confirm - [#1127](https://github.com/paritytech/cargo-contract/pull/1127)
- Add command line argument --max-memory-pages - [#1128](https://github.com/paritytech/cargo-contract/pull/1128)
- Show Gas consumption by default for dry-runs - [#1121](https://github.com/paritytech/cargo-contract/pull/1121)

### Changed
- Dry-run result output improvements - [1123](https://github.com/paritytech/cargo-contract/pull/1123)
- Display build progress with --output-json, print to stderr - [1211](https://github.com/paritytech/cargo-contract/pull/1211)
- Update `subxt` to `0.30.1` with new `subxt-signer` crate - [#1236](https://github.com/paritytech/cargo-contract/pull/1236)
- Upgrade wasm-opt to 0.113 - [#1188](https://github.com/paritytech/cargo-contract/pull/1188)
- Update substrate dependencies - [#1149](https://github.com/paritytech/cargo-contract/pull/1149)
- Make output format of cargo contract info consistent with other subcommands - [#1120](https://github.com/paritytech/cargo-contract/pull/1120)

### Fixed
- Configure tty output correctly - [#1209](https://github.com/paritytech/cargo-contract/pull/1209)
- Set `lto = "thin"` for metadata build to fix `linkme` on macOS - [#1200](https://github.com/paritytech/cargo-contract/pull/1200)
- fix(build): An error when running with `--lint` - [#1174](https://github.com/paritytech/cargo-contract/pull/1174)
- Dry-run result output improvements - [#1123](https://github.com/paritytech/cargo-contract/pull/1123)
- feat: use `CARGO_ENCODED_RUSTFLAGS` instead of `RUSTFLAGS` - [#1124](https://github.com/paritytech/cargo-contract/pull/1124)