### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-contract"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -952,7 +952,7 @@ checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "contract-build"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "blake2",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "contract-extrinsics"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",


### PR DESCRIPTION
Latest release of `cargo-contract` has not updated the `Cargo.lock` which still contained `3.0.1` version of `cargo-contract` crates