### PR TITLE
Fix for a Url to String conversion in info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `verify` command - [#1306](https://github.com/paritytech/cargo-contract/pull/1306)
 - Add `--binary` flag for `info` command - [#1311](https://github.com/paritytech/cargo-contract/pull/1311/)
 - Add `--all` flag for `info` command - [#1319](https://github.com/paritytech/cargo-contract/pull/1319)
+- Fix for a Url to String conversion in `info` command - [#1330](https://github.com/paritytech/cargo-contract/pull/1330)
 
 ## [4.0.0-alpha]
 

--- a/crates/cargo-contract/src/cmd/info.rs
+++ b/crates/cargo-contract/src/cmd/info.rs
@@ -70,7 +70,8 @@ pub struct InfoCommand {
 
 impl InfoCommand {
     pub async fn run(&self) -> Result<(), ErrorVariant> {
-        let client = OnlineClient::<DefaultConfig>::from_url(&self.url).await?;
+        let client =
+            OnlineClient::<DefaultConfig>::from_url(url_to_string(&self.url)).await?;
 
         // All flag applied
         if self.all {
@@ -140,5 +141,20 @@ impl InfoCommand {
             }
             Ok(())
         }
+    }
+}
+
+// Converts a URL into a string representation without excluding the default port.
+fn url_to_string(url: &url::Url) -> String {
+    match (url.port(), url.port_or_known_default()) {
+        (None, Some(port)) => {
+            format!(
+                "{}:{port}{}",
+                &url[..url::Position::AfterHost],
+                &url[url::Position::BeforePath..]
+            )
+            .to_string()
+        }
+        _ => url.to_string(),
     }
 }

--- a/crates/cargo-contract/src/cmd/info.rs
+++ b/crates/cargo-contract/src/cmd/info.rs
@@ -144,8 +144,8 @@ impl InfoCommand {
     }
 }
 
-// Converts a URL into a string representation without excluding the default port.
-fn url_to_string(url: &url::Url) -> String {
+// Converts a Url into a String representation without excluding the default port.
+pub fn url_to_string(url: &url::Url) -> String {
     match (url.port(), url.port_or_known_default()) {
         (None, Some(port)) => {
             format!(


### PR DESCRIPTION
## Summary
Closes none
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->
Fix for Url to String conversion
## Description
According to url crate specification: "default port numbers are never reflected by the serialization"
Implemented function converts a Url into a string representation without excluding the default port.

For now the change is only for info command, but as follow up task is required a change in contract-extrinsics.
Conversion used there does not support correctly urls like: wss://shiden.api.onfinality.io:443/public-ws
The best option would be to have one common public function

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
