### PR TITLE
Improve JSON Output for Upload and Remove Commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Do not allow to execute calls on immutable contract messages - [#1397](https://github.com/paritytech/cargo-contract/pull/1397)
+- Improve JSON Output for Upload and Remove Commands - [#1389](https://github.com/paritytech/cargo-contract/pull/1389)
 
 ## [4.0.0-alpha]
 

--- a/crates/cargo-contract/src/cmd/remove.rs
+++ b/crates/cargo-contract/src/cmd/remove.rs
@@ -77,7 +77,7 @@ impl RemoveCommand {
                 // Create a JSON object with the events and the removed code hash.
                 let json_object = serde_json::json!({
                     "events": serde_json::from_str::<serde_json::Value>(&output_events)?,
-                    "removed_code_hash": remove_result,
+                    "code_hash": remove_result,
                 });
                 let json_object = serde_json::to_string_pretty(&json_object)?;
                 println!("{}", json_object);

--- a/crates/cargo-contract/src/cmd/remove.rs
+++ b/crates/cargo-contract/src/cmd/remove.rs
@@ -74,6 +74,7 @@ impl RemoveCommand {
             let remove_result = code_removed.code_hash;
 
             if self.output_json() {
+                // Create a JSON object with the events and the removed code hash.
                 let json_object = serde_json::json!({
                     "events": serde_json::from_str::<serde_json::Value>(&output_events)?,
                     "removed_code_hash": remove_result,

--- a/crates/cargo-contract/src/cmd/remove.rs
+++ b/crates/cargo-contract/src/cmd/remove.rs
@@ -62,7 +62,7 @@ impl RemoveCommand {
             .await?;
         let remove_result = remove_exec.remove_code().await?;
         let display_events = remove_result.display_events;
-        let output = if self.output_json() {
+        let output_events = if self.output_json() {
             display_events.to_json()?
         } else {
             display_events.display_events(
@@ -70,13 +70,18 @@ impl RemoveCommand {
                 remove_exec.token_metadata(),
             )?
         };
-        println!("{output}");
         if let Some(code_removed) = remove_result.code_removed {
             let remove_result = code_removed.code_hash;
 
             if self.output_json() {
-                println!("{}", &remove_result);
+                let json_object = serde_json::json!({
+                    "events": serde_json::from_str::<serde_json::Value>(&output_events)?,
+                    "removed_code_hash": remove_result,
+                });
+                let json_object = serde_json::to_string_pretty(&json_object)?;
+                println!("{}", json_object);
             } else {
+                println!("{}", output_events);
                 name_value_println!("Code hash", format!("{remove_result:?}"));
             }
             Result::<(), ErrorVariant>::Ok(())

--- a/crates/cargo-contract/src/cmd/upload.rs
+++ b/crates/cargo-contract/src/cmd/upload.rs
@@ -99,6 +99,7 @@ impl UploadCommand {
             if let Some(code_stored) = upload_result.code_stored {
                 let code_hash = code_stored.code_hash;
                 if self.output_json() {
+                    // Create a JSON object with the events and the code hash.
                     let json_object = serde_json::json!({
                         "events": serde_json::from_str::<serde_json::Value>(&output_events)?,
                         "code_hash": code_hash,

--- a/crates/cargo-contract/src/cmd/upload.rs
+++ b/crates/cargo-contract/src/cmd/upload.rs
@@ -88,7 +88,7 @@ impl UploadCommand {
         } else {
             let upload_result = upload_exec.upload_code().await?;
             let display_events = upload_result.display_events;
-            let output = if self.output_json() {
+            let output_events = if self.output_json() {
                 display_events.to_json()?
             } else {
                 display_events.display_events(
@@ -96,15 +96,17 @@ impl UploadCommand {
                     upload_exec.token_metadata(),
                 )?
             };
-            println!("{output}");
             if let Some(code_stored) = upload_result.code_stored {
-                let upload_result = CodeHashResult {
-                    code_hash: format!("{:?}", code_stored.code_hash),
-                };
+                let code_hash = code_stored.code_hash;
                 if self.output_json() {
-                    println!("{}", upload_result.to_json()?);
+                    let json_object = serde_json::json!({
+                        "events": serde_json::from_str::<serde_json::Value>(&output_events)?,
+                        "code_hash": code_hash,
+                    });
+                    println!("{}", serde_json::to_string_pretty(&json_object)?);
                 } else {
-                    upload_result.print();
+                    println!("{}", output_events);
+                    name_value_println!("Code hash", format!("{:?}", code_hash));
                 }
             } else {
                 let code_hash = hex::encode(code_hash);
@@ -115,21 +117,6 @@ impl UploadCommand {
             }
         }
         Ok(())
-    }
-}
-
-#[derive(serde::Serialize)]
-pub struct CodeHashResult {
-    pub code_hash: String,
-}
-
-impl CodeHashResult {
-    pub fn to_json(&self) -> Result<String> {
-        Ok(serde_json::to_string_pretty(self)?)
-    }
-
-    pub fn print(&self) {
-        name_value_println!("Code hash", format!("{:?}", self.code_hash));
     }
 }
 


### PR DESCRIPTION
## Summary
This PR addresses an issue where the JSON output for both the `upload` and `remove` commands in cargo contract was in an invalid format.
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
This pull request enhances the JSON output for both the `upload` and `remove` commands in cargo contract.
Previously, the JSON output was in an invalid format, making it challenging to parse and extract information. The modified format now produces valid JSON objects for easier parsing.

#### Example: JSON Output Before:
```bash
// Invalid JSON Format (Before)
[
  {
    "pallet": "Balances",
    "name": "Withdraw",
    // ... Other fields
  },
  // ... Additional events
]
{
  "code_hash": "0xe62b681614e6b7dbe892796b..."
}
```
#### Example: JSON Output After:
```bash
// Valid JSON Format (After)
{
  "code_hash": "0xe62b681614e6b7dbe892796b...",
  "events": [
    {
      "name": "Withdraw",
      "pallet": "Balances",
      // ... Other fields
    },
    // ... Additional events
  ]
}
```

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
