### PR TITLE
Remove docker container on build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix parsing of docker STDOUT - [#1526](https://github.com/paritytech/cargo-contract/pull/1526)
+- Remove docker container on build failure - [#1531](https://github.com/paritytech/cargo-contract/pull/1531)
 
 ## [4.0.0-rc.3]
 


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
Remove docker container on build failure

## Description
It fixed an error where the docker container was left in an improper state after a build failure. 
When a failure occurred during contract build, the container was left in an improper state. So, even when the user attempted to compile the contract with the fix, the build still failed due to the incorrect container state after the first build.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
