### PR TITLE
Add flag --all to cargo contract info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect `INK_STATIC_BUFFER_SIZE` env var - [#1310](https://github.com/paritytech/cargo-contract/pull/1310)
 - Add `verify` command - [#1306](https://github.com/paritytech/cargo-contract/pull/1306)
 - Add `--binary` flag for `info` command - [#1311](https://github.com/paritytech/cargo-contract/pull/1311/)
-- Add `--all` flag for `info` command - [#1311](https://github.com/paritytech/cargo-contract/pull/1311/)
+- Add `--all` flag for `info` command - [#1319](https://github.com/paritytech/cargo-contract/pull/1319)
 
 ## [4.0.0-alpha]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect `INK_STATIC_BUFFER_SIZE` env var - [#1310](https://github.com/paritytech/cargo-contract/pull/1310)
 - Add `verify` command - [#1306](https://github.com/paritytech/cargo-contract/pull/1306)
 - Add `--binary` flag for `info` command - [#1311](https://github.com/paritytech/cargo-contract/pull/1311/)
+- Add `--all` flag for `info` command - [#1311](https://github.com/paritytech/cargo-contract/pull/1311/)
 
 ## [4.0.0-alpha]
 

--- a/crates/cargo-contract/src/cmd/info.rs
+++ b/crates/cargo-contract/src/cmd/info.rs
@@ -70,19 +70,19 @@ pub struct InfoCommand {
 
 impl InfoCommand {
     pub async fn run(&self) -> Result<(), ErrorVariant> {
-        let url = self.url.clone();
-        let client = OnlineClient::<DefaultConfig>::from_url(url).await?;
+        let client = OnlineClient::<DefaultConfig>::from_url(&self.url).await?;
 
         // All flag applied
         if self.all {
             // 1000 is max allowed value
-            const COUNT: u32 = 1000;
+            const MAX_COUNT: u32 = 1000;
             let mut from = None;
             let mut contracts = Vec::new();
             loop {
                 let len = contracts.len();
-                contracts.append(&mut fetch_all_contracts(&client, COUNT, from).await?);
-                if contracts.len() < len + COUNT as usize {
+                contracts
+                    .append(&mut fetch_all_contracts(&client, MAX_COUNT, from).await?);
+                if contracts.len() < len + MAX_COUNT as usize {
                     break
                 }
                 from = contracts.last();

--- a/crates/cargo-contract/src/cmd/info.rs
+++ b/crates/cargo-contract/src/cmd/info.rs
@@ -16,6 +16,7 @@
 
 use super::{
     basic_display_format_contract_info,
+    display_all_contracts,
     DefaultConfig,
 };
 use anyhow::{
@@ -23,6 +24,7 @@ use anyhow::{
     Result,
 };
 use contract_extrinsics::{
+    fetch_all_contracts,
     fetch_contract_info,
     fetch_wasm_code,
     ErrorVariant,
@@ -41,8 +43,13 @@ use tokio::runtime::Runtime;
 #[clap(name = "info", about = "Get infos from a contract")]
 pub struct InfoCommand {
     /// The address of the contract to display info of.
-    #[clap(name = "contract", long, env = "CONTRACT")]
-    contract: <DefaultConfig as Config>::AccountId,
+    #[clap(
+        name = "contract",
+        long,
+        env = "CONTRACT",
+        required_unless_present = "all"
+    )]
+    contract: Option<<DefaultConfig as Config>::AccountId>,
     /// Websockets url of a substrate node.
     #[clap(
         name = "url",
@@ -55,74 +62,119 @@ pub struct InfoCommand {
     #[clap(name = "output-json", long)]
     output_json: bool,
     /// Display the contract's Wasm bytecode.
-    #[clap(name = "binary", long)]
+    #[clap(name = "binary", long, conflicts_with = "all")]
     binary: bool,
+    /// Display all contracts addresses
+    #[clap(name = "all", long, conflicts_with = "contract")]
+    all: bool,
 }
 
 impl InfoCommand {
     pub fn run(&self) -> Result<(), ErrorVariant> {
-        tracing::debug!(
-            "Getting contract information for AccountId {:?}",
-            self.contract
-        );
-
         Runtime::new()?.block_on(async {
             let url = self.url.clone();
             let client = OnlineClient::<DefaultConfig>::from_url(url).await?;
 
-            let info_result = fetch_contract_info(&self.contract, &client).await?;
+            if self.all {
+                tracing::debug!("Getting all contracts");
+                let count = 100;
+                let mut from = None;
+                let mut contracts_all = Vec::new();
+                loop {
+                    let mut contracts =
+                        fetch_all_contracts(&client, count, from.as_ref()).await?;
+                    display_all_contracts(&contracts);
+                    if contracts.len()
+                        < count
+                            .try_into()
+                            .expect("Converting u32 to usize type failed")
+                    {
+                        contracts_all.append(&mut contracts);
+                        break
+                    } else {
+                        from = contracts.last().cloned();
+                        contracts_all.append(&mut contracts);
+                    }
+                }
+                if self.output_json {
+                    let contracts_json = serde_json::json!({
+                        "contracts": contracts_all
+                    });
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&contracts_json).map_err(|err| {
+                            anyhow!("JSON serialization failed: {}", err)
+                        })?
+                    );
+                }
+                Ok(())
+            } else {
+                tracing::debug!(
+                    "Getting contract information for AccountId {:?}",
+                    self.contract
+                );
+                let info_result = fetch_contract_info(
+                    self.contract
+                        .as_ref()
+                        .expect("Contract argument was not provided"),
+                    &client,
+                )
+                .await?;
 
-            match info_result {
-                Some(info_to_json) => {
-                    match (self.output_json, self.binary) {
-                        (true, false) => println!("{}", info_to_json.to_json()?),
-                        (false, false) => {
-                            basic_display_format_contract_info(&info_to_json)
-                        }
-                        // Binary flag applied
-                        (_, true) => {
-                            let wasm_code =
-                                fetch_wasm_code(*info_to_json.code_hash(), &client)
-                                    .await?;
-                            match (wasm_code, self.output_json) {
-                                (Some(code), false) => {
-                                    std::io::stdout()
-                                        .write_all(&code)
-                                        .expect("Writing to stdout failed")
-                                }
-                                (Some(code), true) => {
-                                    let wasm = serde_json::json!({
-                                        "wasm": format!("0x{}", hex::encode(code))
-                                    });
-                                    println!(
-                                        "{}",
-                                        serde_json::to_string_pretty(&wasm).map_err(
-                                            |err| {
-                                                anyhow!(
-                                                    "JSON serialization failed: {}",
-                                                    err
-                                                )
-                                            }
-                                        )?
-                                    );
-                                }
-                                (None, _) => {
-                                    return Err(anyhow!(
-                                        "Contract wasm code was not found"
-                                    )
-                                    .into())
+                match info_result {
+                    Some(info_to_json) => {
+                        match (self.output_json, self.binary) {
+                            (true, false) => println!("{}", info_to_json.to_json()?),
+                            (false, false) => {
+                                basic_display_format_contract_info(&info_to_json)
+                            }
+                            // Binary flag applied
+                            (_, true) => {
+                                let wasm_code =
+                                    fetch_wasm_code(*info_to_json.code_hash(), &client)
+                                        .await?;
+                                match (wasm_code, self.output_json) {
+                                    (Some(code), false) => {
+                                        std::io::stdout()
+                                            .write_all(&code)
+                                            .expect("Writing to stdout failed")
+                                    }
+                                    (Some(code), true) => {
+                                        let wasm = serde_json::json!({
+                                            "wasm": format!("0x{}", hex::encode(code))
+                                        });
+                                        println!(
+                                            "{}",
+                                            serde_json::to_string_pretty(&wasm).map_err(
+                                                |err| {
+                                                    anyhow!(
+                                                        "JSON serialization failed: {}",
+                                                        err
+                                                    )
+                                                }
+                                            )?
+                                        );
+                                    }
+                                    (None, _) => {
+                                        return Err(anyhow!(
+                                            "Contract wasm code was not found"
+                                        )
+                                        .into())
+                                    }
                                 }
                             }
                         }
+                        Ok(())
                     }
-                    Ok(())
-                }
-                None => {
-                    Err(anyhow!(
-                        "No contract information was found for account id {}",
-                        self.contract
-                    )
-                    .into())
+                    None => {
+                        Err(anyhow!(
+                            "No contract information was found for account id {}",
+                            self.contract
+                                .as_ref()
+                                .expect("Contract argument was not provided")
+                        )
+                        .into())
+                    }
                 }
             }
         })

--- a/crates/cargo-contract/src/cmd/info.rs
+++ b/crates/cargo-contract/src/cmd/info.rs
@@ -76,16 +76,17 @@ impl InfoCommand {
         if self.all {
             // 1000 is max allowed value
             const MAX_COUNT: u32 = 1000;
-            let mut from = None;
+            let mut count_from = None;
             let mut contracts = Vec::new();
             loop {
                 let len = contracts.len();
-                contracts
-                    .append(&mut fetch_all_contracts(&client, MAX_COUNT, from).await?);
+                contracts.append(
+                    &mut fetch_all_contracts(&client, MAX_COUNT, count_from).await?,
+                );
                 if contracts.len() < len + MAX_COUNT as usize {
                     break
                 }
-                from = contracts.last();
+                count_from = contracts.last();
             }
 
             if self.output_json {

--- a/crates/cargo-contract/src/cmd/mod.rs
+++ b/crates/cargo-contract/src/cmd/mod.rs
@@ -65,8 +65,10 @@ use std::io::{
     self,
     Write,
 };
-use subxt::utils::AccountId32;
-pub use subxt::PolkadotConfig as DefaultConfig;
+pub use subxt::{
+    Config,
+    PolkadotConfig as DefaultConfig,
+};
 
 /// Arguments required for creating and sending an extrinsic to a substrate node.
 #[derive(Clone, Debug, clap::Args)]
@@ -233,8 +235,10 @@ pub fn basic_display_format_contract_info(info: &ContractInfo) {
 }
 
 /// Display all contracts addresses in a formatted way
-pub fn display_all_contracts(contracts: &[AccountId32]) {
-    contracts.iter().for_each(|e: &AccountId32| {
-        name_value_println!("Contract", format!("{}", e), MAX_KEY_COL_WIDTH);
-    })
+pub fn display_all_contracts(contracts: &[<DefaultConfig as Config>::AccountId]) {
+    contracts
+        .iter()
+        .for_each(|e: &<DefaultConfig as Config>::AccountId| {
+            name_value_println!("Contract", format!("{}", e), MAX_KEY_COL_WIDTH);
+        })
 }

--- a/crates/cargo-contract/src/cmd/mod.rs
+++ b/crates/cargo-contract/src/cmd/mod.rs
@@ -65,6 +65,7 @@ use std::io::{
     self,
     Write,
 };
+use subxt::utils::AccountId32;
 pub use subxt::PolkadotConfig as DefaultConfig;
 
 /// Arguments required for creating and sending an extrinsic to a substrate node.
@@ -229,4 +230,11 @@ pub fn basic_display_format_contract_info(info: &ContractInfo) {
         format!("{:?}", info.storage_item_deposit()),
         MAX_KEY_COL_WIDTH
     );
+}
+
+/// Display all contracts addresses in a formatted way
+pub fn display_all_contracts(contracts: &[AccountId32]) {
+    contracts.iter().for_each(|e: &AccountId32| {
+        name_value_println!("Contract", format!("{}", e), MAX_KEY_COL_WIDTH);
+    })
 }

--- a/crates/cargo-contract/src/cmd/mod.rs
+++ b/crates/cargo-contract/src/cmd/mod.rs
@@ -238,7 +238,5 @@ pub fn basic_display_format_contract_info(info: &ContractInfo) {
 pub fn display_all_contracts(contracts: &[<DefaultConfig as Config>::AccountId]) {
     contracts
         .iter()
-        .for_each(|e: &<DefaultConfig as Config>::AccountId| {
-            name_value_println!("Contract", format!("{}", e), MAX_KEY_COL_WIDTH);
-        })
+        .for_each(|e: &<DefaultConfig as Config>::AccountId| println!("{}", e))
 }

--- a/crates/cargo-contract/src/main.rs
+++ b/crates/cargo-contract/src/main.rs
@@ -217,7 +217,9 @@ fn exec(cmd: Command) -> Result<()> {
                     .map_err(|err| map_extrinsic_err(err, remove.output_json()))
             })
         }
-        Command::Info(info) => info.run().map_err(format_err),
+        Command::Info(info) => {
+            runtime.block_on(async { info.run().await.map_err(format_err) })
+        }
         Command::Verify(verify) => {
             let result = verify.run().map_err(format_err)?;
 

--- a/crates/extrinsics/src/error.rs
+++ b/crates/extrinsics/src/error.rs
@@ -72,6 +72,12 @@ impl From<std::io::Error> for ErrorVariant {
     }
 }
 
+impl From<serde_json::Error> for ErrorVariant {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Generic(GenericError::from_message(format!("{error:?}")))
+    }
+}
+
 #[derive(serde::Serialize)]
 pub struct ModuleError {
     pub pallet: String,

--- a/crates/extrinsics/src/integration_tests.rs
+++ b/crates/extrinsics/src/integration_tests.rs
@@ -417,8 +417,7 @@ async fn build_upload_instantiate_info() {
         "getting all contracts failed: {stderr}"
     );
 
-    let contract_account_all = extract_contract_address(stdout);
-    assert_eq!(contract_account_all, contract_account, "{stdout:?}");
+    assert_eq!(stdout.trim_end(), contract_account, "{stdout:?}");
 
     // prevent the node_process from being dropped and killed
     let _ = node_process;

--- a/crates/extrinsics/src/integration_tests.rs
+++ b/crates/extrinsics/src/integration_tests.rs
@@ -405,6 +405,21 @@ async fn build_upload_instantiate_info() {
         .assert()
         .stdout(predicate::str::contains(r#""wasm": "0x"#));
 
+    let output = cargo_contract(project_path.as_path())
+        .arg("info")
+        .arg("--all")
+        .output()
+        .expect("failed to execute process");
+    let stdout = str::from_utf8(&output.stdout).unwrap();
+    let stderr = str::from_utf8(&output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "getting all contracts failed: {stderr}"
+    );
+
+    let contract_account_all = extract_contract_address(stdout);
+    assert_eq!(contract_account_all, contract_account, "{stdout:?}");
+
     // prevent the node_process from being dropped and killed
     let _ = node_process;
 }

--- a/crates/extrinsics/src/lib.rs
+++ b/crates/extrinsics/src/lib.rs
@@ -410,9 +410,9 @@ pub async fn fetch_all_contracts(
         .map(|e| {
             let mut account =
                 e.0.get(16 + 16 + 8..)
-                    .ok_or(anyhow!("Slice out of range"))?;
+                    .ok_or(anyhow!("Unexpected storage key size"))?;
             AccountId32::decode(&mut account)
-                .map_err(|err| anyhow!("Deserialization error: {}", err))
+                .map_err(|err| anyhow!("AccountId deserialization error: {}", err))
         })
         .collect::<Result<_, _>>()?;
 

--- a/crates/extrinsics/src/lib.rs
+++ b/crates/extrinsics/src/lib.rs
@@ -407,7 +407,13 @@ pub async fn fetch_all_contracts(
     // Twox64Concat(AccountId)
     let contracts = keys
         .into_iter()
-        .map(|e| AccountId32::decode(&mut &e.0[16 + 16 + 8..]))
+        .map(|e| {
+            let mut account =
+                e.0.get(16 + 16 + 8..)
+                    .ok_or(anyhow!("Slice out of range"))?;
+            AccountId32::decode(&mut account)
+                .map_err(|err| anyhow!("Derialization error: {}", err))
+        })
         .collect::<Result<_, _>>()?;
 
     Ok(contracts)

--- a/crates/extrinsics/src/lib.rs
+++ b/crates/extrinsics/src/lib.rs
@@ -367,7 +367,10 @@ impl ContractInfo {
 }
 
 /// Fetch the contract wasm code from the storage using the provided client and code hash.
-pub async fn fetch_wasm_code(hash: CodeHash, client: &Client) -> Result<Option<Vec<u8>>> {
+pub async fn fetch_wasm_code(
+    client: &Client,
+    hash: &CodeHash,
+) -> Result<Option<Vec<u8>>> {
     let pristine_code_address = api::storage().contracts().pristine_code(hash);
 
     let pristine_bytes = client

--- a/crates/extrinsics/src/lib.rs
+++ b/crates/extrinsics/src/lib.rs
@@ -412,7 +412,7 @@ pub async fn fetch_all_contracts(
                 e.0.get(16 + 16 + 8..)
                     .ok_or(anyhow!("Slice out of range"))?;
             AccountId32::decode(&mut account)
-                .map_err(|err| anyhow!("Derialization error: {}", err))
+                .map_err(|err| anyhow!("Deserialization error: {}", err))
         })
         .collect::<Result<_, _>>()?;
 

--- a/docs/info.md
+++ b/docs/info.md
@@ -19,3 +19,4 @@ cargo contract info \
 - `--url` the url of the rpc endpoint you want to specify - by default `ws://localhost:9944`.
 - `--output-json` to export the output as JSON.
 - `--binary` outputs Wasm code as a binary blob. If used in combination with `--output-json`, outputs Wasm code as JSON object with hex string.
+- `--all` outputs all contracts addresses. It can not be used together with `--binary` flag.


### PR DESCRIPTION
Closes https://github.com/paritytech/cargo-contract/issues/797

- Output for command `cargo info -all` is:

```
5DpyotvcUDkFxTtHzkwR7Rqe37bdjc6M5Rxeiy57Gv2RQzp8
5GsoMKLTgFEpzHQTi7c4ZKCLZC6VxtHZxwMydSi79uemABez
```

- Flag combination --all --output-json outputs:

```
{
  "contracts": [
    "5DpyotvcUDkFxTtHzkwR7Rqe37bdjc6M5Rxeiy57Gv2RQzp8",
    "5GsoMKLTgFEpzHQTi7c4ZKCLZC6VxtHZxwMydSi79uemABez"
  ]
}
```

- Flags combination --binary --all is forbidden

- Current implementation does not support response paging 