### PR TITLE
fix(docker): Remove `linting` dependencies

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -91,8 +91,6 @@ RUN apt-get -y update && apt-get -y install gcc=${GCC_VERSION} g++=${G_VERSION} 
     fi \
     && echo "Executing ${COMMAND}" \
     && eval "${COMMAND}" \
-    && echo "Installing linting dependencies" \
-    && cargo install cargo-dylint dylint-link \
     # Cleanup after `cargo install`
     && rm -rf ${CARGO_HOME}/"registry" ${CARGO_HOME}/"git" /root/.cache/sccache \
     # apt clean up


### PR DESCRIPTION
## Summary
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?

Remove `linting` dependencies

## Description
The Docker image is used for release builds with an older stable compiler, which doesn't allow us to build the linting dependencies. However, for the current release, we can entirely disable it, since the linter is optional for the Wasm target.

## Checklist before requesting a review
- (n/a) My code follows the style guidelines of this project
- (n/a) I have added an entry to `CHANGELOG.md`
- (n/a) I have commented my code, particularly in hard-to-understand areas
- (n/a) I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
