### PR TITLE
Refactor: extract `contract_info` and `contract_artifacts` mods from extrinsics root lib

### DIFF
--- a/crates/extrinsics/src/contract_artifacts.rs
+++ b/crates/extrinsics/src/contract_artifacts.rs
@@ -1,0 +1,157 @@
+// Copyright 2018-2023 Parity Technologies (UK) Ltd.
+// This file is part of cargo-contract.
+//
+// cargo-contract is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// cargo-contract is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::{
+    ContractMessageTranscoder,
+    ContractMetadata,
+    CrateMetadata,
+    WasmCode,
+};
+use anyhow::{
+    Context,
+    Result,
+};
+use colored::Colorize;
+use std::path::{
+    Path,
+    PathBuf,
+};
+
+/// Contract artifacts for use with extrinsic commands.
+#[derive(Debug)]
+pub struct ContractArtifacts {
+    /// The original artifact path
+    artifacts_path: PathBuf,
+    /// The expected path of the file containing the contract metadata.
+    metadata_path: PathBuf,
+    /// The deserialized contract metadata if the expected metadata file exists.
+    metadata: Option<ContractMetadata>,
+    /// The Wasm code of the contract if available.
+    pub code: Option<WasmCode>,
+}
+
+impl ContractArtifacts {
+    /// Load contract artifacts.
+    pub fn from_manifest_or_file(
+        manifest_path: Option<&PathBuf>,
+        file: Option<&PathBuf>,
+    ) -> Result<ContractArtifacts> {
+        let artifact_path = match (manifest_path, file) {
+            (manifest_path, None) => {
+                let crate_metadata = CrateMetadata::from_manifest_path(
+                    manifest_path,
+                    contract_build::Target::Wasm,
+                )?;
+
+                if crate_metadata.contract_bundle_path().exists() {
+                    crate_metadata.contract_bundle_path()
+                } else if crate_metadata.metadata_path().exists() {
+                    crate_metadata.metadata_path()
+                } else {
+                    anyhow::bail!(
+                        "Failed to find any contract artifacts in target directory. \n\
+                        Run `cargo contract build --release` to generate the artifacts."
+                    )
+                }
+            }
+            (None, Some(artifact_file)) => artifact_file.clone(),
+            (Some(_), Some(_)) => {
+                anyhow::bail!("conflicting options: --manifest-path and --file")
+            }
+        };
+        Self::from_artifact_path(artifact_path.as_path())
+    }
+    /// Given a contract artifact path, load the contract code and metadata where
+    /// possible.
+    fn from_artifact_path(path: &Path) -> Result<Self> {
+        tracing::debug!("Loading contracts artifacts from `{}`", path.display());
+        let (metadata_path, metadata, code) =
+            match path.extension().and_then(|ext| ext.to_str()) {
+                Some("contract") | Some("json") => {
+                    let metadata = ContractMetadata::load(path)?;
+                    let code = metadata.clone().source.wasm.map(|wasm| WasmCode(wasm.0));
+                    (PathBuf::from(path), Some(metadata), code)
+                }
+                Some("wasm") => {
+                    let file_name = path.file_stem()
+                        .context("WASM bundle file has unreadable name")?
+                        .to_str()
+                        .context("Error parsing filename string")?;
+                    let code = Some(WasmCode(std::fs::read(path)?));
+                    let dir = path.parent().map_or_else(PathBuf::new, PathBuf::from);
+                    let metadata_path = dir.join(format!("{file_name}.json"));
+                    if !metadata_path.exists() {
+                        (metadata_path, None, code)
+                    } else {
+                        let metadata = ContractMetadata::load(&metadata_path)?;
+                        (metadata_path, Some(metadata), code)
+                    }
+                }
+                Some(ext) => anyhow::bail!(
+                    "Invalid artifact extension {ext}, expected `.contract`, `.json` or `.wasm`"
+                ),
+                None => {
+                    anyhow::bail!(
+                        "Artifact path has no extension, expected `.contract`, `.json`, or `.wasm`"
+                    )
+                }
+            };
+
+        if let Some(contract_metadata) = metadata.as_ref() {
+            if let Err(e) = contract_metadata.check_ink_compatibility() {
+                eprintln!("{} {}", "warning:".yellow().bold(), e.to_string().bold());
+            }
+        }
+        Ok(Self {
+            artifacts_path: path.into(),
+            metadata_path,
+            metadata,
+            code,
+        })
+    }
+
+    /// Get the path of the artifact file used to load the artifacts.
+    pub fn artifact_path(&self) -> &Path {
+        self.artifacts_path.as_path()
+    }
+
+    /// Get contract metadata, if available.
+    ///
+    /// ## Errors
+    /// - No contract metadata could be found.
+    /// - Invalid contract metadata.
+    pub fn metadata(&self) -> Result<ContractMetadata> {
+        self.metadata.clone().ok_or_else(|| {
+            anyhow::anyhow!(
+                "No contract metadata found. Expected file {}",
+                self.metadata_path.as_path().display()
+            )
+        })
+    }
+
+    /// Get the code hash from the contract metadata.
+    pub fn code_hash(&self) -> Result<[u8; 32]> {
+        let metadata = self.metadata()?;
+        Ok(metadata.source.hash.0)
+    }
+
+    /// Construct a [`ContractMessageTranscoder`] from contract metadata.
+    pub fn contract_transcoder(&self) -> Result<ContractMessageTranscoder> {
+        let metadata = self.metadata()?;
+        ContractMessageTranscoder::try_from(metadata)
+            .context("Failed to deserialize ink project metadata from contract metadata")
+    }
+}

