### PR TITLE
refactor(build): use wasm32v1-none on rust stable

### DIFF
--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -156,7 +156,7 @@ impl Target {
     /// The target string to be passed to rustc in order to build for this target.
     pub fn llvm_target(&self) -> &'static str {
         match self {
-            Self::Wasm => "wasm32-unknown-unknown",
+            Self::Wasm => "wasm32v1-none",
             Self::RiscV => "riscv32i-unknown-none-elf",
         }
     }


### PR DESCRIPTION
Also currently disables `-Clinker-plugin-lto` flag as that is the root cause of `CodeRejected` failures from `pallet-contracts`. This only occurs when contracts are built in debug mode with Rust stable due, to bulk-memory instruction (`memory.fill)` usage which is prohibited by the wasmi validation config used in `pallet-contracts`.

## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

## Checklist before requesting a review
- [ ] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
