### PR TITLE
Add schema generation and verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add schema generation and verification - [#1404](https://github.com/paritytech/cargo-contract/pull/1404)
 - Compare `Environment` types against the node - [#1377](https://github.com/paritytech/cargo-contract/pull/1377)
 - Adds workflow for publishing docker images for the verifiable builds - [#1267](https://github.com/paritytech/cargo-contract/pull/1267)
 - Detect `INK_STATIC_BUFFER_SIZE` env var - [#1310](https://github.com/paritytech/cargo-contract/pull/1310)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.10",
  "once_cell",
+ "serde",
  "version_check",
 ]
 
@@ -435,6 +436,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,10 +757,13 @@ dependencies = [
  "contract-transcode",
  "current_platform",
  "hex",
+ "ink_metadata",
+ "jsonschema",
  "pallet-contracts-primitives",
  "predicates",
  "primitive-types",
  "regex",
+ "schemars",
  "semver",
  "serde",
  "serde_json",
@@ -1591,6 +1616,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "environmental"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1685,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,6 +1749,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1884,8 +1938,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2468,6 +2524,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,6 +2538,15 @@ dependencies = [
  "hermit-abi",
  "rustix 0.38.21",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "iso8601"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -2621,6 +2692,36 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash 0.8.3",
+ "anyhow",
+ "base64 0.21.3",
+ "bytecount",
+ "clap",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.10",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2852,6 +2953,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,6 +3043,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,6 +3064,21 @@ checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+dependencies = [
  "num-traits",
 ]
 
@@ -2963,6 +3099,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3572,6 +3719,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+dependencies = [
+ "base64 0.21.3",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
 ]
 
 [[package]]
@@ -5130,6 +5312,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5800,6 +6003,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6253,6 +6468,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -35,7 +35,9 @@ serde_json = "1.0.108"
 serde = { version = "1.0.192", default-features = false, features = ["derive"] }
 url = { version = "2.4.1", features = ["serde"] }
 semver = "1.0"
-
+jsonschema = "0.17"
+schemars = "0.8"
+ink_metadata = "5.0.0-alpha"
 
 
 # dependencies for extrinsics (deploying and calling a contract)

--- a/crates/cargo-contract/src/cmd/mod.rs
+++ b/crates/cargo-contract/src/cmd/mod.rs
@@ -21,6 +21,7 @@ pub mod encode;
 pub mod info;
 pub mod instantiate;
 pub mod remove;
+pub mod schema;
 pub mod upload;
 pub mod verify;
 
@@ -37,6 +38,10 @@ pub(crate) use self::{
     },
     instantiate::InstantiateCommand,
     remove::RemoveCommand,
+    schema::{
+        GenerateSchemaCommand,
+        VerifySchemaCommand,
+    },
     upload::UploadCommand,
     verify::VerifyCommand,
 };

--- a/crates/cargo-contract/src/cmd/schema.rs
+++ b/crates/cargo-contract/src/cmd/schema.rs
@@ -22,9 +22,9 @@ enum Metadata {
     /// Represents the outer schema format of the contract
     #[clap(name = "outer")]
     #[default]
+    Outer,
     /// Represents the inner schema format of the contract.
     /// Contains specification of the ink! contract.
-    Outer,
     #[clap(name = "inner")]
     Inner,
 }
@@ -37,23 +37,15 @@ pub struct GenerateSchemaCommand {
     metadata: Metadata,
 }
 
-/// Represents the result of schema generation
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct GenerationResult {
-    pub schema: String,
-}
-
 impl GenerateSchemaCommand {
-    pub fn run(&self) -> Result<GenerationResult> {
+    pub fn run(&self) -> Result<String> {
         let schema = match self.metadata {
             Metadata::Outer => schema_for!(ink_metadata::InkProject),
             Metadata::Inner => schema_for!(ink_metadata::ConstructorSpec),
         };
         let pretty_string = serde_json::to_string_pretty(&schema)?;
 
-        Ok(GenerationResult {
-            schema: pretty_string,
-        })
+        Ok(pretty_string)
     }
 }
 
@@ -100,7 +92,7 @@ impl VerifySchemaCommand {
             metadata_source = path.display().to_string();
         }
 
-        // 1a. Read metadata file
+        // 1b. Read metadata file
         if let Some(path) = &self.metadata {
             let file = File::open(path)
                 .context(format!("Failed to open metadata file {}", path.display()))?;

--- a/crates/cargo-contract/src/cmd/schema.rs
+++ b/crates/cargo-contract/src/cmd/schema.rs
@@ -1,0 +1,180 @@
+use std::{
+    fs::File,
+    path::PathBuf,
+};
+
+use anyhow::{
+    anyhow,
+    Context,
+    Result,
+};
+use colored::Colorize;
+use contract_build::{
+    Verbosity,
+    VerbosityFlags,
+};
+use jsonschema::JSONSchema;
+use schemars::schema_for;
+
+#[derive(Debug, Clone, Default, clap::ValueEnum)]
+#[clap(name = "metadata")]
+enum Metadata {
+    /// Represents the outer schema format of the contract
+    #[clap(name = "outer")]
+    #[default]
+    /// Represents the inner schema format of the contract.
+    /// Contains specification of the ink! contract.
+    Outer,
+    #[clap(name = "inner")]
+    Inner,
+}
+
+/// Checks if a contract in the given workspace matches that of a reference contract.
+#[derive(Debug, clap::Args)]
+pub struct GenerateSchemaCommand {
+    /// What type of metadata to generate.
+    #[clap(long, value_enum, default_value = "outer")]
+    metadata: Metadata,
+}
+
+/// Represents the result of schema generation
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct GenerationResult {
+    pub schema: String,
+}
+
+impl GenerateSchemaCommand {
+    pub fn run(&self) -> Result<GenerationResult> {
+        let schema = match self.metadata {
+            Metadata::Outer => schema_for!(ink_metadata::InkProject),
+            Metadata::Inner => schema_for!(ink_metadata::ConstructorSpec),
+        };
+        let pretty_string = serde_json::to_string_pretty(&schema)?;
+
+        Ok(GenerationResult {
+            schema: pretty_string,
+        })
+    }
+}
+
+/// Verifies the metadata of the given contract against the schema file.
+#[derive(Debug, clap::Args)]
+pub struct VerifySchemaCommand {
+    /// The path to metadata
+    #[clap(long, value_parser)]
+    schema: PathBuf,
+    /// The .contract path to verify the metadata
+    #[clap(name = "bundle", long, value_parser)]
+    contract_bundle: Option<PathBuf>,
+    /// What type of metadata to verify.
+    #[clap(long, conflicts_with = "bundle", value_parser)]
+    metadata: Option<PathBuf>,
+    /// Denotes if output should be printed to stdout.
+    #[clap(flatten)]
+    verbosity: VerbosityFlags,
+    /// Output the result in JSON format
+    #[clap(long, conflicts_with = "verbose")]
+    output_json: bool,
+}
+
+impl VerifySchemaCommand {
+    pub fn run(&self) -> Result<SchemaVerificationResult> {
+        let verbosity: Verbosity = TryFrom::<&VerbosityFlags>::try_from(&self.verbosity)?;
+
+        let mut metadata = serde_json::Value::Null;
+        let mut metadata_source = String::new();
+
+        // 1a. Extract given metadata from .contract bundle
+        if let Some(path) = &self.contract_bundle {
+            let file = File::open(path)
+                .context(format!("Failed to open contract bundle {}", path.display()))?;
+
+            let mut contract_metadata: contract_metadata::ContractMetadata =
+                serde_json::from_reader(&file).context(format!(
+                    "Failed to deserialize contract bundle {}",
+                    path.display()
+                ))?;
+            contract_metadata.remove_source_wasm_attribute();
+
+            metadata = serde_json::value::to_value(contract_metadata)?;
+            metadata_source = path.display().to_string();
+        }
+
+        // 1a. Read metadata file
+        if let Some(path) = &self.metadata {
+            let file = File::open(path)
+                .context(format!("Failed to open metadata file {}", path.display()))?;
+
+            let contract_metadata: contract_metadata::ContractMetadata =
+                serde_json::from_reader(&file).context(format!(
+                    "Failed to deserialize metadata file {}",
+                    path.display()
+                ))?;
+
+            metadata = serde_json::value::to_value(contract_metadata)?;
+            metadata_source = path.display().to_string();
+        }
+
+        // 2. Open schema file
+        let path = &self.schema;
+        let file = File::open(path)
+            .context(format!("Failed to open schema file {}", path.display()))?;
+
+        let schema: serde_json::Value = serde_json::from_reader(&file).context(
+            format!("Failed to deserialize schema file {}", path.display()),
+        )?;
+
+        // 3. Build validator
+
+        // We have to use let-else here, otherwise `&schema` is required to be static
+        let Ok(validator) = JSONSchema::compile(&schema) else {
+            anyhow::bail!("Failed to compile schema to validation tree")
+        };
+
+        // 3. Validate and display error if any
+        validator.validate(&metadata).map_err(|errors| {
+            let error_msg = errors.fold(
+                String::from("Error during schema validation:\n"),
+                |acc, e| format!("{}\n{}", acc, e),
+            );
+            anyhow!(error_msg)
+        })?;
+
+        Ok(SchemaVerificationResult {
+            is_verified: true,
+            metadata_source,
+            schema: self.schema.display().to_string(),
+            output_json: self.output_json,
+            verbosity,
+        })
+    }
+}
+
+/// The result of verification process
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct SchemaVerificationResult {
+    pub is_verified: bool,
+    pub metadata_source: String,
+    pub schema: String,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub output_json: bool,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub verbosity: Verbosity,
+}
+
+impl SchemaVerificationResult {
+    /// Display the result in a fancy format
+    pub fn display(&self) -> String {
+        format!(
+            "\n{} {} against schema {}",
+            "Successfully verified metadata in".bright_green().bold(),
+            format!("`{}`", &self.metadata_source).bold(),
+            format!("`{}`!", &self.schema).bold()
+        )
+    }
+
+    /// Display the build results in a pretty formatted JSON string.
+    pub fn serialize_json(&self) -> Result<String> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+}

--- a/crates/cargo-contract/src/main.rs
+++ b/crates/cargo-contract/src/main.rs
@@ -240,7 +240,7 @@ fn exec(cmd: Command) -> Result<()> {
         }
         Command::GenerateSchema(generate) => {
             let result = generate.run().map_err(format_err)?;
-            println!("{}", result.schema);
+            println!("{}", result);
             Ok(())
         }
         Command::VerifySchema(verify) => {

--- a/crates/cargo-contract/src/main.rs
+++ b/crates/cargo-contract/src/main.rs
@@ -24,11 +24,13 @@ use self::cmd::{
     CheckCommand,
     DecodeCommand,
     ErrorVariant,
+    GenerateSchemaCommand,
     InfoCommand,
     InstantiateCommand,
     RemoveCommand,
     UploadCommand,
     VerifyCommand,
+    VerifySchemaCommand,
 };
 use anyhow::{
     anyhow,
@@ -142,6 +144,12 @@ enum Command {
     /// workspace.
     #[clap(name = "verify")]
     Verify(VerifyCommand),
+    /// Generates schema from the current metadata specification.
+    #[clap(name = "generate-schema")]
+    GenerateSchema(GenerateSchemaCommand),
+    /// Verify schema from the current metadata specification.
+    #[clap(name = "verify-schema")]
+    VerifySchema(VerifySchemaCommand),
 }
 
 fn main() {
@@ -221,6 +229,21 @@ fn exec(cmd: Command) -> Result<()> {
             runtime.block_on(async { info.run().await.map_err(format_err) })
         }
         Command::Verify(verify) => {
+            let result = verify.run().map_err(format_err)?;
+
+            if result.output_json {
+                println!("{}", result.serialize_json()?)
+            } else if result.verbosity.is_verbose() {
+                println!("{}", result.display())
+            }
+            Ok(())
+        }
+        Command::GenerateSchema(generate) => {
+            let result = generate.run().map_err(format_err)?;
+            println!("{}", result.schema);
+            Ok(())
+        }
+        Command::VerifySchema(verify) => {
             let result = verify.run().map_err(format_err)?;
 
             if result.output_json {


### PR DESCRIPTION
## Summary
Closes #1090 and https://github.com/paritytech/ink/issues/1564
- [n] y/n | Does it introduce breaking changes?
- [y] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`? - 5.0.0-alpha

Introudeces schema generation and verfication commands.

## Description

This PR automated proces for metadata schema generation.

Whenever there are changes to the schema, if `cargo-contract` targets the latest version of `ink_metadata` the scheme can be generated with `cargo contract schema-generate inner/outer`. This will print json to STDOUT.

And here is the sample of how to verify the metadata against specified schema file:

Bundle:

```
cargo contract verify-schema --schema /Users/skymanone/Projects/ink/crates/metadata/contract_schema.json --bundle target/ink/flipper.contract

Successfully verified metadata in `target/ink/flipper.contract` against schema `/Users/skymanone/Projects/ink/crates/metadata/contract_schema.json`!
```

Metadata file:
```
cargo contract verify-schema --schema /Users/skymanone/Projects/ink/crates/metadata/contract_schema.json --metadata target/ink/flipper.json

Successfully verified metadata in `target/ink/flipper.json` against schema `/Users/skymanone/Projects/ink/crates/metadata/contract_schema.json`!
```

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand aras
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
