### PR TITLE
Fix docker image release

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -57,5 +57,5 @@ jobs:
           build-args: |
             CARGO_CONTRACT_GIT=https://github.com/paritytech/cargo-contract
             CARGO_CONTRACT_TAG=${{ github.event.release.tag_name }}
-          tags: ${{ env.IMAGE_NAME }}:${DOCKER_TAG}
+          tags: ${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}
 


### PR DESCRIPTION
## Summary
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
Fix Docker image creation on release

## Description
The Docker image tag was expanded too late, and the environment variable used at that point was not present.

## Checklist before requesting a review
- [y] My code follows the style guidelines of this project
- [n] I have added an entry to `CHANGELOG.md`
- [n] I have commented my code, particularly in hard-to-understand areas
- [n] I have added tests that prove my fix is effective or that my feature works
- [y] Any dependent changes have been merged and published in downstream modules
