### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To achieve it, you should build your contract using Docker image we provide:
 cargo contract build --verifiable
 ```
 
-You can find more detailed documentation how to use the image [here](/build-image/README.md)
+You can find more detailed documentation how to use the image [here](/build-image/README.md).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,6 @@ docker run --rm -it -v ${pwd}:/sources paritytech/contracts-ci-linux \
   cargo contract new --target-dir /sources my_contract
 ```
 
-If you want to reproduce other steps of CI process you can use the following
-[guide](https://github.com/paritytech/scripts#reproduce-ci-locally).
-
 ### Verifiable builds
 
 Some block explorers require the Wasm binary to be compiled in the deterministic environment.


### PR DESCRIPTION
Remove a deprecated link about testing the GitLab-Based CI locally: https://github.com/paritytech/scripts/blob/master/docs/legacy/reproduce_ci_locally.md.

Currently, we use GitHub Actions, allowing users to choose a tool to test CI locally. For example [`act`](https://github.com/nektos/act) works correctly, at least for `build` tests.