### PR TITLE
Do not use `wasm-opt` default features

### DIFF
--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = "1.0.107"
 tempfile = "3.8.0"
 term_size = "0.3.2"
 url = { version = "2.4.1", features = ["serde"] }
-wasm-opt = "=0.116.0"
+wasm-opt = { version = "=0.116.0", deafult-features = false }
 which = "5.0.0"
 zip = { version = "0.6.6", default-features = false }
 strum = { version = "0.25", features = ["derive"] }


### PR DESCRIPTION
The most recent version of `wasm-opt` added a feature flag for supporting binaryens DWARF passes. I'm not aware that we need those, and because this will introduce namespace conflicts with LLVM, [if the crate is used together with other LLVM crates](https://github.com/brson/wasm-opt-rs/issues/154), we should consider deactivating them.  