### PR TITLE
Only append features in `cargo contract test` when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Event decoding when interacting with a contract - [2162](https://github.com/use-ink/cargo-contract/pull/2162)
 - Accept plain string call arguments by inferring types from metadata - [2161](https://github.com/use-ink/cargo-contract/pull/2161).
+- Only use `--all-features` in `cargo contract test` when no feature specified - [2164](https://github.com/use-ink/cargo-contract/pull/2164)
 
 ## Version 6.0.0-beta
 

--- a/crates/cargo-contract/src/cmd/test_cmd.rs
+++ b/crates/cargo-contract/src/cmd/test_cmd.rs
@@ -31,6 +31,7 @@ pub struct TestCommand {
     /// Path to the `Cargo.toml` of the contract to test.
     #[clap(long, value_parser)]
     manifest_path: Option<PathBuf>,
+    /// Activate specific features.
     #[clap(flatten)]
     features: Features,
     /// Activate all available features.


### PR DESCRIPTION
For `cargo contract test`: Only append custom `--features` when `--all-features` is not set.