### PR TITLE
Add `-Clink-dead-code` to metadata gen `RUSTFLAGS`

### DIFF
--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -149,6 +149,12 @@ pub fn execute(
         network.append_to_args(&mut args);
         features.append_to_args(&mut args);
 
+        #[cfg(windows)]
+        let link_dead_code = "";
+
+        #[cfg(not(windows))]
+        let link_dead_code = "\x1f-Clink-dead-code";
+
         let cmd = util::cargo_cmd(
             "run",
             args,
@@ -156,7 +162,7 @@ pub fn execute(
             verbosity,
             vec![(
                 "CARGO_ENCODED_RUSTFLAGS",
-                Some("--cap-lints=allow\x1f-Clink-dead-code".to_string()),
+                Some(format!("--cap-lints=allow{link_dead_code}")),
             )],
         );
         let output = cmd.stdout_capture().run()?;

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -156,7 +156,7 @@ pub fn execute(
             verbosity,
             vec![(
                 "CARGO_ENCODED_RUSTFLAGS",
-                Some("--cap-lints=allow".to_string()),
+                Some("--cap-lints=allow\x1f-Clink-dead-code".to_string()),
             )],
         );
         let output = cmd.stdout_capture().run()?;


### PR DESCRIPTION
The cause of the ink! CI failing https://github.com/paritytech/ink/pull/1921 was that there has been a recent change #1190 which passes `CARGO_ENCODED_RUSTFLAGS` when generating the metadata, thus overriding the `RUSTFLAGS` set in the environment.