### PR TITLE
Fix e2e tests in the contract template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,4 +203,6 @@ jobs:
           # Build with linting
           cargo run --profile debug-ci -- contract build --lint --manifest-path=${{ runner.temp }}/foobar/Cargo.toml &&
           cargo run --profile debug-ci -- contract check --manifest-path=${{ runner.temp }}/foobar/Cargo.toml &&
-          cargo run --profile debug-ci -- contract build --manifest-path=${{ runner.temp }}/foobar/Cargo.toml --release
+          cargo run --profile debug-ci -- contract build --manifest-path=${{ runner.temp }}/foobar/Cargo.toml --release &&
+          # Run tests
+          cargo test --profile debug-ci --all-features -- --test-threads=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+Fix e2e tests in the contract template - [#1537](https://github.com/paritytech/cargo-contract/pull/1537)
+
 ## [4.0.0]
 
 This `cargo-contract` release is compatible with Rust versions `>=1.70`and ink! versions `>=5.0.0`

--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 [dependencies]
 ink = { version = "5.0.0", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
+[dev-dependencies]
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"
@@ -17,8 +17,6 @@ path = "lib.rs"
 default = ["std"]
 std = [
     "ink/std",
-    "scale/std",
-    "scale-info/std",
 ]
 ink-as-dependency = []
 e2e-tests = []


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
Fix e2e tests in the contract template

## Description
ink e2e tests were not updated to version 5, causing failures when executing the following commands
```
cargo contract new hehe
cargo test --release --features e2e-tests
```

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
