### PR TITLE
add build image release workflow

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,51 @@
+name: release-verifiable-image
+on:
+  push:
+    branches:
+      - 'master'
+  release:
+    types:
+      - edited
+      - prereleased
+      - published
+env:
+  IMAGE_NAME: paritytech/contracts-verifiable
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASS }}
+
+      - name: Build and push Docker image from master
+        if: ${{ github.event_name == "push" }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./build-image/Dockerfile
+          push: true
+          build-args: |
+            CARGO_CONTRACT_GIT="https://github.com/paritytech/cargo-contract"
+            CARGO_CONTRACT_BRANCH="master"
+          tags: ${{ env.IMAGE_NAME }}:master
+
+      - name: Build and push Docker image from release
+        if: ${{ github.event_name == "release" }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./build-image/Dockerfile
+          push: true
+          build-args: |
+            CARGO_CONTRACT_GIT="https://github.com/paritytech/cargo-contract"
+            CARGO_CONTRACT_TAG=${{ github.event.release.tag_name }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -39,6 +39,14 @@ jobs:
             ${{ env.IMAGE_NAME }}:master
             ${{ env.IMAGE_NAME }}:latest
 
+      # Store the version, stripping any v-prefix
+      - name: Write release version
+        if: ${{ github.event_name == "release" }}
+        run: |
+          GH_TAG=${{ github.event.release.tag_name }}
+          echo Published github tag: $GH_TAG
+          echo "DOCKER_TAG=${GH_TAG#v}" >> $GITHUB_ENV
+
       - name: Build and push Docker image from release
         if: ${{ github.event_name == "release" }}
         uses: docker/build-push-action@v4
@@ -49,5 +57,5 @@ jobs:
           build-args: |
             CARGO_CONTRACT_GIT="https://github.com/paritytech/cargo-contract"
             CARGO_CONTRACT_TAG=${{ github.event.release.tag_name }}
-          tags: ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}
+          tags: ${{ env.IMAGE_NAME }}:${DOCKER_TAG}
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -35,7 +35,9 @@ jobs:
           build-args: |
             CARGO_CONTRACT_GIT="https://github.com/paritytech/cargo-contract"
             CARGO_CONTRACT_BRANCH="master"
-          tags: ${{ env.IMAGE_NAME }}:master
+          tags: |
+            ${{ env.IMAGE_NAME }}:master
+            ${{ env.IMAGE_NAME }}:latest
 
       - name: Build and push Docker image from release
         if: ${{ github.event_name == "release" }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Adds workflow for publishing docker images for the verifiable builds - [#1267](https://github.com/paritytech/cargo-contract/pull/1267)
+
 ## [4.0.0-alpha]
 
-Replaces the yanked `3.1.0` due to issues with supporting *both* Rust versions < `1.70` 
+Replaces the yanked `3.1.0` due to issues with supporting *both* Rust versions < `1.70`
 and >= `1.70`.
 
 If you intend to use `cargo-contract` with Rust >= `1.70`, and deploy to a node with a


### PR DESCRIPTION
Follow-up for #1148

Adds a workflow that automatically pushes an image to the docker hub when:
- A new commit is pushed a master (in this case the `master` tag gets updated)
- A new release is published | prereleaed | edited (the new tag under the corresponding tag name gets published or updated)