### PR TITLE
Make the error message on incompatible versions clearer

### DIFF
--- a/crates/metadata/src/byte_str.rs
+++ b/crates/metadata/src/byte_str.rs
@@ -23,7 +23,7 @@ where
 {
     if bytes.is_empty() {
         // Return empty string without prepended `0x`.
-        return serializer.serialize_str("")
+        return serializer.serialize_str("");
     }
     serde_hex::serialize(bytes, serializer)
 }

--- a/crates/metadata/src/compatibility.rs
+++ b/crates/metadata/src/compatibility.rs
@@ -81,7 +81,7 @@ pub fn check_contract_ink_compatibility(
             .join(", ");
 
         let ink_update_message = format!(
-            "update the contract ink! to a version of {}",
+            "change the ink! version of your contract to {}",
             ink_required_versions
         );
         let contract_not_compatible_message = "The cargo-contract is not compatible \
@@ -143,8 +143,8 @@ mod tests {
         assert_eq!(
             res.to_string(),
             "The cargo-contract is not compatible with the contract's ink! version. \
-            Please use cargo-contract in version '1.5.0' or update \
-            the contract ink! to a version of '^4.0.0-alpha.3', '^4.0.0'"
+            Please use cargo-contract in version '1.5.0' or change \
+            the ink! version of your contract to '^4.0.0-alpha.3', '^4.0.0'"
         );
 
         let ink_version =
@@ -155,8 +155,8 @@ mod tests {
         assert_eq!(
             res.to_string(),
             "The cargo-contract is not compatible with the contract's ink! version. \
-            Please use cargo-contract in version '1.5.0' or update \
-            the contract ink! to a version of '^4.0.0-alpha.3', '^4.0.0'"
+            Please use cargo-contract in version '1.5.0' or change \
+            the ink! version of your contract to '^4.0.0-alpha.3', '^4.0.0'"
         );
     }
 

--- a/crates/metadata/src/compatibility.rs
+++ b/crates/metadata/src/compatibility.rs
@@ -85,7 +85,7 @@ pub fn check_contract_ink_compatibility(
             ink_required_versions
         );
         let contract_not_compatible_message = "The cargo-contract is not compatible \
-                                                    with the contract's ink! version. Please";
+                                                    with the contract's ink! version.";
 
         // Find best cargo-contract version
         let best_cargo_contract_version = compatibility
@@ -97,7 +97,7 @@ pub fn check_contract_ink_compatibility(
                     .iter()
                     .any(|req| req.matches(ink_version))
                 {
-                    return Some(ver)
+                    return Some(ver);
                 }
                 None
             })
@@ -115,7 +115,7 @@ pub fn check_contract_ink_compatibility(
             ))?;
 
         bail!(
-            "{} update the cargo-contract to version \
+            "{} Please use cargo-contract in version \
             '{}' or {}",
             contract_not_compatible_message,
             best_cargo_contract_version,
@@ -143,7 +143,7 @@ mod tests {
         assert_eq!(
             res.to_string(),
             "The cargo-contract is not compatible with the contract's ink! version. \
-            Please update the cargo-contract to version '1.5.0' or update \
+            Please use cargo-contract in version '1.5.0' or update \
             the contract ink! to a version of '^4.0.0-alpha.3', '^4.0.0'"
         );
 
@@ -155,7 +155,7 @@ mod tests {
         assert_eq!(
             res.to_string(),
             "The cargo-contract is not compatible with the contract's ink! version. \
-            Please update the cargo-contract to version '1.5.0' or update \
+            Please use cargo-contract in version '1.5.0' or update \
             the contract ink! to a version of '^4.0.0-alpha.3', '^4.0.0'"
         );
     }


### PR DESCRIPTION
## Summary
- [] n | Does it introduce breaking changes?
- [] n | Is it dependent on the specific version of `ink` or `pallet-contracts`?

## Description
Previously the error message when using ver `4` of cargo contracts on contracts written in ink version `4.x` was to "update to cargo contract to 3.2" which is slightly confusing, since you actually have to downgrade then. The error message was adjusted.
