### PR TITLE
Replace `users` dep with `uzers`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
- "users",
+ "uzers",
  "wabt",
  "walkdir",
  "wasm-opt",
@@ -6056,16 +6056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6076,6 +6066,16 @@ name = "uuid"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+
+[[package]]
+name = "uzers"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "valuable"

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -47,7 +47,7 @@ crossterm = "0.27.0"
 contract-metadata = { version = "4.0.0-rc.1", path = "../metadata" }
 
 [target.'cfg(unix)'.dependencies]
-users = "0.11"
+uzers = "0.11"
 
 [build-dependencies]
 anyhow = "1.0.79"

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -329,8 +329,8 @@ async fn create_container(
     {
         user = Some(format!(
             "{}:{}",
-            users::get_current_uid(),
-            users::get_current_gid()
+            uzers::get_current_uid(),
+            uzers::get_current_gid()
         ));
     };
     #[cfg(windows)]


### PR DESCRIPTION
The `users` dep is no longer maintained, someone forked it to the `uzers` crate and maintains it there now. Details [here](https://github.com/ogham/rust-users/issues/54#issuecomment-1686030024).

Will get rid of
* https://github.com/paritytech/cargo-contract/security/dependabot/21 
* https://github.com/paritytech/ink/security/dependabot/6