### PR TITLE
Fix build --verifiable command

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/bitnami/minideb:bullseye-amd64 as slimmed-rust
 # The rust version to use
 ARG RUST_VERSION=stable
 # The cargo contract version to use
-ARG CARGO_CONTRACT_VERSION=3.1.0
+ARG CARGO_CONTRACT_VERSION=3.2.0
 # Url to the cargo-contract repository to install from
 ARG CARGO_CONTRACT_GIT
 # Branch to use in git repository
@@ -49,7 +49,7 @@ RUN set -eux \
     && url="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
     && wget "$url" \
     && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --component rust-src rustfmt --default-toolchain $RUST_VERSION  \
+    && ./rustup-init -y --no-modify-path --profile minimal --component rust-src rustfmt clippy --default-toolchain $RUST_VERSION  \
     && rm rustup-init \
     && chmod -R a+w $RUSTUP_HOME $CARGO_HOME \
     && rustup --version \

--- a/build-image/README.md
+++ b/build-image/README.md
@@ -26,7 +26,7 @@ and work directory is set to `/contract`. You need to mount the folder with the 
 docker run -d \
     --name ink-container \
     --mount type=bind,source="$(pwd)",target="/contract" \
-    paritytech/contracts-verified
+    paritytech/contracts-verifiable
 ```
 
 For multi-contract projects, like in the example below:
@@ -50,3 +50,20 @@ to the root contract:
 It is a known issue that running AMD64 image on the ARM host architecture significantly impacts the performance
 and build times. To solve this issues, enable _Use Rosetta for x86/amd64 emulation on Apple Silicon_ in
 _Settings_ -> _Features in development_ tab in Docker Desktop App.
+
+**How to debug**
+
+Build docker image:
+
+```bash
+docker buildx build -t paritytech/contracts-verifiable:0.0.1 .
+```
+
+Run docker container:
+
+```bash
+docker container run \
+    -it --entrypoint /bin/bash \
+    --mount type=bind,source="$(pwd)",target="/contract" \
+    paritytech/contracts-verifiable:0.0.1
+```


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
Fix build --verifiable

## Description
Cargo contract version `4.0.0-rc.2`

`cargo contract build --verifiable`
causes an issue:
 ```
 [==] Checking clippy linting rules
error: 'cargo-clippy' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'
To install, run `rustup component add clippy`
ERROR: 
ERROR: Failed to read build result from docker build
```
## Checklist before requesting a review
- [ ] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
