### PR TITLE
[ci] Run dependabot with app credentials

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,9 +4,16 @@ on:
 jobs:
   merge:
     runs-on: ubuntu-latest
+    # run action only on dependabot branches
+    if: github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
           target: patch
-          github-token: ${{ secrets.DEPENDABOT_AUTO_MERGE_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
Closes #_
- [x] n | Does it introduce breaking changes?
- [x] n | Is it dependent on the specific version of `ink` or `pallet-contracts`?

More details can be found in [this comment](https://github.com/paritytech/ci_cd/issues/957#issuecomment-1983192568)

