### PR TITLE
Print type comparison warning only on `--verbose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `rpc` command - [#1458](https://github.com/paritytech/cargo-contract/pull/1458)
 
 ### Changed
+- Print type comparison warning only on `--verbose` - [#1483](https://github.com/paritytech/cargo-contract/pull/1483)
 - Mandatory dylint-based lints - [#1412](https://github.com/paritytech/cargo-contract/pull/1412)
 
 ## [4.0.0-rc.1]

--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -45,7 +45,9 @@ impl TryFrom<&VerbosityFlags> for Verbosity {
 }
 
 /// Denotes if output should be printed to stdout.
-#[derive(Clone, Copy, Default, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+#[derive(
+    Clone, Copy, Default, serde::Serialize, serde::Deserialize, Eq, PartialEq, Debug,
+)]
 pub enum Verbosity {
     /// Use default output
     #[default]

--- a/crates/cargo-contract/src/cmd/call.rs
+++ b/crates/cargo-contract/src/cmd/call.rs
@@ -93,6 +93,7 @@ impl CallCommand {
             .url(self.extrinsic_cli_opts.url.clone())
             .suri(self.extrinsic_cli_opts.suri.clone())
             .storage_deposit_limit(self.extrinsic_cli_opts.storage_deposit_limit.clone())
+            .verbosity(self.extrinsic_cli_opts.verbosity()?)
             .done();
         let call_exec = CallCommandBuilder::default()
             .contract(self.contract.clone())

--- a/crates/extrinsics/src/call.rs
+++ b/crates/extrinsics/src/call.rs
@@ -189,7 +189,7 @@ impl CallCommandBuilder<state::Message, state::ExtrinsicOptions> {
         let rpc = RpcClient::from_url(&url).await?;
         let client = OnlineClient::from_rpc_client(rpc.clone()).await?;
         let rpc = LegacyRpcMethods::new(rpc);
-        check_env_types(&client, &transcoder)?;
+        check_env_types(&client, &transcoder, self.opts.extrinsic_opts.verbosity())?;
 
         let token_metadata = TokenMetadata::query(&rpc).await?;
 

--- a/crates/extrinsics/src/extrinsic_opts.rs
+++ b/crates/extrinsics/src/extrinsic_opts.rs
@@ -217,7 +217,7 @@ impl ExtrinsicOpts {
             .transpose()?)
     }
 
-    /// Verbosity for error reporting.s
+    /// Verbosity for message reporting.
     pub fn verbosity(&self) -> &Verbosity {
         &self.verbosity
     }

--- a/crates/extrinsics/src/extrinsic_opts.rs
+++ b/crates/extrinsics/src/extrinsic_opts.rs
@@ -16,6 +16,7 @@
 
 use core::marker::PhantomData;
 
+use contract_build::Verbosity;
 use subxt_signer::{
     sr25519::Keypair,
     SecretUri,
@@ -47,6 +48,7 @@ pub struct ExtrinsicOpts {
     url: url::Url,
     suri: String,
     storage_deposit_limit: Option<BalanceVariant>,
+    verbosity: Verbosity,
 }
 
 /// Type state for the extrinsics' commands to tell that some mandatory state has not yet
@@ -130,6 +132,13 @@ impl<S> ExtrinsicOptsBuilder<S> {
         this.opts.storage_deposit_limit = storage_deposit_limit;
         this
     }
+
+    /// Set the verbosity level.
+    pub fn verbosity(self, verbosity: Verbosity) -> Self {
+        let mut this = self;
+        this.opts.verbosity = verbosity;
+        this
+    }
 }
 
 impl ExtrinsicOptsBuilder<state::Suri> {
@@ -150,6 +159,7 @@ impl ExtrinsicOpts {
                 url: url::Url::parse("ws://localhost:9944").unwrap(),
                 suri: String::new(),
                 storage_deposit_limit: None,
+                verbosity: Verbosity::Default,
             },
             marker: PhantomData,
         }
@@ -205,6 +215,11 @@ impl ExtrinsicOpts {
             .as_ref()
             .map(|bv| bv.denominate_balance(token_metadata))
             .transpose()?)
+    }
+
+    /// Verbosity for error reporting.s
+    pub fn verbosity(&self) -> &Verbosity {
+        &self.verbosity
     }
 }
 

--- a/crates/extrinsics/src/instantiate.rs
+++ b/crates/extrinsics/src/instantiate.rs
@@ -191,7 +191,7 @@ impl InstantiateCommandBuilder<state::ExtrinsicOptions> {
 
         let rpc_cli = RpcClient::from_url(&url).await?;
         let client = OnlineClient::from_rpc_client(rpc_cli.clone()).await?;
-        check_env_types(&client, &transcoder)?;
+        check_env_types(&client, &transcoder, self.opts.extrinsic_opts.verbosity())?;
         let rpc = LegacyRpcMethods::new(rpc_cli);
 
         let token_metadata = TokenMetadata::query(&rpc).await?;

--- a/crates/extrinsics/src/lib.rs
+++ b/crates/extrinsics/src/lib.rs
@@ -42,6 +42,7 @@ use env_check::compare_node_env_with_contract;
 use anyhow::Result;
 use contract_build::{
     CrateMetadata,
+    Verbosity,
     DEFAULT_KEY_COL_WIDTH,
 };
 use scale::{
@@ -260,11 +261,16 @@ async fn get_best_block<C: Config>(
 fn check_env_types<T>(
     client: &OnlineClient<T>,
     transcoder: &ContractMessageTranscoder,
+    verbosity: &Verbosity,
 ) -> Result<()>
 where
     T: Config,
 {
-    compare_node_env_with_contract(client.metadata().types(), transcoder.metadata())
+    compare_node_env_with_contract(
+        client.metadata().types(),
+        transcoder.metadata(),
+        verbosity,
+    )
 }
 
 // Converts a Url into a String representation without excluding the default port.

--- a/crates/extrinsics/src/upload.rs
+++ b/crates/extrinsics/src/upload.rs
@@ -118,7 +118,7 @@ impl UploadCommandBuilder<state::ExtrinsicOptions> {
         let url = self.opts.extrinsic_opts.url();
         let rpc_cli = RpcClient::from_url(&url).await?;
         let client = OnlineClient::from_rpc_client(rpc_cli.clone()).await?;
-        check_env_types(&client, &transcoder)?;
+        check_env_types(&client, &transcoder, self.opts.extrinsic_opts.verbosity())?;
         let rpc = LegacyRpcMethods::new(rpc_cli);
 
         let token_metadata = TokenMetadata::query(&rpc).await?;


### PR DESCRIPTION
## Summary
Closes #1482
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?



## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
