### PR TITLE
Prevent submitting calls to messages marked as immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove check for compatible `scale` and `scale-info` versions - [#1370](https://github.com/paritytech/cargo-contract/pull/1370)
 - Add workspace support -[#1358](https://github.com/paritytech/cargo-contract/pull/1358)
 
+### Fixed
+- Do not allow to execute calls on immutable contract messages - [#1397](https://github.com/paritytech/cargo-contract/pull/1397)
+
 ## [4.0.0-alpha]
 
 Replaces the yanked `3.1.0` due to issues with supporting *both* Rust versions < `1.70`

--- a/crates/extrinsics/src/call.rs
+++ b/crates/extrinsics/src/call.rs
@@ -15,13 +15,31 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{
-    account_id, events::DisplayEvents, runtime_api::api, state, state_call,
-    submit_extrinsic, AccountId32, Balance, BalanceVariant, Client,
-    ContractMessageTranscoder, DefaultConfig, ErrorVariant, Missing, TokenMetadata,
+    account_id,
+    events::DisplayEvents,
+    runtime_api::api,
+    state,
+    state_call,
+    submit_extrinsic,
+    AccountId32,
+    Balance,
+    BalanceVariant,
+    Client,
+    ContractMessageTranscoder,
+    DefaultConfig,
+    ErrorVariant,
+    Missing,
+    TokenMetadata,
 };
-use crate::{check_env_types, extrinsic_opts::ExtrinsicOpts};
+use crate::{
+    check_env_types,
+    extrinsic_opts::ExtrinsicOpts,
+};
 
-use anyhow::{anyhow, Result};
+use anyhow::{
+    anyhow,
+    Result,
+};
 use pallet_contracts_primitives::ContractExecResult;
 use scale::Encode;
 use sp_weights::Weight;
@@ -29,8 +47,12 @@ use subxt_signer::sr25519::Keypair;
 
 use core::marker::PhantomData;
 use subxt::{
-    backend::{legacy::LegacyRpcMethods, rpc::RpcClient},
-    Config, OnlineClient,
+    backend::{
+        legacy::LegacyRpcMethods,
+        rpc::RpcClient,
+    },
+    Config,
+    OnlineClient,
 };
 
 pub struct CallOpts {

--- a/crates/extrinsics/src/call.rs
+++ b/crates/extrinsics/src/call.rs
@@ -278,7 +278,7 @@ impl CallExec {
             .mutates()
         {
             let inner = anyhow!(
-                "Tried to execute a call to immutable contract message '{}'. Please do a dry-run instead.",
+                "Tried to execute a call on the immutable contract message '{}'. Please do a dry-run instead.",
                 &self.message
             );
             return Err(inner.into());

--- a/crates/extrinsics/src/integration_tests.rs
+++ b/crates/extrinsics/src/integration_tests.rs
@@ -15,27 +15,14 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-    CallCommandBuilder,
-    ExtrinsicOptsBuilder,
-    InstantiateCommandBuilder,
-    RemoveCommandBuilder,
-    UploadCommandBuilder,
+    CallCommandBuilder, ExtrinsicOptsBuilder, InstantiateCommandBuilder,
+    RemoveCommandBuilder, UploadCommandBuilder,
 };
 use anyhow::Result;
 use contract_build::code_hash;
 use predicates::prelude::*;
-use std::{
-    ffi::OsStr,
-    path::Path,
-    process,
-    str,
-    thread,
-    time,
-};
-use subxt::{
-    OnlineClient,
-    PolkadotConfig as DefaultConfig,
-};
+use std::{ffi::OsStr, path::Path, process, str, thread, time};
+use subxt::{OnlineClient, PolkadotConfig as DefaultConfig};
 
 const CONTRACTS_NODE: &str = "substrate-contracts-node";
 
@@ -96,24 +83,22 @@ impl ContractsNodeProcess {
             );
             let result = OnlineClient::new().await;
             if let Ok(client) = result {
-                break Ok(client)
+                break Ok(client);
             }
             if attempts < MAX_ATTEMPTS {
                 attempts += 1;
-                continue
+                continue;
             }
             if let Err(err) = result {
-                break Err(err)
+                break Err(err);
             }
         };
         match client {
-            Ok(client) => {
-                Ok(Self {
-                    proc,
-                    client,
-                    tmp_dir,
-                })
-            }
+            Ok(client) => Ok(Self {
+                proc,
+                client,
+                tmp_dir,
+            }),
             Err(err) => {
                 let err = anyhow::anyhow!(
                     "Failed to connect to node rpc after {} attempts: {}",
@@ -508,6 +493,13 @@ async fn api_build_upload_instantiate_call() {
         .unwrap()
         .to_string();
     assert!(value.contains("true"), "{:#?}", value);
+
+    // call the contract on the immutable "get" message trying to execute
+    // this should fail because "get" is immutable
+    match call.call(None).await {
+        Err(crate::ErrorVariant::Generic(_)) => {}
+        _ => panic!("immutable call was not prevented"),
+    }
 
     // call the contract
     // flip the value

--- a/crates/extrinsics/src/integration_tests.rs
+++ b/crates/extrinsics/src/integration_tests.rs
@@ -15,14 +15,27 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{
-    CallCommandBuilder, ExtrinsicOptsBuilder, InstantiateCommandBuilder,
-    RemoveCommandBuilder, UploadCommandBuilder,
+    CallCommandBuilder,
+    ExtrinsicOptsBuilder,
+    InstantiateCommandBuilder,
+    RemoveCommandBuilder,
+    UploadCommandBuilder,
 };
 use anyhow::Result;
 use contract_build::code_hash;
 use predicates::prelude::*;
-use std::{ffi::OsStr, path::Path, process, str, thread, time};
-use subxt::{OnlineClient, PolkadotConfig as DefaultConfig};
+use std::{
+    ffi::OsStr,
+    path::Path,
+    process,
+    str,
+    thread,
+    time,
+};
+use subxt::{
+    OnlineClient,
+    PolkadotConfig as DefaultConfig,
+};
 
 const CONTRACTS_NODE: &str = "substrate-contracts-node";
 
@@ -94,11 +107,13 @@ impl ContractsNodeProcess {
             }
         };
         match client {
-            Ok(client) => Ok(Self {
-                proc,
-                client,
-                tmp_dir,
-            }),
+            Ok(client) => {
+                Ok(Self {
+                    proc,
+                    client,
+                    tmp_dir,
+                })
+            }
             Err(err) => {
                 let err = anyhow::anyhow!(
                     "Failed to connect to node rpc after {} attempts: {}",


### PR DESCRIPTION
## Summary

Related issue: https://github.com/paritytech/ink/issues/1969

`ink!` can't properly prevent messages supposed to be immutable from changing state regardless. Instead, we rely on the client and tooling to honor the `mutates` field in the metadata.

## Description
Without this change, cargo contract will happily execute messages like the one below. This message receives `&self` which signals it should be immutable. Other contract languages, e.g. Solidity, would refuse to compile this. Instead, we rely on the client to prevent it. The rogue balance transfer is just an illustration; Things like that might come from a rogue snippet or sit inside a rogue library.

```rust
        #[ink(message)]
        pub fn get(&self) -> bool {
            // oops
            self.env()
                .transfer(self.env().caller(), self.env().balance())
                .unwrap();

            self.value
        }
```

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
