### PR TITLE
feat: allow to freely specify directory name for contract

### DIFF
--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -325,7 +325,7 @@ mod tests {
                 let name = "project_with_valid_abi";
                 let dir = path.join(name);
                 fs::create_dir_all(&dir).unwrap();
-                let result = new_contract_project(name, Some(path), Some(abi));
+                let result = new_contract_project(name, Some(path.join(name)), Some(abi));
                 assert!(result.is_ok(), "Should succeed");
 
                 let manifest_path = ManifestPath::new(dir.join("Cargo.toml")).unwrap();
@@ -350,7 +350,7 @@ mod tests {
             let name = "project_with_no_abi";
             let dir = path.join(name);
             fs::create_dir_all(&dir).unwrap();
-            let result = new_contract_project(name, Some(path), None);
+            let result = new_contract_project(name, Some(path.join(name)), None);
             assert!(result.is_ok(), "Should succeed");
 
             let cargo_toml = dir.join("Cargo.toml");
@@ -375,7 +375,7 @@ mod tests {
             let name = "project_with_invalid_abi";
             let dir = path.join(name);
             fs::create_dir_all(&dir).unwrap();
-            let result = new_contract_project(name, Some(path), None);
+            let result = new_contract_project(name, Some(path.join(name)), None);
             assert!(result.is_ok(), "Should succeed");
 
             let cargo_toml = dir.join("Cargo.toml");

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -1007,7 +1007,7 @@ mod unit_tests {
                 let name = "project_with_valid_config";
                 let dir = path.join(name);
                 fs::create_dir_all(&dir).unwrap();
-                let result = new_contract_project(name, Some(path), abi);
+                let result = new_contract_project(name, Some(path.join(name)), abi);
                 assert!(result.is_ok(), "Should succeed");
 
                 let manifest_path = ManifestPath::new(dir.join("Cargo.toml")).unwrap();
@@ -1044,7 +1044,7 @@ mod unit_tests {
                 let name = "project_with_invalid_config";
                 let dir = path.join(name);
                 fs::create_dir_all(&dir).unwrap();
-                let result = new_contract_project(name, Some(path), abi);
+                let result = new_contract_project(name, Some(path.join(name)), abi);
                 assert!(result.is_ok(), "Should succeed");
 
                 let manifest_path = ManifestPath::new(dir.join("Cargo.toml")).unwrap();

--- a/crates/build/src/new.rs
+++ b/crates/build/src/new.rs
@@ -53,9 +53,7 @@ where
         anyhow::bail!("Contract names must begin with an alphabetic character");
     }
 
-    let out_dir = dir
-        .map_or(env::current_dir()?, |p| p.as_ref().to_path_buf())
-        .join(name);
+    let out_dir = dir.map_or(env::current_dir()?, |p| p.as_ref().to_path_buf());
     if out_dir.join("Cargo.toml").exists() {
         anyhow::bail!("A Cargo package already exists in {name}");
     }
@@ -216,7 +214,7 @@ mod tests {
             let dir = path.join(name);
             fs::create_dir_all(&dir).unwrap();
             fs::File::create(dir.join(".gitignore")).unwrap();
-            let result = new_contract_project(name, Some(path), None);
+            let result = new_contract_project(name, Some(path.join(name)), None);
 
             assert!(result.is_err(), "Should fail");
             assert_eq!(
@@ -233,7 +231,8 @@ mod tests {
             let name = "project_with_sol_abi";
             let dir = path.join(name);
             fs::create_dir_all(&dir).unwrap();
-            let result = new_contract_project(name, Some(path), Some(Abi::Solidity));
+            let result =
+                new_contract_project(name, Some(path.join(name)), Some(Abi::Solidity));
 
             assert!(result.is_ok(), "Should succeed");
 

--- a/crates/build/src/tests.rs
+++ b/crates/build/src/tests.rs
@@ -822,8 +822,12 @@ impl BuildTestContext {
         working_project_name: &str,
         abi: Option<Abi>,
     ) -> Result<Self> {
-        crate::new_contract_project(working_project_name, Some(tmp_dir), abi)
-            .expect("new project creation failed");
+        crate::new_contract_project(
+            working_project_name,
+            Some(tmp_dir.join(working_project_name)),
+            abi,
+        )
+        .expect("new project creation failed");
         let working_dir = tmp_dir.join(working_project_name);
 
         let template_dir = tmp_dir.join(format!("{working_project_name}_template"));

--- a/crates/cargo-contract/src/main.rs
+++ b/crates/cargo-contract/src/main.rs
@@ -188,7 +188,11 @@ fn exec(cmd: Command) -> Result<()> {
             target_dir,
             abi,
         } => {
-            contract_build::new_contract_project(name, target_dir.as_ref(), *abi)?;
+            let dir = target_dir
+                .as_ref()
+                .map(|d| d.join(name))
+                .unwrap_or(std::env::current_dir()?.join(name));
+            contract_build::new_contract_project(name, Some(dir), *abi)?;
             println!("Created contract {name}");
             Ok(())
         }


### PR DESCRIPTION
This PR allows users to freely specify the folder's name for a contract project. Currently the folder name is subject to severe restrictions, like not using dashes. This is only applicable for the contract name and makes total sense there, but it's not the case for the folder where the contract lives.

When executing the `new` command the previous behaviour remains, but when using as a library it can be tweaked. I thought it'd be a major change if now contract files are unzipped in a different folder, but this is of course open to discuss.