--- a/crates/extrinsics/src/contract_info.rs
+++ b/crates/extrinsics/src/contract_info.rs
@@ -1,0 +1,163 @@
+// Copyright 2018-2023 Parity Technologies (UK) Ltd.
+// This file is part of cargo-contract.
+//
+// cargo-contract is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// cargo-contract is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
+
+use anyhow::{
+    anyhow,
+    Result,
+};
+
+use super::{
+    get_best_block,
+    runtime_api::api,
+    Balance,
+    Client,
+    CodeHash,
+    DefaultConfig,
+};
+
+use scale::Decode;
+use std::option::Option;
+use subxt::{
+    backend::legacy::LegacyRpcMethods,
+    utils::AccountId32,
+};
+
+/// Fetch the contract info from the storage using the provided client.
+pub async fn fetch_contract_info(
+    contract: &AccountId32,
+    rpc: &LegacyRpcMethods<DefaultConfig>,
+    client: &Client,
+) -> Result<Option<ContractInfo>> {
+    let info_contract_call = api::storage().contracts().contract_info_of(contract);
+
+    let best_block = get_best_block(rpc).await?;
+
+    let contract_info_of = client
+        .storage()
+        .at(best_block)
+        .fetch(&info_contract_call)
+        .await?;
+
+    match contract_info_of {
+        Some(info_result) => {
+            let convert_trie_id = hex::encode(info_result.trie_id.0);
+            Ok(Some(ContractInfo {
+                trie_id: convert_trie_id,
+                code_hash: info_result.code_hash,
+                storage_items: info_result.storage_items,
+                storage_item_deposit: info_result.storage_item_deposit,
+            }))
+        }
+        None => Ok(None),
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct ContractInfo {
+    trie_id: String,
+    code_hash: CodeHash,
+    storage_items: u32,
+    storage_item_deposit: Balance,
+}
+
+impl ContractInfo {
+    /// Convert and return contract info in JSON format.
+    pub fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+
+    /// Return the trie_id of the contract.
+    pub fn trie_id(&self) -> &str {
+        &self.trie_id
+    }
+
+    /// Return the code_hash of the contract.
+    pub fn code_hash(&self) -> &CodeHash {
+        &self.code_hash
+    }
+
+    /// Return the number of storage items of the contract.
+    pub fn storage_items(&self) -> u32 {
+        self.storage_items
+    }
+
+    /// Return the storage item deposit of the contract.
+    pub fn storage_item_deposit(&self) -> Balance {
+        self.storage_item_deposit
+    }
+}
+
+/// Fetch the contract wasm code from the storage using the provided client and code hash.
+pub async fn fetch_wasm_code(
+    client: &Client,
+    rpc: &LegacyRpcMethods<DefaultConfig>,
+    hash: &CodeHash,
+) -> Result<Option<Vec<u8>>> {
+    let pristine_code_address = api::storage().contracts().pristine_code(hash);
+    let best_block = get_best_block(rpc).await?;
+
+    let pristine_bytes = client
+        .storage()
+        .at(best_block)
+        .fetch(&pristine_code_address)
+        .await?
+        .map(|v| v.0);
+
+    Ok(pristine_bytes)
+}
+
+/// Parse a contract account address from a storage key. Returns error if a key is
+/// malformated.
+fn parse_contract_account_address(
+    storage_contract_account_key: &[u8],
+    storage_contract_root_key_len: usize,
+) -> Result<AccountId32> {
+    // storage_contract_account_key is a concatenation of contract_info_of root key and
+    // Twox64Concat(AccountId)
+    let mut account = storage_contract_account_key
+        .get(storage_contract_root_key_len + 8..)
+        .ok_or(anyhow!("Unexpected storage key size"))?;
+    AccountId32::decode(&mut account)
+        .map_err(|err| anyhow!("AccountId deserialization error: {}", err))
+}
+
+/// Fetch all contract addresses from the storage using the provided client and count of
+/// requested elements starting from an optional address
+pub async fn fetch_all_contracts(
+    client: &Client,
+    rpc: &LegacyRpcMethods<DefaultConfig>,
+) -> Result<Vec<AccountId32>> {
+    let root_key = api::storage()
+        .contracts()
+        .contract_info_of_iter()
+        .to_root_bytes();
+
+    let best_block = get_best_block(rpc).await?;
+    let mut keys = client
+        .storage()
+        .at(best_block)
+        .fetch_raw_keys(root_key.clone())
+        .await?;
+
+    let mut contract_accounts = Vec::new();
+    while let Some(result) = keys.next().await {
+        let key = result?;
+        let contract_account = parse_contract_account_address(&key, root_key.len())?;
+        contract_accounts.push(contract_account);
+    }
+
+    Ok(contract_accounts)
+}


### PR DESCRIPTION
This PR simply moves related `contract_info` and `contract_artifacts` related code into their own files. The code and the crate API are unchanged.

The crate lib file had become too large, so this begins to split it up a bit.