### PR TITLE
Fixing Flipper template typo

### DIFF
--- a/crates/build/templates/new/lib.rs
+++ b/crates/build/templates/new/lib.rs
@@ -106,7 +106,7 @@ mod {{name}} {
             Ok(())
         }
 
-        /// We test that we can read and write a value from the on-chain contract contract.
+        /// We test that we can read and write a value from the on-chain contract.
         #[ink_e2e::test]
         async fn it_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
             // Given


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
Just a typo, repetition of "contract" word. 

## Checklist before requesting a review
- [y] My code follows the style guidelines of this project
- [n] I have added an entry to `CHANGELOG.md`
- [y] I have commented my code, particularly in hard-to-understand areas
- [y] I have added tests that prove my fix is effective or that my feature works
- [y] Any dependent changes have been merged and published in downstream modules
