### PR TITLE
Add `SignextLowering` pass to `wasm-opt`

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -308,16 +308,6 @@ fn exec_cargo_for_onchain_target(
             env.push(("RUSTC_BOOTSTRAP", Some("1".to_string())))
         }
 
-        // newer rustc versions might emit unsupported instructions
-        if rustc_version::version_meta()?.semver >= Version::new(1, 70, 0) {
-            eprintln!(
-                "{} {}",
-                "warning:".yellow().bold(),
-                "You are using a rustc version that might emit unsupported wasm instructions. Build using a version lower than 1.70.0 to make sure your contract will deploy."
-                    .bold()
-            );
-        }
-
         // merge target specific flags with the common flags (defined here)
         // We want to disable warnings here as they will be duplicates of the clippy pass.
         // However, if we want to do so with either `--cap-lints allow` or  `-A


### PR DESCRIPTION
Fixes #1239.

As suggested here: https://github.com/paritytech/cargo-contract/issues/1239#issuecomment-1673810089, this will allow a newer toolchain > `1.69` to be used to deploy to older versions of `pallet-contracts` which do not yet support `signext`.

It does so by adding an extra `wasm-opt` pass which "lowers" any `signext` instructions to mvp only features.

Tested that a contract built with Rust >= `1.70` can be uploaded to a node which does not support `signext`.

If it does work we can then consider either backporting this to a `3.2.0` release, or just going ahead and doing a `4.0.0` release.