### PR TITLE
Disable linter in docker container

### DIFF
--- a/crates/cargo-contract/src/cmd/build.rs
+++ b/crates/cargo-contract/src/cmd/build.rs
@@ -62,7 +62,7 @@ pub struct BuildCommand {
     ///
     /// This only adds extra ink! linting checks. Basic clippy and ink! lints which we
     /// are deem important are run anyways.
-    #[clap(long)]
+    #[clap(long, conflicts_with = "verifiable")]
     lint: bool,
     /// Which build artifacts to generate.
     ///


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
Disable flags combination: `cargo contract build --verifiable --lint`

## Description
Do not allow for lint option when running contract build in docker container 

## Checklist before requesting a review
- [ ] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
