### PR TITLE
`[extrinsics]` set minimum supported `rust-version` to `1.70`

### DIFF
--- a/crates/extrinsics/Cargo.toml
+++ b/crates/extrinsics/Cargo.toml
@@ -3,6 +3,7 @@ name = "contract-extrinsics"
 version = "3.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
+rust-version = "1.70"
 
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
The `subxt-signer` crate utilizes `OnceLock` which was only [stabilized](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#oncecell-and-oncelock) in `1.70`.

I have update the MSRV in subxt see https://github.com/paritytech/subxt/pull/1097. But we should do it here too so we can get a release out in the meantime to prevent issues such as https://github.com/paritytech/cargo-contract/issues/1240.