### PR TITLE
Verify raw Wasm in `cargo contract verify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Verify raw Wasm in cargo contract verify - [#1551](https://github.com/paritytech/cargo-contract/pull/1551)
+
 ## [4.0.2]
 
 ### Fixed

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -89,13 +89,7 @@ impl VerifyCommand {
         path: &PathBuf,
     ) -> Result<VerificationResult> {
         // 1. Read code hash binary from the path.
-        let file = File::open(path)
-            .context(format!("Failed to open contract binary {}", path.display()))?;
-
-        let mut ref_reader = BufReader::new(file);
-        let mut ref_buffer = Vec::new();
-        ref_reader
-            .read_to_end(&mut ref_buffer)
+       let ref_buffer = std::fs::read(path)
             .context(format!("Failed to read contract binary {}", path.display()))?;
 
         let reference_code_hash = code_hash(&ref_buffer);
@@ -126,16 +120,8 @@ impl VerifyCommand {
                 .bright_yellow())
         };
 
-        let file = File::open(&built_wasm_path).context(format!(
-            "Failed to open contract binary {}",
-            &built_wasm_path.display()
-        ))?;
-
-        let mut target_reader = BufReader::new(file);
-        let mut target_buffer = Vec::new();
-        target_reader
-            .read_to_end(&mut target_buffer)
-            .context(format!("Failed to read contract binary {}", path.display()))?;
+       let target_buffer = std::fs::read(&built_wasm_path)
+            .context(format!("Failed to read contract binary {}", built_wasm_path.display()))?;
 
         let output_code_hash = code_hash(&target_buffer);
 

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -130,8 +130,8 @@ impl VerifyCommand {
             anyhow::bail!(format!(
                 "\nFailed to verify the authenticity of wasm binary at {} against the workspace \n\
                 found at {}.\n Expected {}, found {}",
-                format!("`{}`", built_wasm_path.display()).bright_white(),
                 format!("`{}`", path.display()).bright_white(),
+                format!("`{}`", built_wasm_path.display()).bright_white(),
                 format!("{}", reference_code_hash).bright_white(),
                 format!("{}", output_code_hash).bright_white())
             );

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -25,13 +25,19 @@ use contract_build::{
     BuildArtifacts,
     BuildInfo,
     BuildMode,
+    BuildResult,
     ExecuteArgs,
     ImageVariant,
     ManifestPath,
+    MetadataArtifacts,
+    MetadataResult,
     Verbosity,
     VerbosityFlags,
 };
-use contract_metadata::ContractMetadata;
+use contract_metadata::{
+    CodeHash,
+    ContractMetadata,
+};
 
 use std::{
     fs::File,
@@ -49,7 +55,11 @@ pub struct VerifyCommand {
     manifest_path: Option<PathBuf>,
     /// The reference Wasm contract (`*.contract`) that the workspace will be checked
     /// against.
-    contract: PathBuf,
+    contract: Option<PathBuf>,
+    /// The reference Wasm contract binary (`*.wasm`) that the workspace will be checked
+    /// against.
+    #[clap(long, conflicts_with = "contract")]
+    wasm: Option<PathBuf>,
     /// Denotes if output should be printed to stdout.
     #[clap(flatten)]
     verbosity: VerbosityFlags,
@@ -62,9 +72,88 @@ impl VerifyCommand {
     pub fn run(&self) -> Result<VerificationResult> {
         let manifest_path = ManifestPath::try_from(self.manifest_path.as_ref())?;
         let verbosity: Verbosity = TryFrom::<&VerbosityFlags>::try_from(&self.verbosity)?;
+        if let Some(path) = &self.contract {
+            self.verify_contract(manifest_path, verbosity, path)
+        } else if let Some(path) = &self.wasm {
+            self.verify_wasm(manifest_path, verbosity, path)
+        } else {
+            anyhow::bail!("Either --wasm or --contract must be specified")
+        }
+    }
 
+    /// Verify `.wasm` binary.
+    fn verify_wasm(
+        &self,
+        manifest_path: ManifestPath,
+        verbosity: Verbosity,
+        path: &PathBuf,
+    ) -> Result<VerificationResult> {
+        // 1. Read code hash binary from the path.
+        let file = File::open(path)
+            .context(format!("Failed to open contract binary {}", path.display()))?;
+
+        let reference_code_hash: CodeHash = serde_json::from_reader(&file).context(
+            format!("Failed to deserialize contract binary {}", path.display()),
+        )?;
+
+        // 2. Call `cargo contract build` in the release mode.
+        let args = ExecuteArgs {
+            manifest_path: manifest_path.clone(),
+            verbosity,
+            build_mode: BuildMode::Release,
+            build_artifact: BuildArtifacts::All,
+            extra_lints: false,
+            ..Default::default()
+        };
+
+        let build_result = execute(args)?;
+
+        // 4. Grab the code hash from the built contract and compare it with the reference
+        //    one.
+        let built_contract_path = if let Some(m) = build_result.metadata_result {
+            m
+        } else {
+            // Since we're building the contract ourselves this should always be
+            // populated, but we'll bail out here just in case.
+            anyhow::bail!(
+                "\nThe metadata for the workspace contract does not contain a Wasm binary,\n\
+                therefore we are unable to verify the contract."
+                .to_string()
+                .bright_yellow()
+            )
+        };
+        let target_bundle = &built_contract_path.dest_bundle;
+
+        if self
+            .compare_code(&reference_code_hash, &verbosity, &built_contract_path)
+            .is_err()
+        {
+            anyhow::bail!(format!(
+                "\nFailed to verify the authenticity of wasm binary at {} against the workspace \n\
+                found at {}.",
+                format!("`{}`", path.display()).bright_white(),
+                format!("{:?}", manifest_path.as_ref()).bright_white()).bright_red()
+            );
+        }
+
+        Ok(VerificationResult {
+            is_verified: true,
+            image: None,
+            contract: target_bundle.display().to_string(),
+            reference_contract: path.display().to_string(),
+            output_json: self.output_json,
+            verbosity,
+        })
+    }
+
+    /// Verify the `.contract` bundle.
+    fn verify_contract(
+        &self,
+        manifest_path: ManifestPath,
+        verbosity: Verbosity,
+        path: &PathBuf,
+    ) -> Result<VerificationResult> {
         // 1. Read the given metadata, and pull out the `BuildInfo`
-        let path = &self.contract;
         let file = File::open(path)
             .context(format!("Failed to open contract bundle {}", path.display()))?;
 
@@ -166,28 +255,12 @@ impl VerifyCommand {
             )
         };
 
-        let target_bundle = built_contract_path.dest_bundle;
+        let target_bundle = &built_contract_path.dest_bundle;
 
-        let file = File::open(target_bundle.clone()).context(format!(
-            "Failed to open contract bundle {}",
-            target_bundle.display()
-        ))?;
-        let built_contract: ContractMetadata =
-            serde_json::from_reader(file).context(format!(
-                "Failed to deserialize contract bundle {}",
-                target_bundle.display()
-            ))?;
-
-        let target_code_hash = built_contract.source.hash;
-
-        if reference_code_hash != target_code_hash {
-            verbose_eprintln!(
-                verbosity,
-                "Expected Code Hash: '{}'\n\nGot Code Hash: `{}`",
-                &reference_code_hash,
-                &target_code_hash
-            );
-
+        if self
+            .compare_code(&reference_code_hash, &verbosity, &built_contract_path)
+            .is_err()
+        {
             anyhow::bail!(format!(
                 "\nFailed to verify the authenticity of {} contract against the workspace \n\
                 found at {}.",
@@ -204,6 +277,41 @@ impl VerifyCommand {
             output_json: self.output_json,
             verbosity,
         })
+    }
+
+    /// Compares the reference code hash with the extracted code from built contract's
+    /// metadata.
+    fn compare_code(
+        &self,
+        reference_code_hash: &CodeHash,
+        verbosity: &Verbosity,
+        built_contract_path: &MetadataArtifacts,
+    ) -> Result<()> {
+        let target_bundle = &built_contract_path.dest_bundle;
+
+        let file = File::open(target_bundle.clone()).context(format!(
+            "Failed to open contract bundle {}",
+            target_bundle.display()
+        ))?;
+        let built_contract: ContractMetadata =
+            serde_json::from_reader(file).context(format!(
+                "Failed to deserialize contract bundle {}",
+                target_bundle.display()
+            ))?;
+
+        let target_code_hash = built_contract.source.hash;
+
+        if reference_code_hash != &target_code_hash {
+            verbose_eprintln!(
+                verbosity,
+                "Expected Code Hash: '{}'\n\nGot Code Hash: `{}`",
+                &reference_code_hash,
+                &target_code_hash
+            );
+            anyhow::bail!("Verification failed.")
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -25,12 +25,10 @@ use contract_build::{
     BuildArtifacts,
     BuildInfo,
     BuildMode,
-    BuildResult,
     ExecuteArgs,
     ImageVariant,
     ManifestPath,
     MetadataArtifacts,
-    MetadataResult,
     Verbosity,
     VerbosityFlags,
 };

--- a/crates/cargo-contract/tests/verify.rs
+++ b/crates/cargo-contract/tests/verify.rs
@@ -23,8 +23,9 @@ fn cargo_contract<P: AsRef<Path>>(path: P) -> assert_cmd::Command {
     cmd
 }
 
-/// Compile the reference contract and return a byte array of its bundle.
-fn compile_reference_contract() -> Vec<u8> {
+/// Compile the reference contract and return a byte array of its bundle and raw wasm
+/// binary.
+fn compile_reference_contract() -> (Vec<u8>, Vec<u8>) {
     let contract = r#"
     #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
@@ -48,7 +49,7 @@ fn compile_reference_contract() -> Vec<u8> {
 
             #[ink(message)]
             pub fn inc(&mut self, by: i32) {
-                self.value.saturating_add(by);
+                self.value = self.value.saturating_add(by);
             }
 
             #[ink(message, selector = 0xCACACACA)]
@@ -82,9 +83,14 @@ fn compile_reference_contract() -> Vec<u8> {
         .success();
 
     let bundle_path = project_dir.join("target/ink/incrementer.contract");
+    let bundle = std::fs::read(bundle_path)
+        .expect("Failed to read the content of the contract bundle!");
 
-    std::fs::read(bundle_path)
-        .expect("Failed to read the content of the contract bundle!")
+    let wasm_path = project_dir.join("target/ink/incrementer.wasm");
+    let wasm = std::fs::read(wasm_path)
+        .expect("Failed to read the content of the contract binary!");
+
+    (bundle, wasm)
 }
 
 #[test]
@@ -113,7 +119,7 @@ fn verify_equivalent_contracts() {
 
             #[ink(message)]
             pub fn inc(&mut self, by: i32) {
-                self.value.saturating_add(by);
+                self.value = self.value.saturating_add(by);
             }
 
             #[ink(message, selector = 0xCACACACA)]
@@ -139,11 +145,14 @@ fn verify_equivalent_contracts() {
     let lib = project_dir.join("lib.rs");
     std::fs::write(lib, contract).expect("Failed to write contract lib.rs");
 
-    // Compile reference contract and write bundle in the directory.
-    let reference_contents = compile_reference_contract();
+    // Compile reference contract and write bundle and wasm in the directory.
+    let (ref_bundle, ref_wasm) = compile_reference_contract();
     let bundle = project_dir.join("reference.contract");
-    std::fs::write(bundle, reference_contents)
+    std::fs::write(bundle, ref_bundle)
         .expect("Failed to write bundle contract to the current dir!");
+    let wasm = project_dir.join("reference.wasm");
+    std::fs::write(wasm, ref_wasm)
+        .expect("Failed to write wasm binary to the current dir!");
 
     // when
     let output: &str = r#""is_verified": true"#;
@@ -151,7 +160,17 @@ fn verify_equivalent_contracts() {
     // then
     cargo_contract(&project_dir)
         .arg("verify")
+        .arg("--contract")
         .arg("reference.contract")
+        .arg("--output-json")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(output));
+    // and
+    cargo_contract(&project_dir)
+        .arg("verify")
+        .arg("--wasm")
+        .arg("reference.wasm")
         .arg("--output-json")
         .assert()
         .success()
@@ -184,7 +203,7 @@ fn verify_different_contracts() {
 
             #[ink(message)]
             pub fn inc(&mut self, by: i32) {
-                self.value.saturating_add(by);
+                self.value = self.value.saturating_add(by);
             }
 
             #[ink(message, selector = 0xCBCBCBCB)]
@@ -214,11 +233,14 @@ fn verify_different_contracts() {
     tracing::debug!("Building contract in {}", project_dir.to_string_lossy());
     cargo_contract(&project_dir).arg("build").assert().success();
 
-    // Compile reference contract and write bundle in the directory.
-    let reference_contents = compile_reference_contract();
+    // Compile reference contract and write bundle and wasm in the directory.
+    let (ref_bundle, ref_wasm) = compile_reference_contract();
     let bundle = project_dir.join("reference.contract");
-    std::fs::write(bundle, reference_contents)
+    std::fs::write(bundle, ref_bundle)
         .expect("Failed to write bundle contract to the current dir!");
+    let wasm = project_dir.join("reference.wasm");
+    std::fs::write(wasm, ref_wasm)
+        .expect("Failed to write wasm binary to the current dir!");
 
     // when
     let output: &str = r#"Failed to verify the authenticity of `incrementer`"#;
@@ -226,7 +248,20 @@ fn verify_different_contracts() {
     // then
     cargo_contract(&project_dir)
         .arg("verify")
+        .arg("--contract")
         .arg("reference.contract")
+        .arg("--output-json")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(output));
+    // and
+
+    let output: &str =
+        r#"Failed to verify the authenticity of wasm binary at `reference.wasm`"#;
+    cargo_contract(&project_dir)
+        .arg("verify")
+        .arg("--wasm")
+        .arg("reference.wasm")
         .arg("--output-json")
         .assert()
         .failure()


### PR DESCRIPTION
## Summary
Closes #1539
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?

Adds a raw verification of the contract against the reference wasm binary.

The command executes the code in the `Release` mode by default and then compares the wasm output with the reference contract.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
