### PR TITLE
Output `stdout` for `cargo contract test` failures

### DIFF
--- a/crates/cargo-contract/src/cmd/test_cmd.rs
+++ b/crates/cargo-contract/src/cmd/test_cmd.rs
@@ -88,12 +88,9 @@ impl TestCommand {
         let output = cmd.run()?;
         if !output.status.success() {
             anyhow::bail!(
-                "Failed to run `cargo test`{}",
-                if output.stderr.is_empty() {
-                    String::new()
-                } else {
-                    format!(": {}", String::from_utf8_lossy(&output.stderr))
-                }
+                "Failed to run `cargo test`:\n{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
             )
         }
 


### PR DESCRIPTION
We're currently swallowing `stdout` for `cargo contract test` failures. 

I noticed this in our `ink` CI runs (https://github.com/use-ink/ink/actions/runs/19196443139/job/54878405295?pr=2718), where we have failures without any indication what happened.